### PR TITLE
⬆️ Drop v2.6 support; Require v2.7.3; Use "..." arg

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,13 +10,6 @@ jobs:
         ruby: [ head, '3.1', '3.0', '2.7' ]
         os: [ ubuntu-latest, macos-latest ]
         experimental: [false]
-        include:
-#          - ruby: 2.6
-#            os: ubuntu-latest
-#            experimental: true
-          - ruby: 2.6
-            os: macos-latest
-            experimental: false
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     steps:

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -1037,8 +1037,8 @@ module Net
     #      imap.login username, password
     #    end
     #
-    def authenticate(mechanism, *args, **props, &cb)
-      authenticator = self.class.authenticator(mechanism, *args, **props, &cb)
+    def authenticate(mechanism, ...)
+      authenticator = self.class.authenticator(mechanism, ...)
       send_command("AUTHENTICATE", mechanism) do |resp|
         if resp.instance_of?(ContinuationRequest)
           data = authenticator.process(resp.data.text.unpack("m")[0])

--- a/lib/net/imap/authenticators.rb
+++ b/lib/net/imap/authenticators.rb
@@ -39,15 +39,11 @@ module Net::IMAP::Authenticators
   #
   # The returned object represents a single authentication exchange and <em>must
   # not</em> be reused for multiple authentication attempts.
-  def authenticator(mechanism, *authargs, **properties, &callback)
-    authenticator = authenticators.fetch(mechanism.upcase) do
+  def authenticator(mechanism, ...)
+    auth = authenticators.fetch(mechanism.upcase) do
       raise ArgumentError, 'unknown auth type - "%s"' % mechanism
     end
-    if authenticator.respond_to?(:new)
-      authenticator.new(*authargs, **properties, &callback)
-    else
-      authenticator.call(*authargs, **properties, &callback)
-    end
+    auth.respond_to?(:new) ? auth.new(...) : auth.call(...)
   end
 
   private

--- a/net-imap.gemspec
+++ b/net-imap.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{Ruby client api for Internet Message Access Protocol}
   spec.description   = %q{Ruby client api for Internet Message Access Protocol}
   spec.homepage      = "https://github.com/ruby/net-imap"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.6.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.7.3")
   spec.licenses       = ["Ruby", "BSD-2-Clause"]
 
   spec.metadata["homepage_uri"] = spec.homepage


### PR DESCRIPTION
Argument forwarding was the issue in #68, and we decided to require ruby 2.7 instead of adding `ruby2_keywords`.

If I remember correctly, v2.7.0-v2.7.2 didn't allow `...` to be used with leading arguments, so this sets the minimum version to v2.7.3.