### PR TITLE
Extract authenticators to their own files

### DIFF
--- a/lib/net/imap/authenticators.rb
+++ b/lib/net/imap/authenticators.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# Registry for SASL authenticators used by Net::IMAP.
+module Net::IMAP::Authenticators
+
+  # Adds an authenticator for Net::IMAP#authenticate.  +auth_type+ is the
+  # {SASL mechanism}[https://www.iana.org/assignments/sasl-mechanisms/sasl-mechanisms.xhtml]
+  # supported by +authenticator+ (for instance, "+LOGIN+").  The +authenticator+
+  # is an object which defines a +#process+ method to handle authentication with
+  # the server.  See Net::IMAP::LoginAuthenticator,
+  # Net::IMAP::CramMD5Authenticator, and Net::IMAP::DigestMD5Authenticator for
+  # examples.
+  #
+  # If +auth_type+ refers to an existing authenticator, it will be
+  # replaced by the new one.
+  def add_authenticator(auth_type, authenticator)
+    authenticators[auth_type] = authenticator
+  end
+
+  # Builds an authenticator for Net::IMAP#authenticate.  +args+ will be passed
+  # directly to the chosen authenticator's +#initialize+.
+  def authenticator(auth_type, *args)
+    auth_type = auth_type.upcase
+    unless authenticators.has_key?(auth_type)
+      raise ArgumentError,
+        format('unknown auth type - "%s"', auth_type)
+    end
+    authenticators[auth_type].new(*args)
+  end
+
+  private
+
+  def authenticators
+    @authenticators ||= {}
+  end
+
+end
+
+Net::IMAP.extend Net::IMAP::Authenticators
+
+require_relative "authenticators/login"
+require_relative "authenticators/plain"
+require_relative "authenticators/cram_md5"
+require_relative "authenticators/digest_md5"

--- a/lib/net/imap/authenticators.rb
+++ b/lib/net/imap/authenticators.rb
@@ -3,11 +3,11 @@
 # Registry for SASL authenticators used by Net::IMAP.
 module Net::IMAP::Authenticators
 
-  # Adds an authenticator for Net::IMAP#authenticate.  +auth_type+ is the
+  # Adds an authenticator for use with Net::IMAP#authenticate.  +auth_type+ is the
   # {SASL mechanism}[https://www.iana.org/assignments/sasl-mechanisms/sasl-mechanisms.xhtml]
-  # supported by +authenticator+ (for instance, "+LOGIN+").  The +authenticator+
+  # supported by +authenticator+ (for instance, "+PLAIN+").  The +authenticator+
   # is an object which defines a +#process+ method to handle authentication with
-  # the server.  See Net::IMAP::LoginAuthenticator,
+  # the server.  See Net::IMAP::PlainAuthenticator, Net::IMAP::LoginAuthenticator,
   # Net::IMAP::CramMD5Authenticator, and Net::IMAP::DigestMD5Authenticator for
   # examples.
   #

--- a/lib/net/imap/authenticators/cram_md5.rb
+++ b/lib/net/imap/authenticators/cram_md5.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "digest/md5"
+
+# Authenticator for the "+CRAM-MD5+" SASL mechanism.  See
+# Net::IMAP#authenticate.
+#
+# == Deprecated
+#
+# +CRAM-MD5+ should be considered obsolete and insecure.  It is included for
+# backward compatibility with historic servers.
+# {draft-ietf-sasl-crammd5-to-historic}[https://tools.ietf.org/html/draft-ietf-sasl-crammd5-to-historic-00.html]
+# recommends using +SCRAM-*+ or +PLAIN+ protected by TLS instead.  Additionally,
+# RFC8314[https://tools.ietf.org/html/rfc8314] discourage the use of cleartext
+# and recommends TLS version 1.2 or greater be used for all traffic.
+class Net::IMAP::CramMD5Authenticator
+  def process(challenge)
+    digest = hmac_md5(challenge, @password)
+    return @user + " " + digest
+  end
+
+  private
+
+  def initialize(user, password)
+    @user = user
+    @password = password
+  end
+
+  def hmac_md5(text, key)
+    if key.length > 64
+      key = Digest::MD5.digest(key)
+    end
+
+    k_ipad = key + "\0" * (64 - key.length)
+    k_opad = key + "\0" * (64 - key.length)
+    for i in 0..63
+      k_ipad[i] = (k_ipad[i].ord ^ 0x36).chr
+      k_opad[i] = (k_opad[i].ord ^ 0x5c).chr
+    end
+
+    digest = Digest::MD5.digest(k_ipad + text)
+
+    return Digest::MD5.hexdigest(k_opad + digest)
+  end
+
+  Net::IMAP.add_authenticator "PLAIN", self
+end

--- a/lib/net/imap/authenticators/cram_md5.rb
+++ b/lib/net/imap/authenticators/cram_md5.rb
@@ -2,17 +2,19 @@
 
 require "digest/md5"
 
-# Authenticator for the "+CRAM-MD5+" SASL mechanism.  See
-# Net::IMAP#authenticate.
+# Authenticator for the "+CRAM-MD5+" SASL mechanism, specified in
+# RFC2195[https://tools.ietf.org/html/rfc2195].  See Net::IMAP#authenticate.
 #
 # == Deprecated
 #
-# +CRAM-MD5+ should be considered obsolete and insecure.  It is included for
-# backward compatibility with historic servers.
+# +CRAM-MD5+ is obsolete and insecure.  It is included for compatibility with
+# existing servers.
 # {draft-ietf-sasl-crammd5-to-historic}[https://tools.ietf.org/html/draft-ietf-sasl-crammd5-to-historic-00.html]
-# recommends using +SCRAM-*+ or +PLAIN+ protected by TLS instead.  Additionally,
-# RFC8314[https://tools.ietf.org/html/rfc8314] discourage the use of cleartext
-# and recommends TLS version 1.2 or greater be used for all traffic.
+# recommends using +SCRAM-*+ or +PLAIN+ protected by TLS instead.
+#
+# Additionally, RFC8314[https://tools.ietf.org/html/rfc8314] discourage the use
+# of cleartext and recommends TLS version 1.2 or greater be used for all
+# traffic.  With TLS +CRAM-MD5+ is okay, but so is +PLAIN+
 class Net::IMAP::CramMD5Authenticator
   def process(challenge)
     digest = hmac_md5(challenge, @password)

--- a/lib/net/imap/authenticators/digest_md5.rb
+++ b/lib/net/imap/authenticators/digest_md5.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "digest/md5"
+require "strscan"
+
+# Net::IMAP authenticator for the "`DIGEST-MD5`" SASL mechanism type.  See
+# Net::IMAP#authenticate.
+#
+# == Deprecated
+#
+# "+DIGEST-MD5+" has been deprecated by
+# {RFC6331}[https://tools.ietf.org/html/rfc6331] and should not be used.  It
+# is included for backward compatibility with historic servers.
+class Net::IMAP::DigestMD5Authenticator
+  def process(challenge)
+    case @stage
+    when STAGE_ONE
+      @stage = STAGE_TWO
+      sparams = {}
+      c = StringScanner.new(challenge)
+      while c.scan(/(?:\s*,)?\s*(\w+)=("(?:[^\\"]+|\\.)*"|[^,]+)\s*/)
+        k, v = c[1], c[2]
+        if v =~ /^"(.*)"$/
+          v = $1
+          if v =~ /,/
+            v = v.split(',')
+          end
+        end
+        sparams[k] = v
+      end
+
+      raise DataFormatError, "Bad Challenge: '#{challenge}'" unless c.rest.size == 0
+      raise Error, "Server does not support auth (qop = #{sparams['qop'].join(',')})" unless sparams['qop'].include?("auth")
+
+      response = {
+        :nonce => sparams['nonce'],
+        :username => @user,
+        :realm => sparams['realm'],
+        :cnonce => Digest::MD5.hexdigest("%.15f:%.15f:%d" % [Time.now.to_f, rand, Process.pid.to_s]),
+        :'digest-uri' => 'imap/' + sparams['realm'],
+        :qop => 'auth',
+        :maxbuf => 65535,
+        :nc => "%08d" % nc(sparams['nonce']),
+        :charset => sparams['charset'],
+      }
+
+      response[:authzid] = @authname unless @authname.nil?
+
+      # now, the real thing
+      a0 = Digest::MD5.digest( [ response.values_at(:username, :realm), @password ].join(':') )
+
+      a1 = [ a0, response.values_at(:nonce,:cnonce) ].join(':')
+      a1 << ':' + response[:authzid] unless response[:authzid].nil?
+
+      a2 = "AUTHENTICATE:" + response[:'digest-uri']
+      a2 << ":00000000000000000000000000000000" if response[:qop] and response[:qop] =~ /^auth-(?:conf|int)$/
+
+      response[:response] = Digest::MD5.hexdigest(
+        [
+          Digest::MD5.hexdigest(a1),
+          response.values_at(:nonce, :nc, :cnonce, :qop),
+          Digest::MD5.hexdigest(a2)
+        ].join(':')
+      )
+
+      return response.keys.map {|key| qdval(key.to_s, response[key]) }.join(',')
+    when STAGE_TWO
+      @stage = nil
+      # if at the second stage, return an empty string
+      if challenge =~ /rspauth=/
+        return ''
+      else
+        raise ResponseParseError, challenge
+      end
+    else
+      raise ResponseParseError, challenge
+    end
+  end
+
+  def initialize(user, password, authname = nil)
+    @user, @password, @authname = user, password, authname
+    @nc, @stage = {}, STAGE_ONE
+  end
+
+  private
+
+  STAGE_ONE = :stage_one
+  STAGE_TWO = :stage_two
+
+  def nc(nonce)
+    if @nc.has_key? nonce
+      @nc[nonce] = @nc[nonce] + 1
+    else
+      @nc[nonce] = 1
+    end
+    return @nc[nonce]
+  end
+
+  # some responses need quoting
+  def qdval(k, v)
+    return if k.nil? or v.nil?
+    if %w"username authzid realm nonce cnonce digest-uri qop".include? k
+      v.gsub!(/([\\"])/, "\\\1")
+      return '%s="%s"' % [k, v]
+    else
+      return '%s=%s' % [k, v]
+    end
+  end
+
+  Net::IMAP.add_authenticator "DIGEST-MD5", self
+end

--- a/lib/net/imap/authenticators/digest_md5.rb
+++ b/lib/net/imap/authenticators/digest_md5.rb
@@ -3,14 +3,14 @@
 require "digest/md5"
 require "strscan"
 
-# Net::IMAP authenticator for the "`DIGEST-MD5`" SASL mechanism type.  See
-# Net::IMAP#authenticate.
+# Net::IMAP authenticator for the "`DIGEST-MD5`" SASL mechanism type, specified
+# in RFC2831(https://tools.ietf.org/html/rfc2831).  See Net::IMAP#authenticate.
 #
 # == Deprecated
 #
 # "+DIGEST-MD5+" has been deprecated by
-# {RFC6331}[https://tools.ietf.org/html/rfc6331] and should not be used.  It
-# is included for backward compatibility with historic servers.
+# {RFC6331}[https://tools.ietf.org/html/rfc6331] and should not be relied on for
+# security.  It is included for compatibility with existing servers.
 class Net::IMAP::DigestMD5Authenticator
   def process(challenge)
     case @stage

--- a/lib/net/imap/authenticators/login.rb
+++ b/lib/net/imap/authenticators/login.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Authenticator for the "+LOGIN+" SASL mechanism.  See Net::IMAP#authenticate.
+#
+# == Deprecated
+#
+# The {SASL mechanisms
+# registry}[https://www.iana.org/assignments/sasl-mechanisms/sasl-mechanisms.xhtml]
+# marks "LOGIN" as obsoleted in favor of "PLAIN".  See also
+# {draft-murchison-sasl-login}[https://www.iana.org/go/draft-murchison-sasl-login].
+class Net::IMAP::LoginAuthenticator
+  def process(data)
+    case @state
+    when STATE_USER
+      @state = STATE_PASSWORD
+      return @user
+    when STATE_PASSWORD
+      return @password
+    end
+  end
+
+  private
+
+  STATE_USER = :USER
+  STATE_PASSWORD = :PASSWORD
+
+  def initialize(user, password)
+    @user = user
+    @password = password
+    @state = STATE_USER
+  end
+
+  Net::IMAP.add_authenticator "LOGIN", self
+end

--- a/lib/net/imap/authenticators/login.rb
+++ b/lib/net/imap/authenticators/login.rb
@@ -2,12 +2,21 @@
 
 # Authenticator for the "+LOGIN+" SASL mechanism.  See Net::IMAP#authenticate.
 #
+# +LOGIN+ authentication sends the password in cleartext.
+# RFC3501[https://tools.ietf.org/html/rfc3501] encourages servers to disable
+# cleartext authentication until after TLS has been negotiated.
+# RFC8314[https://tools.ietf.org/html/rfc8314] recommends TLS version 1.2 or
+# greater be used for all traffic, and deprecate cleartext access ASAP.  +LOGIN+
+# can be secured by TLS encryption.
+#
 # == Deprecated
 #
 # The {SASL mechanisms
 # registry}[https://www.iana.org/assignments/sasl-mechanisms/sasl-mechanisms.xhtml]
-# marks "LOGIN" as obsoleted in favor of "PLAIN".  See also
-# {draft-murchison-sasl-login}[https://www.iana.org/go/draft-murchison-sasl-login].
+# marks "LOGIN" as obsoleted in favor of "PLAIN".  It is included here for
+# compatibility with existing servers.  See
+# {draft-murchison-sasl-login}[https://www.iana.org/go/draft-murchison-sasl-login]
+# for both specification and deprecation.
 class Net::IMAP::LoginAuthenticator
   def process(data)
     case @state

--- a/lib/net/imap/authenticators/plain.rb
+++ b/lib/net/imap/authenticators/plain.rb
@@ -4,15 +4,30 @@
 #
 # See RFC4616[https://tools.ietf.org/html/rfc4616] for the specification.
 class Net::IMAP::PlainAuthenticator
+
   def process(data)
-    return "\0#{@user}\0#{@password}"
+    return "#@authzid\0#@username\0#@password"
   end
+
+  NULL = -"\0".b
 
   private
 
-  def initialize(user, password)
-    @user = user
+  # +username+ is the authentication identity, the identity whose +password+ is
+  # used.  +username+ is referred to as +authcid+ by
+  # RFC4616[https://tools.ietf.org/html/rfc4616].
+  #
+  # +authzid+ is the authorization identity (identity to act as).  It can
+  # usually be left blank. When +authzid+ is left blank (nil or empty string)
+  # the server will derive an identity from the credentials and use that as the
+  # authorization identity.
+  def initialize(username, password, authzid: nil)
+    raise ArgumentError, "username contains NULL" if username&.include?(NULL)
+    raise ArgumentError, "password contains NULL" if password&.include?(NULL)
+    raise ArgumentError, "authzid  contains NULL" if authzid&.include?(NULL)
+    @username = username
     @password = password
+    @authzid  = authzid
   end
 
   Net::IMAP.add_authenticator "PLAIN", self

--- a/lib/net/imap/authenticators/plain.rb
+++ b/lib/net/imap/authenticators/plain.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Authenticator for the "+PLAIN+" SASL mechanism.  See Net::IMAP#authenticate.
+#
+# See RFC4616[https://tools.ietf.org/html/rfc4616] for the specification.
+class Net::IMAP::PlainAuthenticator
+  def process(data)
+    return "\0#{@user}\0#{@password}"
+  end
+
+  private
+
+  def initialize(user, password)
+    @user = user
+    @password = password
+  end
+
+  Net::IMAP.add_authenticator "PLAIN", self
+end

--- a/lib/net/imap/authenticators/plain.rb
+++ b/lib/net/imap/authenticators/plain.rb
@@ -1,14 +1,21 @@
 # frozen_string_literal: true
 
-# Authenticator for the "+PLAIN+" SASL mechanism.  See Net::IMAP#authenticate.
+# Authenticator for the "+PLAIN+" SASL mechanism, specified in
+# RFC4616[https://tools.ietf.org/html/rfc4616].  See Net::IMAP#authenticate.
 #
-# See RFC4616[https://tools.ietf.org/html/rfc4616] for the specification.
+# +PLAIN+ authentication sends the password in cleartext.
+# RFC3501[https://tools.ietf.org/html/rfc3501] encourages servers to disable
+# cleartext authentication until after TLS has been negotiated.
+# RFC8314[https://tools.ietf.org/html/rfc8314] recommends TLS version 1.2 or
+# greater be used for all traffic, and deprecate cleartext access ASAP.  +PLAIN+
+# can be secured by TLS encryption.
 class Net::IMAP::PlainAuthenticator
 
   def process(data)
     return "#@authzid\0#@username\0#@password"
   end
 
+  # :nodoc:
   NULL = -"\0".b
 
   private

--- a/test/net/imap/test_imap_authenticators.rb
+++ b/test/net/imap/test_imap_authenticators.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "net/imap"
+require "test/unit"
+
+class IMAPAuthenticatorsTest < Test::Unit::TestCase
+
+  PLAIN = Net::IMAP::PlainAuthenticator
+
+  def test_plain
+    assert_equal("\0authc\0passwd",
+                 PLAIN.new("authc", "passwd").process(nil))
+    assert_equal("authz\0user\0pass",
+                 PLAIN.new("user", "pass", authzid: "authz").process(nil))
+  end
+
+  def test_plain_no_null_chars
+    assert_raise(ArgumentError) { PLAIN.new("bad\0user", "pass") }
+    assert_raise(ArgumentError) { PLAIN.new("user", "bad\0pass") }
+    assert_raise(ArgumentError) { PLAIN.new("u", "p", authzid: "bad\0authz") }
+  end
+
+end


### PR DESCRIPTION
I've started down the path of implementing #10. This PR simply copies authenticators with some minor changes, but this raises a big issue I've been meaning to ask about: SASL.  I'll open another issue to discuss that: #23.  I'm marking this as a draft, pending that discussion.

In addition to moving the authenticators to new files, I've updated the rdoc and added `authnid` support for `PLAIN`.