### PR TITLE
🔊 Warn about deprecated `#responses` usage

### DIFF
--- a/lib/net/imap/config.rb
+++ b/lib/net/imap/config.rb
@@ -306,7 +306,7 @@ module Net
         open_timeout: 30,
         idle_response_timeout: 5,
         sasl_ir: true,
-        responses_without_block: :silence_deprecation_warning,
+        responses_without_block: :warn,
       ).freeze
 
       @global = default.new


### PR DESCRIPTION
This was extracted from #93 and split into a separate PR.

This allows us to prepare dependent projects for the new behavior before their logs are flooded with deprecation warnings.

Also adds `Net::IMAP.attr_accessor :silence_thread_safety_deprecation_warnings`.  This is provided as a temporary workaround, until dependant projects can update their usage.