### PR TITLE
Update Gemfile.lock with newer versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,20 @@
 PATH
   remote: .
   specs:
-    net-imap (0.1.0)
+    net-imap (0.2.1)
+      digest
+      net-protocol
+      strscan
 
 GEM
   remote: https://rubygems.org/
   specs:
-    power_assert (1.1.5)
-    rake (13.0.1)
-    test-unit (3.3.5)
+    digest (3.0.0)
+    net-protocol (0.1.0)
+    power_assert (2.0.0)
+    rake (13.0.3)
+    strscan (3.0.0)
+    test-unit (3.4.1)
       power_assert
 
 PLATFORMS


### PR DESCRIPTION
`rake` could already run without bundler, but this allows `bundle exec rake` to work with ruby 2.6, 2.7, and 3.0.
Otherwise, those versions all fail with something like the following error:

    You have already activated power_assert 1.1.7, but your Gemfile
    requires power_assert 1.1.5. Prepending `bundle exec` to your
    command may solve this. (Gem::LoadError)