### PR TITLE
ResponseParser docs

### DIFF
--- a/lib/net/imap/response_parser.rb
+++ b/lib/net/imap/response_parser.rb
@@ -5,7 +5,9 @@ require_relative "errors"
 module Net
   class IMAP < Protocol
 
-    class ResponseParser # :nodoc:
+    # Parses an \IMAP server response.
+    class ResponseParser
+      # :call-seq: Net::IMAP::ResponseParser.new -> Net::IMAP::ResponseParser
       def initialize
         @str = nil
         @pos = nil
@@ -13,6 +15,12 @@ module Net
         @token = nil
       end
 
+      # :call-seq:
+      #   parse(str) -> ContinuationRequest
+      #   parse(str) -> UntaggedResponse
+      #   parse(str) -> TaggedResponse
+      #
+      # Raises ResponseParseError for unparsable strings.
       def parse(str)
         @str = str
         @pos = 0
@@ -22,6 +30,8 @@ module Net
       end
 
       private
+
+      # :stopdoc:
 
       EXPR_BEG          = :EXPR_BEG
       EXPR_DATA         = :EXPR_DATA


### PR DESCRIPTION
There's no reason not to include at least very basic user-visible docs for ResponseParser.  I've been using Net::IMAP::ResponseParser (both separate from and combined with the rest of the Net::IMAP client, both my forked version and the upstream version) for over a decade. 😄

Also, I want to consider adding some parser options, e.g. "#{provider} quirks mode" vs "strict mode" vs "support experimental draft rfc", and it would make the most sense to document options those here.