### PR TITLE
Use ruby2_keywords for authenticator forwarding

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -15,6 +15,7 @@
 
 require "socket"
 require "monitor"
+require "ruby2_keywords"
 require 'net/protocol'
 begin
   require "openssl"
@@ -409,9 +410,9 @@ module Net
     #
     # See +Net::IMAP::Authenticators+ for more information on plugging in your
     # own authenticator.
-    def authenticate(auth_type, *args)
-      authenticator = self.class.authenticator(auth_type, *args)
-      send_command("AUTHENTICATE", auth_type) do |resp|
+    def authenticate(mechanism, *args)
+      authenticator = self.class.authenticator(mechanism, *args)
+      send_command("AUTHENTICATE", mechanism) do |resp|
         if resp.instance_of?(ContinuationRequest)
           data = authenticator.process(resp.data.text.unpack("m")[0])
           s = [data].pack("m0")
@@ -420,6 +421,7 @@ module Net
         end
       end
     end
+    ruby2_keywords :authenticate
 
     # Sends a LOGIN command to identify the client and carries
     # the plaintext +password+ authenticating this +user+.  Note

--- a/lib/net/imap/authenticators.rb
+++ b/lib/net/imap/authenticators.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "ruby2_keywords"
+
 # Registry for SASL authenticators used by Net::IMAP.
 module Net::IMAP::Authenticators
 
@@ -13,22 +15,24 @@ module Net::IMAP::Authenticators
   #
   # If +auth_type+ refers to an existing authenticator, it will be
   # replaced by the new one.
+  #
   def add_authenticator(auth_type, authenticator)
     authenticators[auth_type] = authenticator
   end
 
   # Builds an authenticator for Net::IMAP#authenticate.  +args+ will be passed
   # directly to the chosen authenticator's +#initialize+.
-  def authenticator(mechanism, *authargs, **properties, &callback)
-    authenticator = authenticators.fetch(mechanism.upcase) do
+  def authenticator(mechanism, *authargs, &callback)
+    authenticator = authenticators.fetch(mechanism.to_s.upcase) do
       raise ArgumentError, 'unknown auth type - "%s"' % mechanism
     end
     if authenticator.respond_to?(:new)
-      authenticator.new(*authargs, **properties, &callback)
+      authenticator.new(*authargs, &callback)
     else
-      authenticator.call(*authargs, **properties, &callback)
+      authenticator.call(*authargs, &callback)
     end
   end
+  ruby2_keywords :authenticator
 
   private
 

--- a/net-imap.gemspec
+++ b/net-imap.gemspec
@@ -32,6 +32,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "net-protocol"
+  spec.add_dependency "ruby2_keywords"
+
   spec.add_development_dependency "digest"
   spec.add_development_dependency "strscan"
 end


### PR DESCRIPTION
Without this, authenticators need to accept keywords for compatibility with older ruby versions.  Ruby 2.6 will send an empty hash for `**properties`, and that can crash (or be interpreted as an optional argument) if the authenticator doesn't accept keyword arguments.

Actually... is that a bad thing?  Maybe the error will motivate people to upgrade to ruby 2.7+ or contribute their custom authenticators to net-imap? 😉

It's easy to stay compatible with `ruby2_keywords`, so let's do that.