### PR TITLE
Capability in response code

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3175,6 +3175,7 @@ module Net
           end
         end
         match(T_RBRA)
+        @pos += 1 if @str[@pos] == " "
         @lex_state = EXPR_RTEXT
         return result
       end

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3114,11 +3114,15 @@ module Net
         token = match(T_ATOM)
         name = token.value.upcase
         match(T_SPACE)
+        UntaggedResponse.new(name, capability_data, @str)
+      end
+
+      def capability_data
         data = []
         while true
           token = lookahead
           case token.symbol
-          when T_CRLF
+          when T_CRLF, T_RBRA
             break
           when T_SPACE
             shift_token
@@ -3126,7 +3130,7 @@ module Net
           end
           data.push(atom.upcase)
         end
-        return UntaggedResponse.new(name, data, @str)
+        data
       end
 
       def resp_text
@@ -3150,6 +3154,8 @@ module Net
         case name
         when /\A(?:ALERT|PARSE|READ-ONLY|READ-WRITE|TRYCREATE|NOMODSEQ)\z/n
           result = ResponseCode.new(name, nil)
+        when /\A(?:CAPABILITY)\z/ni
+          result = ResponseCode.new(name, capability_data)
         when /\A(?:PERMANENTFLAGS)\z/n
           match(T_SPACE)
           result = ResponseCode.new(name, flag_list)

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3355,6 +3355,18 @@ module Net
         return token
       end
 
+      # like match, but does not raise error on failure.
+      #
+      # returns and shifts token on successful match
+      # returns nil and leaves @token unshifted on no match
+      def accept(*args)
+        token = lookahead
+        if args.include?(token.symbol)
+          shift_token
+          token
+        end
+      end
+
       def lookahead
         unless @token
           @token = next_token

--- a/test/net/imap/test_imap_response_parser.rb
+++ b/test/net/imap/test_imap_response_parser.rb
@@ -236,7 +236,7 @@ EOF
     assert_equal("AUTH=PLAIN", response.data.last)
     response = parser.parse("* OK [CAPABILITY IMAP4rev1 SASL-IR 1234 NIL THIS+THAT + AUTH=PLAIN ID] IMAP4rev1 Hello\r\n")
     assert_equal("OK", response.name)
-    assert_equal(" IMAP4rev1 Hello", response.data.text)
+    assert_equal("IMAP4rev1 Hello", response.data.text)
     code = response.data.code
     assert_equal("CAPABILITY", code.name)
     assert_equal(

--- a/test/net/imap/test_imap_response_parser.rb
+++ b/test/net/imap/test_imap_response_parser.rb
@@ -234,6 +234,15 @@ EOF
     response = parser.parse("* CAPABILITY st11p00mm-iscream009 1Q49 XAPPLEPUSHSERVICE IMAP4 IMAP4rev1 SASL-IR AUTH=ATOKEN AUTH=PLAIN \r\n")
     assert_equal("CAPABILITY", response.name)
     assert_equal("AUTH=PLAIN", response.data.last)
+    response = parser.parse("* OK [CAPABILITY IMAP4rev1 SASL-IR 1234 NIL THIS+THAT + AUTH=PLAIN ID] IMAP4rev1 Hello\r\n")
+    assert_equal("OK", response.name)
+    assert_equal(" IMAP4rev1 Hello", response.data.text)
+    code = response.data.code
+    assert_equal("CAPABILITY", code.name)
+    assert_equal(
+      ["IMAP4REV1", "SASL-IR", "1234", "NIL", "THIS+THAT", "+", "AUTH=PLAIN", "ID"],
+      code.data
+    )
   end
 
   def test_mixed_boundary


### PR DESCRIPTION
In RFC3501, `capability-data` is found both in `response-data` and in
`resp-text-code`.  Many IMAP servers return `CAPABILITY` codes in the
server greeting or in the tagged `OK` for `STARTTLS`, `LOGIN`, or
`AUTHENTICATE`.

This adds parsing for `CAPABILITY` data in a `ResponseCode`, the same as
already existed for `CAPABILITY` data in an `UntaggedResponse`.

This also fixes `resp-text` to properly match the text that comes after a
`resp-text-code`. The extra `SP` has been removed.

n.b. I submitted this PR previously, before net-imap was gemified:
* https://bugs.ruby-lang.org/issues/16626
* https://github.com/ruby/ruby/pull/2890