### PR TITLE
Fixes "bundle exec rake" clash with test/unit

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ require "rake/testtask"
 
 Rake::TestTask.new(:test) do |t|
   t.libs << "test/lib"
-  t.ruby_opts << "-rhelper"
+  t.ruby_opts << "-rbundler/setup -rhelper"
   t.test_files = FileList["test/**/test_*.rb"]
 end
 


### PR DESCRIPTION
When multiple versions of "test/unit" are installed, the Gemfile.lock can be out of sync with "test/unit" version selected without bundler. When that happens, "bundle exec rake" fails, even when "rake" passes.

This can generally be fixed by simply running "bundle update" so the lockfile has the latest version, too.  And the lockfile is gitignored so this doesn't affect CI.  But, the error can be confusing and waste time.