### PR TITLE
Add Net::IMAP::IgnoredResponse

### DIFF
--- a/test/net/imap/test_imap_response_parser.rb
+++ b/test/net/imap/test_imap_response_parser.rb
@@ -308,4 +308,13 @@ EOF
     assert_equal(nil, response.data.code)
     assert_equal("", response.data.text)
   end
+
+  def test_ignored_response
+    parser = Net::IMAP::ResponseParser.new
+    response = nil
+    assert_nothing_raised do
+      response = parser.parse("* NOOP\r\n")
+    end
+    assert_instance_of(Net::IMAP::IgnoredResponse, response)
+  end
 end


### PR DESCRIPTION
Zimbra server can send an untagged response "* NOOP\r\n" in order to
keep alive connection during long-running requests. These responses are
not syntactically correct, but can be safely ignored.

Add Net::IMAP::IgnoredResponse, and use it for this case.

Fixes ruby/net-imap#2