### PR TITLE
Revert "Fixes "bundle exec rake", clash with test/unit"

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ require "rake/clean"
 
 Rake::TestTask.new(:test) do |t|
   t.libs << "test/lib"
-  t.ruby_opts << "-rbundler/setup -rhelper"
+  t.ruby_opts << "-rhelper"
   t.test_files = FileList["test/**/test_*.rb"]
 end
 


### PR DESCRIPTION
This reverts commit 6864428c763a6455c9f5cd57279b66c3443de0ae.

This breaks `test-bundled-gems` on ruby/ruby CIs.

https://github.com/ruby/ruby/actions/runs/3704473681/jobs/6277137022#step:16:259

```
  /home/runner/work/ruby/ruby/build/ruby -C /home/runner/work/ruby/ruby/src/gems/src/net-imap /home/runner/work/ruby/ruby/src/.bundle/bin/rake test
  /home/runner/work/ruby/ruby/src/lib/bundler/resolver.rb:263:in `raise_not_found!': Could not find gem 'digest' in locally installed gems. (Bundler::GemNotFound)
```