### PR TITLE
Add support for ENABLE (RFC 5161)

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -199,8 +199,8 @@ module Net
   # [IDLE[https://tools.ietf.org/html/rfc2177]],
   # [NAMESPACE[https://tools.ietf.org/html/rfc2342]],
   # [UNSELECT[https://tools.ietf.org/html/rfc3691]],
+  # [ENABLE[https://tools.ietf.org/html/rfc5161]],
   #--
-  # TODO: [ENABLE[https://tools.ietf.org/html/rfc5161]],
   # TODO: [LIST-EXTENDED[https://tools.ietf.org/html/rfc5258]],
   # TODO: [LIST-STATUS[https://tools.ietf.org/html/rfc5819]],
   #++
@@ -1877,6 +1877,27 @@ module Net
     # [RFC5256[https://tools.ietf.org/html/rfc5256]].
     def uid_thread(algorithm, search_keys, charset)
       return thread_internal("UID THREAD", algorithm, search_keys, charset)
+    end
+
+    # Sends an {ENABLE command [RFC5161 §3.2]}[https://www.rfc-editor.org/rfc/rfc5161#section-3.1]
+    # {[IMAP4rev2 §6.3.1]}[https://www.rfc-editor.org/rfc/rfc9051#section-6.3.1]
+    # to enable the specified extenstions, which may be either an
+    # array or a string.
+    #
+    # Some of the extensions that use ENABLE permit the server to send
+    # syntax that this class cannot parse. Caution is advised.
+    #
+    # ===== Capabilities
+    #
+    # The server's capabilities must include +ENABLE+
+    # [RFC5161[https://tools.ietf.org/html/rfc5161]] or IMAP4REV2
+    # [RFC9051[https://tools.ietf.org/html/rfc9051]].
+
+    def enable(extensions)
+      synchronize do
+        send_command("ENABLE #{[extensions].flatten.join(' ')}")
+        return @responses.delete("ENABLED")[-1]
+      end
     end
 
     # Sends an {IDLE command [RFC2177 §3]}[https://www.rfc-editor.org/rfc/rfc6851#section-3]

--- a/lib/net/imap/response_parser.rb
+++ b/lib/net/imap/response_parser.rb
@@ -160,6 +160,8 @@ module Net
             return capability_response
           when /\A(?:NOOP)\z/ni
             return ignored_response
+          when /\A(?:ENABLED)\z/ni
+            return enabled_response
           else
             return text_response
           end
@@ -968,6 +970,13 @@ module Net
       end
 
       def capability_response
+        token = match(T_ATOM)
+        name = token.value.upcase
+        match(T_SPACE)
+        UntaggedResponse.new(name, capability_data, @str)
+      end
+
+      def enabled_response
         token = match(T_ATOM)
         name = token.value.upcase
         match(T_SPACE)

--- a/test/net/imap/test_imap_response_parser.rb
+++ b/test/net/imap/test_imap_response_parser.rb
@@ -222,6 +222,14 @@ EOF
     )
   end
 
+  def test_enable
+    parser = Net::IMAP::ResponseParser.new
+    response = parser.parse("* ENABLED SMTPUTF8\r\n")
+    assert_equal("ENABLED", response.name)
+    assert_equal(1, response.data.length)
+    assert_equal("SMTPUTF8", response.data.first)
+  end
+
   def test_id
     parser = Net::IMAP::ResponseParser.new
     response = parser.parse("* ID NIL\r\n")


### PR DESCRIPTION
Hi,

this is almost a no-op because it doesn't change the parser.

Once this is merged, I'll contribute code to support UTF8=ACCEPT (RFC 6855), which depends on this, does extend the parser and has effect.

(There is a certain risk that I may implement QRESYNC as well.)