### PR TITLE
💥 Changes to responses handling, motivated by thread-safety

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -734,8 +734,6 @@ module Net
     # Seconds to wait until an IDLE response is received.
     attr_reader :idle_response_timeout
 
-    attr_accessor :client_thread # :nodoc:
-
     # The hostname this client connected to
     attr_reader :host
 
@@ -766,6 +764,11 @@ module Net
       alias default_imap_port default_port
       alias default_imaps_port default_tls_port
       alias default_ssl_port default_tls_port
+    end
+
+    def client_thread # :nodoc:
+      warn "Net::IMAP#client_thread is deprecated and will be removed soon."
+      @client_thread
     end
 
     # Disconnects from the server.


### PR DESCRIPTION
Calling `#responses` with no arguments or block is deprecated, as it
can't be made thread-safe and backward-compatible.  For convenience, an
optional `type` paramater has been added to `#responses`, to yield only
the array for that type of response.

Added `#clear_responses` as a convenience method for the common "read
and delete" pattern, and to provide a thread-safe responses
method that doesn't require a block.

The response handlers methods are synchronized, but `#response_handlers`
now returns a frozen clone to alert users who had manipulated it
directly.  Hopefully very few are affected, but this change is backwards
incompatible.  N.b: there currently is no API for inserting a
response handler into a particular position in the array.

Also, improve yields_in_test_server_thread test helper: it no longer
reads `last_tag` from the block result, it sets a short `IO#timeout` in
ruby 3.2+, it uses a slightly longer timeout for overall test
completion, and it defines `sock.getcmd` so the tests can