### PR TITLE
✅ Fix CI by pinning psych; Fixes #86

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,10 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake"
-gem "rdoc"
 gem "test-unit"
+
+# Some of the docs are difficult to read when rendered by earlier releases.
+# Customizations in rakelib/rdoc.rake were written for 6.5.
+gem "rdoc", ">=6.5"
+
+gem "psych", "~>4.0.0" # needed until actions/runner-images#6740 rolls out


### PR DESCRIPTION
This is only needed temporarily, until actions/runner-images#6740 rolls out.

We *could* remove "rdoc" and use the system gem, but the "rake rdoc" customizations were written for 6.5.