### PR TITLE
Remove max_flag_count. Ruby 2.2+ can GC symbols.

### DIFF
--- a/lib/net/imap/errors.rb
+++ b/lib/net/imap/errors.rb
@@ -55,9 +55,5 @@ module Net
     RESPONSE_ERRORS["NO"] = NoResponseError
     RESPONSE_ERRORS["BAD"] = BadResponseError
 
-    # Error raised when too many flags are interned to symbols.
-    class FlagCountError < Error
-    end
-
   end
 end

--- a/lib/net/imap/flags.rb
+++ b/lib/net/imap/flags.rb
@@ -60,17 +60,5 @@ module Net
     # Flag indicating that the mailbox does not contains new messages.
     UNMARKED = :Unmarked
 
-    @@max_flag_count = 10000
-
-    # Returns the max number of flags interned to symbols.
-    def self.max_flag_count
-      return @@max_flag_count
-    end
-
-    # Sets the max number of flags interned to symbols.
-    def self.max_flag_count=(count)
-      @@max_flag_count = count
-    end
-
   end
 end

--- a/lib/net/imap/response_parser.rb
+++ b/lib/net/imap/response_parser.rb
@@ -11,7 +11,6 @@ module Net
         @pos = nil
         @lex_state = nil
         @token = nil
-        @flag_symbols = {}
       end
 
       def parse(str)
@@ -1214,12 +1213,7 @@ module Net
             if atom
               atom
             else
-              symbol = flag.capitalize.intern
-              @flag_symbols[symbol] = true
-              if @flag_symbols.length > IMAP.max_flag_count
-                raise FlagCountError, "number of flag symbols exceeded"
-              end
-              symbol
+              flag.capitalize.intern
             end
           }
         else

--- a/test/net/imap/test_imap_response_parser.rb
+++ b/test/net/imap/test_imap_response_parser.rb
@@ -7,33 +7,10 @@ class IMAPResponseParserTest < Test::Unit::TestCase
   def setup
     @do_not_reverse_lookup = Socket.do_not_reverse_lookup
     Socket.do_not_reverse_lookup = true
-    if Net::IMAP.respond_to?(:max_flag_count)
-      @max_flag_count = Net::IMAP.max_flag_count
-      Net::IMAP.max_flag_count = 3
-    end
   end
 
   def teardown
     Socket.do_not_reverse_lookup = @do_not_reverse_lookup
-    if Net::IMAP.respond_to?(:max_flag_count)
-      Net::IMAP.max_flag_count = @max_flag_count
-    end
-  end
-
-  def test_flag_list_too_many_flags
-    parser = Net::IMAP::ResponseParser.new
-    assert_nothing_raised do
-      3.times do |i|
-      parser.parse(<<EOF.gsub(/\n/, "\r\n"))
-* LIST (\\Foo#{i}) "." "INBOX"
-EOF
-      end
-    end
-    assert_raise(Net::IMAP::FlagCountError) do
-      parser.parse(<<EOF.gsub(/\n/, "\r\n"))
-* LIST (\\Foo3) "." "INBOX"
-EOF
-    end
   end
 
   def test_flag_list_many_same_flags


### PR DESCRIPTION
Removing this isn't a high priority, but...

I believe the original reason for `max_flag_count` was because of GC concerns with uncollected symbols.  However, ruby can GC symbols now.  Any unbounded memory consumption or memory leaks most likely comes from other culprits (e.g. accumulating unhandled responses).

The `max_flag_count` was added in 5049da5, 2009-11-19, during the ruby 1.9.1 series.

@shugo  What do you think?