### PR TITLE
Warn when using deprecated SASL mechanisms

### DIFF
--- a/lib/net/imap/authenticators/cram_md5.rb
+++ b/lib/net/imap/authenticators/cram_md5.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "digest/md5"
-
 # Authenticator for the "+CRAM-MD5+" SASL mechanism, specified in
 # RFC2195[https://tools.ietf.org/html/rfc2195].  See Net::IMAP#authenticate.
 #
@@ -23,7 +21,11 @@ class Net::IMAP::CramMD5Authenticator
 
   private
 
-  def initialize(user, password)
+  def initialize(user, password, warn_deprecation: true, **_ignored)
+    if warn_deprecation
+      warn "WARNING: CRAM-MD5 mechanism is deprecated." # TODO: recommend SCRAM
+    end
+    require "digest/md5"
     @user = user
     @password = password
   end

--- a/lib/net/imap/authenticators/login.rb
+++ b/lib/net/imap/authenticators/login.rb
@@ -33,7 +33,10 @@ class Net::IMAP::LoginAuthenticator
   STATE_USER = :USER
   STATE_PASSWORD = :PASSWORD
 
-  def initialize(user, password)
+  def initialize(user, password, warn_deprecation: true, **_ignored)
+    if warn_deprecation
+      warn "WARNING: LOGIN SASL mechanism is deprecated. Use PLAIN instead."
+    end
     @user = user
     @password = password
     @state = STATE_USER

--- a/net-imap.gemspec
+++ b/net-imap.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "net-protocol"
-  spec.add_dependency "digest"
-  spec.add_dependency "strscan"
+  spec.add_development_dependency "digest"
+  spec.add_development_dependency "strscan"
 end

--- a/test/net/imap/test_imap_authenticators.rb
+++ b/test/net/imap/test_imap_authenticators.rb
@@ -5,19 +5,128 @@ require "test/unit"
 
 class IMAPAuthenticatorsTest < Test::Unit::TestCase
 
-  PLAIN = Net::IMAP::PlainAuthenticator
+  # ----------------------
+  # PLAIN
+  # ----------------------
 
-  def test_plain
-    assert_equal("\0authc\0passwd",
-                 PLAIN.new("authc", "passwd").process(nil))
+  def plain(*args, **kwargs, &block)
+    Net::IMAP.authenticator("PLAIN", *args, **kwargs, &block)
+  end
+
+  def test_plain_authenticator_matches_mechanism
+    assert_kind_of(Net::IMAP::PlainAuthenticator, plain("user", "pass"))
+  end
+
+  def test_plain_response
+    assert_equal("\0authc\0passwd", plain("authc", "passwd").process(nil))
     assert_equal("authz\0user\0pass",
-                 PLAIN.new("user", "pass", authzid: "authz").process(nil))
+                 plain("user", "pass", authzid: "authz").process(nil))
   end
 
   def test_plain_no_null_chars
-    assert_raise(ArgumentError) { PLAIN.new("bad\0user", "pass") }
-    assert_raise(ArgumentError) { PLAIN.new("user", "bad\0pass") }
-    assert_raise(ArgumentError) { PLAIN.new("u", "p", authzid: "bad\0authz") }
+    assert_raise(ArgumentError) { plain("bad\0user", "pass") }
+    assert_raise(ArgumentError) { plain("user", "bad\0pass") }
+    assert_raise(ArgumentError) { plain("u", "p", authzid: "bad\0authz") }
+  end
+
+  # ----------------------
+  # LOGIN (obsolete)
+  # ----------------------
+
+  def login(*args, warn_deprecation: false, **kwargs, &block)
+    Net::IMAP.authenticator(
+      "LOGIN", *args, warn_deprecation: warn_deprecation, **kwargs, &block
+    )
+  end
+
+  def test_login_authenticator_matches_mechanism
+    assert_kind_of(Net::IMAP::LoginAuthenticator, login("n", "p"))
+  end
+
+  def test_login_authenticator_deprecated
+    assert_warn(/LOGIN.+deprecated.+PLAIN/) do
+      Net::IMAP.authenticator("LOGIN", "user", "pass")
+    end
+  end
+
+  def test_login_responses
+    auth_session = login("username", "password")
+    assert_equal("username", auth_session.process("username?"))
+    assert_equal("password", auth_session.process("password?"))
+  end
+
+  # ----------------------
+  # CRAM-MD5 (obsolete)
+  # ----------------------
+
+  def cram_md5(*args, warn_deprecation: false, **kwargs, &block)
+    Net::IMAP.authenticator(
+      "CRAM-MD5", *args, warn_deprecation: warn_deprecation, **kwargs, &block
+    )
+  end
+
+  def test_cram_md5_authenticator_matches_mechanism
+    assert_kind_of(Net::IMAP::CramMD5Authenticator, cram_md5("n", "p"))
+  end
+
+  def test_cram_md5_authenticator_deprecated
+    assert_warn(/CRAM-MD5.+deprecated./) do
+      Net::IMAP.authenticator("CRAM-MD5", "user", "pass")
+    end
+  end
+
+  def test_cram_md5_authenticator
+    auth = cram_md5("username", "password")
+    assert_match("username e2ce8ff3d1b914ddf339aa9f55198f86",
+                 auth.process("fake-server-challence-string"))
+  end
+
+  # ----------------------
+  # DIGEST-MD5 (obsolete)
+  # ----------------------
+
+  def digest_md5(*args, warn_deprecation: false, **kwargs, &block)
+    Net::IMAP.authenticator(
+      "DIGEST-MD5", *args, warn_deprecation: warn_deprecation, **kwargs, &block
+    )
+  end
+
+  def test_digest_md5_authenticator_matches_mechanism
+    assert_kind_of(Net::IMAP::DigestMD5Authenticator, digest_md5("n", "p", "z"))
+  end
+
+  def test_digest_md5_authenticator_deprecated
+    assert_warn(/DIGEST-MD5.+deprecated.+RFC6331/) do
+      Net::IMAP.authenticator("DIGEST-MD5", "user", "pass")
+    end
+  end
+
+  def test_digest_md5_authenticator
+    auth = digest_md5("cid", "password", "zid")
+    assert_match(
+      %r{\A
+        nonce="OA6MG9tEQGm2hh",
+        username="cid",
+        realm="somerealm",
+        cnonce="[a-zA-Z0-9+/]{12,}={0,3}", # RFC2831: >= 64 bits of entropy
+        digest-uri="imap/somerealm",
+        qop="auth",
+        maxbuf=65535,
+        nc=00000001,
+        charset=utf-8,
+        authzid="zid",
+        response=[a-f0-9]+
+      \Z}x,
+      auth.process(
+        %w[
+          realm="somerealm"
+          nonce="OA6MG9tEQGm2hh"
+          qop="auth"
+          charset=utf-8
+          algorithm=md5-sess
+        ].join(",")
+      )
+    )
   end
 
 end


### PR DESCRIPTION
Mark obolete SASL mechanisms as deprecated (fixes GH-55):
* This is a backwards-compatible alternative to the approach here: GH-58.  We can still use that incompatible approach in a future version.
* Warn every time a deprecated mechanism is used.
* Warnings can be disabled with `warn_deprecation: false`
* Fixes GH-56: delay loading standard gem dependencies until
  `#initialize`, and convert the gems to development dependencies.

Additionally:
* Adds basic tests for every authenticator (to avoid another GH-52!)
* Fixes a frozen string bug in DigestMD5Authenticator.
* Fixes constant resolution for exceptions in DigestMD5Authenticator.
* Can register an authenticator type that responds to #call (instead of
  #new).  I was originally going to register deprecated authenticators
  with a Proc that required the file and issued a warning, but I decided
  to put everything into the initializer instead.  `#authenticator`
  needed to be updated to safely delegate all args, and I left this in.

The DIGEST-MD5 bug was originally reported, tested, and fixed by
@singpolyma here: https://github.com/nevans/net-sasl/pull/3.

Co-authored-by: Stephen Paul Weber <singpolyma@singpolyma.net>