### PR TITLE
Fix text_response and resp-text

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -2880,10 +2880,7 @@ module Net
         token = match(T_ATOM)
         name = token.value.upcase
         match(T_SPACE)
-        @lex_state = EXPR_TEXT
-        token = match(T_TEXT)
-        @lex_state = EXPR_BEG
-        return UntaggedResponse.new(name, token.value)
+        return UntaggedResponse.new(name, text)
       end
 
       def flags_response
@@ -3127,6 +3124,12 @@ module Net
           data.push(atom.upcase)
         end
         return UntaggedResponse.new(name, data, @str)
+      end
+
+      # text            = 1*TEXT-CHAR
+      # TEXT-CHAR       = <any CHAR except CR and LF>
+      def text
+        match(T_TEXT, lex_state: EXPR_TEXT).value
       end
 
       def resp_text

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -1774,8 +1774,7 @@ module Net
     # Net::IMAP::ResponseText represents texts of responses.
     # The text may be prefixed by the response code.
     #
-    #   resp_text       ::= ["[" resp_text_code "]" SPACE] (text_mime2 / text)
-    #                       ;; text SHOULD NOT begin with "[" or "="
+    #   resp_text       ::= ["[" resp-text-code "]" SP] text
     #
     # ==== Fields:
     #
@@ -3132,22 +3131,21 @@ module Net
         match(T_TEXT, lex_state: EXPR_TEXT).value
       end
 
+      # resp-text       = ["[" resp-text-code "]" SP] text
       def resp_text
-        @lex_state = EXPR_RTEXT
-        token = lookahead
-        if token.symbol == T_LBRA
+        token = match(T_LBRA, T_TEXT, lex_state: EXPR_RTEXT)
+        case token.symbol
+        when T_LBRA
           code = resp_text_code
-        else
-          code = nil
+          match(T_RBRA)
+          accept_space # violating RFC
+          ResponseText.new(code, text)
+        when T_TEXT
+          ResponseText.new(nil, token.value)
         end
-        token = match(T_TEXT)
-        @lex_state = EXPR_BEG
-        return ResponseText.new(code, token.value)
       end
 
       def resp_text_code
-        @lex_state = EXPR_BEG
-        match(T_LBRA)
         token = match(T_ATOM)
         name = token.value.upcase
         case name
@@ -3163,16 +3161,12 @@ module Net
           token = lookahead
           if token.symbol == T_SPACE
             shift_token
-            @lex_state = EXPR_CTEXT
-            token = match(T_TEXT)
-            @lex_state = EXPR_BEG
+            token = match(T_TEXT, lex_state: EXPR_CTEXT)
             result = ResponseCode.new(name, token.value)
           else
             result = ResponseCode.new(name, nil)
           end
         end
-        match(T_RBRA)
-        @lex_state = EXPR_RTEXT
         return result
       end
 

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3344,6 +3344,28 @@ module Net
         return nil
       end
 
+      SPACES_REGEXP = /\G */n
+
+      # This advances @pos directly so it's safe before changing @lex_state.
+      def accept_space
+        if @token
+          shift_token if @token.symbol == T_SPACE
+        elsif @str[@pos] == " "
+          @pos += 1
+        end
+      end
+
+      # The RFC is very strict about this and usually we should be too.
+      # But skipping spaces is usually a safe workaround for buggy servers.
+      #
+      # This advances @pos directly so it's safe before changing @lex_state.
+      def accept_spaces
+        shift_token if @token&.symbol == T_SPACE
+        if @str.index(SPACES_REGEXP, @pos)
+          @pos = $~.end(0)
+        end
+      end
+
       def match(*args, lex_state: @lex_state)
         if @token && lex_state != @lex_state
           parse_error("invalid lex_state change to %s with unconsumed token",

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3344,22 +3344,28 @@ module Net
         return nil
       end
 
-      def match(*args)
-        token = lookahead
-        unless args.include?(token.symbol)
-          parse_error('unexpected token %s (expected %s)',
-                      token.symbol.id2name,
-                      args.collect {|i| i.id2name}.join(" or "))
+      def match(*args, lex_state: @lex_state)
+        if @token && lex_state != @lex_state
+          parse_error("invalid lex_state change to %s with unconsumed token",
+                      lex_state)
         end
-        shift_token
-        return token
+        begin
+          @lex_state, original_lex_state = lex_state, @lex_state
+          token = lookahead
+          unless args.include?(token.symbol)
+            parse_error('unexpected token %s (expected %s)',
+                        token.symbol.id2name,
+                        args.collect {|i| i.id2name}.join(" or "))
+          end
+          shift_token
+          return token
+        ensure
+          @lex_state = original_lex_state
+        end
       end
 
       def lookahead
-        unless @token
-          @token = next_token
-        end
-        return @token
+        @token ||= next_token
       end
 
       def shift_token

--- a/test/net/imap/test_imap_response_parser.rb
+++ b/test/net/imap/test_imap_response_parser.rb
@@ -301,6 +301,14 @@ EOF
     assert_equal(12345, response.data.attr["MODSEQ"])
   end
 
+  def test_msg_rfc3501_response_text_with_T_LBRA
+    parser = Net::IMAP::ResponseParser.new
+    response = parser.parse("RUBY0004 OK [READ-WRITE] [Gmail]/Sent Mail selected. (Success)\r\n")
+    assert_equal("RUBY0004", response.tag)
+    assert_equal("READ-WRITE", response.data.code.name)
+    assert_equal("[Gmail]/Sent Mail selected. (Success)", response.data.text)
+  end
+
   def test_continuation_request_without_response_text
     parser = Net::IMAP::ResponseParser.new
     response = parser.parse("+\r\n")


### PR DESCRIPTION
This fixes e.g.:
```
RUBY0004 OK [READ-WRITE] [Gmail]/Sent Mail selected. (Success)
```

Specifically, "text" is allowed to begin with "[" or "=". Excluding those was a an older RFC 2060 restriction.

(RFC 2060 was written in 1996. RFC 3501 in 2003)  :slightly_smiling_face: 