### PR TITLE
✨🔒 Add SASL-IR support

### DIFF
--- a/lib/net/imap/authenticators/plain.rb
+++ b/lib/net/imap/authenticators/plain.rb
@@ -11,6 +11,8 @@
 # can be secured by TLS encryption.
 class Net::IMAP::PlainAuthenticator
 
+  def initial_response?; true end
+
   def process(data)
     return "#@authzid\0#@username\0#@password"
   end

--- a/lib/net/imap/authenticators/xoauth2.rb
+++ b/lib/net/imap/authenticators/xoauth2.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class Net::IMAP::XOauth2Authenticator
+
+  def initial_response?; true end
+
   def process(_data)
     build_oauth2_string(@user, @oauth2_token)
   end

--- a/lib/net/imap/sasl.rb
+++ b/lib/net/imap/sasl.rb
@@ -39,6 +39,10 @@ module Net
         Net::IMAP::StringPrep::SASLprep.saslprep(string, **opts)
       end
 
+      def initial_response?(mechanism)
+        mechanism.respond_to?(:initial_response?) && mechanism.initial_response?
+      end
+
     end
   end
 

--- a/test/net/imap/fake_server/command_reader.rb
+++ b/test/net/imap/fake_server/command_reader.rb
@@ -32,7 +32,7 @@ class Net::IMAP::FakeServer
     def parse(buf)
       /\A([^ ]+) ((?:UID )?\w+)(?: (.+))?\r\n\z/min =~ buf or raise "bad request"
       case $2.upcase
-      when "LOGIN", "SELECT", "ENABLE"
+      when "LOGIN", "SELECT", "ENABLE", "AUTHENTICATE"
         Command.new $1, $2, scan_astrings($3), buf
       else
         Command.new $1, $2, $3, buf # TODO...

--- a/test/net/imap/fake_server/command_router.rb
+++ b/test/net/imap/fake_server/command_router.rb
@@ -55,7 +55,17 @@ class Net::IMAP::FakeServer
       resp.args.nil? or return resp.fail_bad_args
       resp.bye
       state.logout
-      resp.done_ok
+      begin
+        resp.done_ok
+      rescue IOError
+        # TODO: fix whatever is causing this!
+        warn "connection issue after bye but before LOGOUT could complete"
+        if $!.respond_to :detailed_message
+          warn $!.detailed_message highlight: true, order: :bottom
+        else
+          warn $!.full_message     highlight: true, order: :bottom
+        end
+      end
     end
 
     on "STARTTLS" do |resp|

--- a/test/net/imap/fake_server/configuration.rb
+++ b/test/net/imap/fake_server/configuration.rb
@@ -22,6 +22,7 @@ class Net::IMAP::FakeServer
       encrypted_login: true,
       cleartext_auth:  false,
       sasl_mechanisms: %i[PLAIN].freeze,
+      sasl_ir: false,
 
       rev1: true,
       rev2: false,
@@ -66,6 +67,7 @@ class Net::IMAP::FakeServer
     alias cleartext_auth?        cleartext_auth
     alias greeting_bye?          greeting_bye
     alias greeting_capabilities? greeting_capabilities
+    alias sasl_ir?               sasl_ir
 
     def on(event, &handler)
       handler or raise ArgumentError
@@ -104,6 +106,7 @@ class Net::IMAP::FakeServer
       capa << "STARTTLS"            if starttls?
       capa << "LOGINDISABLED"   unless cleartext_login?
       capa.concat auth_capabilities if cleartext_auth?
+      capa << "SASL-IR" if sasl_ir? && cleartext_auth?
       capa
     end
 
@@ -111,6 +114,7 @@ class Net::IMAP::FakeServer
       capa = basic_capabilities
       capa << "LOGINDISABLED" unless encrypted_login?
       capa.concat auth_capabilities
+      capa << "SASL-IR" if sasl_ir?
       capa
     end
 

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -776,6 +776,96 @@ EOF
     end
   end
 
+  test("#authenticate sends an initial response " \
+       "when supported by both the mechanism and the server") do
+    with_fake_server(
+      preauth: false, cleartext_auth: true, sasl_ir: true
+    ) do |server, imap|
+      imap.authenticate("PLAIN", "test_user", "test-password")
+      cmd = server.commands.pop
+      assert_equal "AUTHENTICATE", cmd.name
+      assert_equal(["PLAIN", ["\x00test_user\x00test-password"].pack("m0")],
+                   cmd.args)
+      assert_empty server.commands
+    end
+  end
+
+  test("#authenticate never sends an initial response " \
+       "when the server doesn't explicitly support the mechanism") do
+    with_fake_server(
+      preauth: false, cleartext_auth: true,
+      sasl_ir: true, sasl_mechanisms: %i[SCRAM-SHA-1 SCRAM-SHA-256],
+    ) do |server, imap|
+      imap.authenticate("PLAIN", "test_user", "test-password")
+      cmd, cont = 2.times.map { server.commands.pop }
+      assert_equal %w[AUTHENTICATE PLAIN], [cmd.name, *cmd.args]
+      assert_equal(["\x00test_user\x00test-password"].pack("m0"),
+                   cont[:continuation].strip)
+      assert_empty server.commands
+    end
+  end
+
+  test("#authenticate never sends an initial response " \
+       "when the server isn't capable") do
+    with_fake_server(
+      preauth: false, cleartext_auth: true, sasl_ir: false
+    ) do |server, imap|
+      imap.authenticate("PLAIN", "test_user", "test-password")
+      cmd, cont = 2.times.map { server.commands.pop }
+      assert_equal %w[AUTHENTICATE PLAIN], [cmd.name, *cmd.args]
+      assert_equal(["\x00test_user\x00test-password"].pack("m0"),
+                   cont[:continuation].strip)
+      assert_empty server.commands
+    end
+  end
+
+  test("#authenticate never sends an initial response " \
+       "when sasl_ir: false") do
+    [true, false].each do |server_support|
+      with_fake_server(
+        preauth: false, cleartext_auth: true, sasl_ir: server_support
+      ) do |server, imap|
+        imap.authenticate("PLAIN", "test_user", "test-password", sasl_ir: false)
+        cmd, cont = 2.times.map { server.commands.pop }
+        assert_equal %w[AUTHENTICATE PLAIN], [cmd.name, *cmd.args]
+        assert_equal(["\x00test_user\x00test-password"].pack("m0"),
+                     cont[:continuation].strip)
+        assert_empty server.commands
+      end
+    end
+  end
+
+  test("#authenticate never sends an initial response " \
+       "when the mechanism does not support client-first") do
+    with_fake_server(
+      preauth: false, cleartext_auth: true,
+      sasl_ir: true, sasl_mechanisms: %i[DIGEST-MD5]
+    ) do |server, imap|
+      server.on "AUTHENTICATE" do |cmd|
+        response_b64 = cmd.request_continuation(
+          [
+            %w[
+              realm="somerealm"
+              nonce="OA6MG9tEQGm2hh"
+              qop="auth"
+              charset=utf-8
+              algorithm=md5-sess
+            ].join(",")
+          ].pack("m0")
+        )
+        state.commands << {continuation: response_b64}
+        server.state.authenticate(server.config.user)
+        cmd.done_ok
+      end
+      imap.authenticate("DIGEST-MD5", "test_user", "test-password",
+                        warn_deprecation: false)
+      cmd, cont = 2.times.map { server.commands.pop }
+      assert_equal %w[AUTHENTICATE DIGEST-MD5], [cmd.name, *cmd.args]
+      assert_match(%r{\A[a-z0-9+/]+=*\z}i, cont[:continuation].strip)
+      assert_empty server.commands
+    end
+  end
+
   def test_uidplus_uid_expunge
     with_fake_server(select: "INBOX",
                      extensions: %i[UIDPLUS]) do |server, imap|

--- a/test/net/imap/test_imap_authenticators.rb
+++ b/test/net/imap/test_imap_authenticators.rb
@@ -9,12 +9,15 @@ class IMAPAuthenticatorsTest < Test::Unit::TestCase
   # PLAIN
   # ----------------------
 
-  def plain(*args, **kwargs, &block)
-    Net::IMAP.authenticator("PLAIN", *args, **kwargs, &block)
-  end
+  def plain(...) Net::IMAP.authenticator("PLAIN", ...) end
 
   def test_plain_authenticator_matches_mechanism
     assert_kind_of(Net::IMAP::PlainAuthenticator, plain("user", "pass"))
+  end
+
+  def test_plain_supports_initial_response
+    assert plain("foo", "bar").initial_response?
+    assert Net::IMAP::SASL.initial_response?(plain("foo", "bar"))
   end
 
   def test_plain_response
@@ -33,11 +36,22 @@ class IMAPAuthenticatorsTest < Test::Unit::TestCase
   # XOAUTH2
   # ----------------------
 
+  def xoauth2(...) Net::IMAP.authenticator("XOAUTH2", ...) end
+
+  def test_xoauth2_authenticator_matches_mechanism
+    assert_kind_of(Net::IMAP::XOauth2Authenticator, xoauth2("user", "pass"))
+  end
+
   def test_xoauth2
     assert_equal(
       "user=username\1auth=Bearer token\1\1",
-      Net::IMAP::XOauth2Authenticator.new("username", "token").process(nil)
+      xoauth2("username", "token").process(nil)
     )
+  end
+
+  def test_xoauth2_supports_initial_response
+    assert xoauth2("foo", "bar").initial_response?
+    assert Net::IMAP::SASL.initial_response?(xoauth2("foo", "bar"))
   end
 
   # ----------------------
@@ -52,6 +66,10 @@ class IMAPAuthenticatorsTest < Test::Unit::TestCase
 
   def test_login_authenticator_matches_mechanism
     assert_kind_of(Net::IMAP::LoginAuthenticator, login("n", "p"))
+  end
+
+  def test_login_does_not_support_initial_response
+    refute Net::IMAP::SASL.initial_response?(login("foo", "bar"))
   end
 
   def test_login_authenticator_deprecated
@@ -78,6 +96,10 @@ class IMAPAuthenticatorsTest < Test::Unit::TestCase
 
   def test_cram_md5_authenticator_matches_mechanism
     assert_kind_of(Net::IMAP::CramMD5Authenticator, cram_md5("n", "p"))
+  end
+
+  def test_cram_md5_does_not_support_initial_response
+    refute Net::IMAP::SASL.initial_response?(cram_md5("foo", "bar"))
   end
 
   def test_cram_md5_authenticator_deprecated
@@ -110,6 +132,10 @@ class IMAPAuthenticatorsTest < Test::Unit::TestCase
     assert_warn(/DIGEST-MD5.+deprecated.+RFC6331/) do
       Net::IMAP.authenticator("DIGEST-MD5", "user", "pass")
     end
+  end
+
+  def test_digest_md5_does_not_support_initial_response
+    refute Net::IMAP::SASL.initial_response?(digest_md5("foo", "bar"))
   end
 
   def test_digest_md5_authenticator

--- a/test/net/imap/test_imap_capabilities.rb
+++ b/test/net/imap/test_imap_capabilities.rb
@@ -190,6 +190,7 @@ class IMAPCapabilitiesTest < Test::Unit::TestCase
 
       imap.authenticate("PLAIN", "test_user", "test-password")
       assert_equal "AUTHENTICATE", server.commands.pop.name
+      assert server.commands.pop[:continuation]
       refute imap.capabilities_cached?
 
       assert imap.capable? :IMAP4rev1
@@ -277,6 +278,7 @@ class IMAPCapabilitiesTest < Test::Unit::TestCase
       rescue Net::IMAP::NoResponseError
       end
       assert_equal "AUTHENTICATE", server.commands.pop.name
+      assert server.commands.pop[:continuation]
       assert_equal original_capabilities, imap.capabilities
       assert_empty server.commands
     end


### PR DESCRIPTION
Fixes #34. 

I decided to enable SASL-IR by default.  Because it checks server capabilities (both `capable?("SASL-IR")` `#auth_capable?(mechanism)`), this should be safe.

This is the first command in `Net::IMAP` to change its behavior based on `#capabilities` (but not the last).