### PR TITLE
Support `UIDPLUS` extension

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -786,6 +786,15 @@ module Net
       end
     end
 
+    # Similar to #expunge, but takes a set of unique identifiers as
+    # argument.
+    def uid_expunge(set)
+      synchronize do
+        send_command("UID EXPUNGE", MessageSet.new(set))
+        return @responses.delete("EXPUNGE")
+      end
+    end
+
     # Sends a SEARCH command to search the mailbox for messages that
     # match the given searching criteria, and returns message sequence
     # numbers.  +keys+ can either be a string holding the entire

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -435,8 +435,8 @@ module Net
     # in the +mailbox+ can be accessed.
     #
     # After you have selected a mailbox, you may retrieve the
-    # number of items in that mailbox from +@responses["EXISTS"][-1]+,
-    # and the number of recent messages from +@responses["RECENT"][-1]+.
+    # number of items in that mailbox from <code>@responses["EXISTS"][-1]</code>,
+    # and the number of recent messages from <code>@responses["RECENT"][-1]</code>.
     # Note that these values can change if new messages arrive
     # during a session; see #add_response_handler for a way of
     # detecting this event.
@@ -444,10 +444,11 @@ module Net
     # A Net::IMAP::NoResponseError is raised if the mailbox does not
     # exist or is for some reason non-selectable.
     #
-    # If the server supports the UIDPLUS extension it may return an additional
-    # "NO" response with a "UIDNOTSTICKY" response code indicating that the
-    # mailstore does not support persistent UIDs:
-    # +@responses["NO"].last.code.name == "UIDNOTSTICKY"+
+    # If the server supports the [UIDPLUS[https://www.rfc-editor.org/rfc/rfc4315.html]]
+    # extension it may return an additional "NO" response with a "UIDNOTSTICKY" response code
+    # indicating that the mailstore does not support persistent UIDs
+    # [1[https://www.rfc-editor.org/rfc/rfc4315.html#page-4]]:
+    #   @responses["NO"].last.code.name == "UIDNOTSTICKY"
     def select(mailbox)
       synchronize do
         @responses.clear
@@ -758,8 +759,9 @@ module Net
     # not exist (it is not created automatically), or if the flags,
     # date_time, or message arguments contain errors.
     #
-    # If the server supports the UIDPLUS extension it returns an array
-    # with the UIDVALIDITY and the assigned UID of the appended message.
+    # If the server supports the [UIDPLUS[https://www.rfc-editor.org/rfc/rfc4315.html]]
+    # extension it returns an array with the UIDVALIDITY and the assigned UID of the
+    # appended message.
     def append(mailbox, message, flags = nil, date_time = nil)
       args = []
       if flags
@@ -800,10 +802,27 @@ module Net
     end
 
     # Similar to #expunge, but takes a set of unique identifiers as
-    # argument.
-    def uid_expunge(set)
+    # argument. Sends a UID EXPUNGE command to permanently remove all
+    # messages that have both the \\Deleted flag set and a UID that is
+    # included in +uid_set+.
+    #
+    # By using UID EXPUNGE instead of EXPUNGE when resynchronizing with
+    # the server, the client can ensure that it does not inadvertantly
+    # remove any messages that have been marked as \\Deleted by other
+    # clients between the time that the client was last connected and
+    # the time the client resynchronizes.
+    #
+    # Note:: Although the command takes a +uid_set+ for its argument, the
+    #        server still returns regular EXPUNGE responses, which contain
+    #        a <em>sequence number</em>. These will be deleted from
+    #        #responses and this method returns them as an array of
+    #        <em>sequence number</em> integers.
+    #
+    # ==== Required capability
+    # +UIDPLUS+ - described in [UIDPLUS[https://www.rfc-editor.org/rfc/rfc4315.html]].
+    def uid_expunge(uid_set)
       synchronize do
-        send_command("UID EXPUNGE", MessageSet.new(set))
+        send_command("UID EXPUNGE", MessageSet.new(uid_set))
         return @responses.delete("EXPUNGE")
       end
     end
@@ -929,9 +948,9 @@ module Net
     # a number, an array of numbers, or a Range object. The number is
     # a message sequence number.
     #
-    # If the server supports the UIDPLUS extension it returns an array with
-    # the UIDVALIDITY, the UID set of the source messages and the assigned
-    # UID set of the copied messages.
+    # If the server supports the  [UIDPLUS[https://www.rfc-editor.org/rfc/rfc4315.html]]
+    # extension it returns an array with the UIDVALIDITY, the UID set of the source messages
+    # and the assigned UID set of the copied messages.
     def copy(set, mailbox)
       copy_internal("COPY", set, mailbox)
     end
@@ -948,9 +967,9 @@ module Net
     #
     # The MOVE extension is described in [EXT-MOVE[https://tools.ietf.org/html/rfc6851]].
     #
-    # If the server supports the UIDPLUS extension it returns an array with
-    # the UIDVALIDITY, the UID set of the source messages and the assigned
-    # UID set of the moved messages.
+    # If the server supports the [UIDPLUS[https://www.rfc-editor.org/rfc/rfc4315.html]]
+    # extension it returns an array with the UIDVALIDITY, the UID set of the source messages
+    # and the assigned UID set of the moved messages.
     def move(set, mailbox)
       copy_internal("MOVE", set, mailbox)
     end

--- a/lib/net/imap/response_parser.rb
+++ b/lib/net/imap/response_parser.rb
@@ -1342,13 +1342,19 @@ module Net
       end
 
       def set
-        token = match(T_ATOM)
-        token.value.split(',').flat_map do |element|
-          if element.include?(':')
-            Range.new(*element.split(':').map(&:to_i)).to_a
-          else
-            element.to_i
+        case lookahead.symbol
+        when T_NUMBER then [match(T_NUMBER).value.to_i]
+        when T_ATOM
+          match(T_ATOM).value.split(',').flat_map do |element|
+            if element.include?(':')
+              Range.new(*element.split(':').map(&:to_i)).to_a
+            else
+              element.to_i
+            end
           end
+        else
+          shift_token
+          nil
         end
       end
 

--- a/lib/net/imap/response_parser.rb
+++ b/lib/net/imap/response_parser.rb
@@ -1135,9 +1135,9 @@ module Net
           match(T_SPACE)
           uidvalidity = number
           match(T_SPACE)
-          from_uid = set
+          from_uid = uid_set
           match(T_SPACE)
-          to_uid = set
+          to_uid = uid_set
           result = ResponseCode.new(name, [uidvalidity, from_uid, to_uid])
         else
           token = lookahead
@@ -1341,7 +1341,15 @@ module Net
         return token.value.to_i
       end
 
-      def set
+      # RFC-4315 (UIDPLUS) or RFC9051 (IMAP4rev2):
+      #      uid-set         = (uniqueid / uid-range) *("," uid-set)
+      #      uid-range       = (uniqueid ":" uniqueid)
+      #                          ; two uniqueid values and all values
+      #                          ; between these two regardless of order.
+      #                          ; Example: 2:4 and 4:2 are equivalent.
+      #      uniqueid        = nz-number
+      #                          ; Strictly ascending
+      def uid_set
         case lookahead.symbol
         when T_NUMBER then [match(T_NUMBER).value.to_i]
         when T_ATOM

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -801,7 +801,7 @@ EOF
       imap = Net::IMAP.new(server_addr, :port => port)
       response = imap.uid_expunge(1000..1003)
       assert_equal("RUBY0001 UID EXPUNGE 1000:1003\r\n", requests.pop)
-      assert_equal(response.length, 3)
+      assert_equal(response, [1, 1, 1])
       imap.logout
     ensure
       imap.disconnect if imap

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -825,12 +825,14 @@ EOF
         requests.push(sock.gets)
         sock.print("RUBY0002 OK [COPYUID 38505 3955,3960:3962 3963:3966] " \
                    "COPY completed\r\n")
+        requests.push(sock.gets)
+        sock.print("RUBY0003 OK [COPYUID 38505 3955 3967] COPY completed\r\n")
         sock.gets
         sock.print("* NO [UIDNOTSTICKY] Non-persistent UIDs\r\n")
-        sock.print("RUBY0003 OK SELECT completed\r\n")
+        sock.print("RUBY0004 OK SELECT completed\r\n")
         sock.gets
         sock.print("* BYE terminating connection\r\n")
-        sock.print("RUBY0004 OK LOGOUT completed\r\n")
+        sock.print("RUBY0005 OK LOGOUT completed\r\n")
       ensure
         sock.close
         server.close
@@ -853,6 +855,9 @@ EOF
         resp,
         [38505, [3955, 3960, 3961, 3962], [3963, 3964, 3965, 3966]]
       )
+      resp = imap.uid_copy(3955, 'trash')
+      assert_equal(requests.pop, "RUBY0003 UID COPY 3955 trash\r\n")
+      assert_equal(resp, [38505, [3955], [3967]])
       imap.select('trash')
       assert_equal(
         imap.responses["NO"].last.code,


### PR DESCRIPTION
Fixes #36.

Added the `UID EXPUNGE` command and parses the `APPENDUID`, `COPYUID` and `UIDNOTSTICKY` responses.
I also modified the `append`, `copy` and `move` methods to return those UIDs when they are present in the response.

I have also tested this against a production Dovecot IMAP server and a Microsoft 365 account.