### PR TITLE
✨ Add attr_readers for @host and @port

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -736,6 +736,12 @@ module Net
 
     attr_accessor :client_thread # :nodoc:
 
+    # The hostname this client connected to
+    attr_reader :host
+
+    # The port this client connected to
+    attr_reader :port
+
     # Returns the debug mode.
     def self.debug
       return @@debug


### PR DESCRIPTION
My initial PR coerced host to a string and port to an Integer and froze both.  I removed all of that, so now the PR is simply `attr_reader :host, :port`.