### PR TITLE
✨ Add greeting code data to responses

### DIFF
--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -928,7 +928,12 @@ EOF
     end
     begin
       imap = Net::IMAP.new(server_addr, port: port)
+      # responses available before SELECT/EXAMINE
+      assert_equal(%w[IMAP4REV1 AUTH=PLAIN STARTTLS],
+                   imap.responses("CAPABILITY", &:last))
       resp = imap.select "INBOX"
+      # responses are cleared after SELECT/EXAMINE
+      assert_equal(nil, imap.responses("CAPABILITY", &:last))
       assert_equal([Net::IMAP::TaggedResponse, "RUBY0001", "OK"],
                    [resp.class, resp.tag, resp.name])
       assert_equal([172], imap.responses { _1["EXISTS"] })


### PR DESCRIPTION
This simplifies caching of the server capabilities, as many servers will send their capabilities inside the greeting.  It's needed for #31.

The PR is based on #93 only because my test for it is based on that branch.  But that PR is a bigger change than this one, so I can rebase this and give it its own test, if necessary.