### PR TITLE
Fix some UIDPLUS issues

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -778,12 +778,7 @@ module Net
       end
       args.push(date_time) if date_time
       args.push(Literal.new(message))
-      synchronize do
-        resp = send_command("APPEND", mailbox, *args)
-        if resp.data.code && resp.data.code.name == "APPENDUID"
-          return resp.data.code.data
-        end
-      end
+      send_command("APPEND", mailbox, *args)
     end
 
     # Sends a CHECK command to request a checkpoint of the currently
@@ -1459,12 +1454,7 @@ module Net
     end
 
     def copy_internal(cmd, set, mailbox)
-      synchronize do
-        resp = send_command(cmd, MessageSet.new(set), mailbox)
-        if resp.data.code && resp.data.code.name == "COPYUID"
-          return resp.data.code.data
-        end
-      end
+      send_command(cmd, MessageSet.new(set), mailbox)
     end
 
     def sort_internal(cmd, sort_keys, search_keys, charset)

--- a/lib/net/imap/response_data.rb
+++ b/lib/net/imap/response_data.rb
@@ -113,6 +113,65 @@ module Net
     class ResponseCode < Struct.new(:name, :data)
     end
 
+    # Net::IMAP::UIDPlusData represents the ResponseCode#data that accompanies
+    # the +APPENDUID+ and +COPYUID+ response codes.
+    #
+    # ==== Capability requirement
+    #
+    # The +UIDPLUS+ capability[rdoc-ref:Net::IMAP#capability] must be supported.
+    # A server that supports +UIDPLUS+ should send a UIDPlusData object inside
+    # every TaggedResponse returned by the append[rdoc-ref:Net::IMAP#append],
+    # copy[rdoc-ref:Net::IMAP#copy], move[rdoc-ref:Net::IMAP#move], {uid
+    # copy}[rdoc-ref:Net::IMAP#uid_copy], and {uid
+    # move}[rdoc-ref:Net::IMAP#uid_move] commands---unless the destination
+    # mailbox reports +UIDNOTSTICKY+.
+    #
+    #--
+    # TODO: support MULTIAPPEND
+    #++
+    #
+    # ==== References
+    #
+    # [UIDPLUS[https://www.rfc-editor.org/rfc/rfc4315.html]]::
+    #   Crispin, M., "Internet Message Access Protocol (IMAP) - UIDPLUS
+    #   extension", RFC 4315, DOI 10.17487/RFC4315, December 2005,
+    #   <https://www.rfc-editor.org/info/rfc4315>.
+    #
+    class UIDPlusData < Struct.new(:uidvalidity, :source_uids, :assigned_uids)
+      ##
+      # method: uidvalidity
+      # :call-seq: uidvalidity -> nonzero uint32
+      #
+      # The UIDVALIDITY of the destination mailbox.
+
+      ##
+      # method: source_uids
+      # :call-seq: source_uids -> nil or an array of nonzero uint32
+      #
+      # The UIDs of the copied or moved messages.
+      #
+      # Note:: Returns +nil+ for Net::IMAP#append.
+
+      ##
+      # method: assigned_uids
+      # :call-seq: assigned_uids -> an array of nonzero uint32
+      #
+      # The newly assigned UIDs of the copied, moved, or appended messages.
+      #
+      # Note:: This always returns an array, even when it contains only one UID.
+
+      ##
+      # :call-seq: uid_mapping -> nil or a hash
+      #
+      # Returns a hash mapping each source UID to the newly assigned destination
+      # UID.
+      #
+      # Note:: Returns +nil+ for Net::IMAP#append.
+      def uid_mapping
+        source_uids&.zip(assigned_uids)&.to_h
+      end
+    end
+
     # Net::IMAP::MailboxList represents contents of the LIST response.
     #
     #   mailbox_list    ::= "(" #("\Marked" / "\Noinferiors" /

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -848,16 +848,16 @@ EOF
 
         hello world
       EOF
-      assert_equal(resp, [38505, 3955])
+      assert_equal([38505, nil, [3955]], resp.data.code.data.to_a)
       resp = imap.uid_copy([3955,3960..3962], 'trash')
       assert_equal(requests.pop, "RUBY0002 UID COPY 3955,3960:3962 trash\r\n")
       assert_equal(
-        resp,
-        [38505, [3955, 3960, 3961, 3962], [3963, 3964, 3965, 3966]]
+        [38505, [3955, 3960, 3961, 3962], [3963, 3964, 3965, 3966]],
+        resp.data.code.data.to_a
       )
       resp = imap.uid_copy(3955, 'trash')
       assert_equal(requests.pop, "RUBY0003 UID COPY 3955 trash\r\n")
-      assert_equal(resp, [38505, [3955], [3967]])
+      assert_equal([38505, [3955], [3967]], resp.data.code.data.to_a)
       imap.select('trash')
       assert_equal(
         imap.responses["NO"].last.code,


### PR DESCRIPTION
* 🐛  Bug fixed: `uid-range` should behave the same, regardless of order.  i.e. "2:4" and "4:2" are equivalent.
* 🐛 Reversed a breaking change: The return values of Net::IMAP#copy, #move, #uid_copy, #uid_move, and #append are incompatible with all previously released versions.  That would break any apps that expect the tagged response.  TaggedResponse is more broadly useful anyway, since it contains the response code with its data.
* Forward compatibility with `MULTIAPPEND`:  I converted "append-uid" to parse a "uid-set" instead of a "uniqueid".  This also provides a consistent interface: assigned_uids will always be an array of ints.
* Replaced arrays with a `UIDPlusData` struct.  In my opinion, it's much nicer to use a Struct than a "tuple". This also provides a home for documentation and utility methods.  E.g. I also added UIDPlusData#uid_mapping, which returns a hash of {src_uid => dst_uid}.
* Number parsing was converted from `to_i` to `Integer`.  We matched the `uid-set` with a single `T_ATOM` token, so we haven't validated that it follows the rest of the grammar.  This will still parse some invalid strings (e.g. `",:1,,:::,,"`), but in practice it's much more likely that a bogus atom would have at least one non-numeric character besides ":" and ",".  (Although I've seen some crazy server bugs...)