### PR TITLE
🚚 Move the StringPrep module out of SASL

### DIFF
--- a/benchmarks/stringprep.yml
+++ b/benchmarks/stringprep.yml
@@ -24,7 +24,7 @@ prelude: |
   $LOAD_PATH.unshift "./lib"
   require "net/imap"
   def net_imap_saslprep(string)
-    Net::IMAP::SASL::SASLprep.saslprep string, exception: false
+    Net::IMAP::StringPrep::SASLprep.saslprep string, exception: false
   end
 
   def libidn_saslprep(string)

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -703,6 +703,9 @@ module Net
   class IMAP < Protocol
     VERSION = "0.3.4"
 
+    autoload :SASL,       File.expand_path("imap/sasl",       __dir__)
+    autoload :StringPrep, File.expand_path("imap/stringprep", __dir__)
+
     include MonitorMixin
     if defined?(OpenSSL::SSL)
       include OpenSSL
@@ -2485,6 +2488,16 @@ module Net
       end
     end
 
+    #--
+    # We could get the saslprep method by extending the SASLprep module
+    # directly.  It's done indirectly, so SASLprep can be lazily autoloaded,
+    # because most users won't need it.
+    #++
+    # Delegates to Net::IMAP::StringPrep::SASLprep#saslprep.
+    def self.saslprep(string, **opts)
+      Net::IMAP::StringPrep::SASLprep.saslprep(string, **opts)
+    end
+
   end
 end
 
@@ -2495,4 +2508,3 @@ require_relative "imap/flags"
 require_relative "imap/response_data"
 require_relative "imap/response_parser"
 require_relative "imap/authenticators"
-require_relative "imap/sasl"

--- a/lib/net/imap/sasl.rb
+++ b/lib/net/imap/sasl.rb
@@ -25,54 +25,21 @@ module Net
 
       # autoloading to avoid loading all of the regexps when they aren't used.
 
-      autoload :StringPrep, File.expand_path("sasl/stringprep", __dir__)
-      autoload :SASLprep, File.expand_path("#{__dir__}/sasl/saslprep", __dir__)
+      sasl_stringprep_rb = File.expand_path("sasl/stringprep", __dir__)
+      autoload :StringPrep,          sasl_stringprep_rb
+      autoload :SASLprep,            sasl_stringprep_rb
+      autoload :StringPrepError,     sasl_stringprep_rb
+      autoload :ProhibitedCodepoint, sasl_stringprep_rb
+      autoload :BidiStringError,     sasl_stringprep_rb
 
-      # ArgumentError raised when +string+ is invalid for the stringprep
-      # +profile+.
-      class StringPrepError < ArgumentError
-        attr_reader :string, :profile
+      module_function
 
-        def initialize(*args, string: nil, profile: nil)
-          @string  = -string.to_str  unless string.nil?
-          @profile = -profile.to_str unless profile.nil?
-          super(*args)
-        end
-      end
-
-      # StringPrepError raised when +string+ contains a codepoint prohibited by
-      # +table+.
-      class ProhibitedCodepoint < StringPrepError
-        attr_reader :table
-
-        def initialize(table, *args, **kwargs)
-          @table = -table.to_str
-          details = (title = StringPrep::TABLE_TITLES[table]) ?
-            "%s [%s]" % [title, table] : table
-          message = "String contains a prohibited codepoint: %s" % [details]
-          super(message, *args, **kwargs)
-        end
-      end
-
-      # StringPrepError raised when +string+ contains bidirectional characters
-      # which violate the StringPrep requirements.
-      class BidiStringError < StringPrepError
-      end
-
-      #--
-      # We could just extend SASLprep module directly.  It's done this way so
-      # SASLprep can be lazily autoloaded.  Most users won't need it.
-      #++
-      extend self
-
-      # See SASLprep#saslprep.
+      # See Net::IMAP::StringPrep::SASLprep#saslprep.
       def saslprep(string, **opts)
-        SASLprep.saslprep(string, **opts)
+        Net::IMAP::StringPrep::SASLprep.saslprep(string, **opts)
       end
 
     end
   end
 
 end
-
-Net::IMAP.extend Net::IMAP::SASL

--- a/lib/net/imap/sasl/stringprep.rb
+++ b/lib/net/imap/sasl/stringprep.rb
@@ -1,72 +1,12 @@
 # frozen_string_literal: true
 
-require_relative "stringprep_tables"
-
 module Net::IMAP::SASL
 
-  # Regexps and utility methods for implementing stringprep profiles.  The
-  # \StringPrep algorithm is defined by
-  # {RFC-3454}[https://www.rfc-editor.org/rfc/rfc3454.html].  Each
-  # codepoint table defined in the RFC-3454 appendices is matched by a Regexp
-  # defined in this module.
-  #--
-  # TODO: generic StringPrep mapping (not needed for SASLprep implementation)
-  #++
-  module StringPrep
+  # Alias for Net::IMAP::StringPrep::SASLPrep.
+  SASLprep            = Net::IMAP::StringPrep::SASLprep
+  StringPrep          = Net::IMAP::StringPrep                      # :nodoc:
+  BidiStringError     = Net::IMAP::StringPrep::BidiStringError     # :nodoc:
+  ProhibitedCodepoint = Net::IMAP::StringPrep::ProhibitedCodepoint # :nodoc:
+  StringPrepError     = Net::IMAP::StringPrep::StringPrepError     # :nodoc:
 
-    # Returns a Regexp matching the given +table+ name.
-    def self.[](table)
-      TABLE_REGEXPS.fetch(table)
-    end
-
-    module_function
-
-    # Checks +string+ for any codepoint in +tables+. Raises a
-    # ProhibitedCodepoint describing the first matching table.
-    #
-    # Also checks bidirectional characters, when <tt>bidi: true</tt>, which may
-    # raise a BidiStringError.
-    #
-    # +profile+ is an optional string which will be added to any exception that
-    # is raised (it does not affect behavior).
-    def check_prohibited!(string, *tables, bidi: false, profile: nil)
-      tables = TABLE_TITLES.keys.grep(/^C/) if tables.empty?
-      tables |= %w[C.8] if bidi
-      table = tables.find {|t| TABLE_REGEXPS[t].match?(string) }
-      raise ProhibitedCodepoint.new(
-        table, string: string, profile: nil
-      ) if table
-      check_bidi!(string, profile: profile) if bidi
-    end
-
-    # Checks that +string+ obeys all of the "Bidirectional Characters"
-    # requirements in RFC-3454, §6:
-    #
-    # * The characters in \StringPrep\[\"C.8\"] MUST be prohibited
-    # * If a string contains any RandALCat character, the string MUST NOT
-    #   contain any LCat character.
-    # * If a string contains any RandALCat character, a RandALCat
-    #   character MUST be the first character of the string, and a
-    #   RandALCat character MUST be the last character of the string.
-    #
-    # This is usually combined with #check_prohibited!, so table "C.8" is only
-    # checked when <tt>c_8: true</tt>.
-    #
-    # Raises either ProhibitedCodepoint or BidiStringError unless all
-    # requirements are met.  +profile+ is an optional string which will be
-    # added to any exception that is raised (it does not affect behavior).
-    def check_bidi!(string, c_8: false, profile: nil)
-      check_prohibited!(string, "C.8", profile: profile) if c_8
-      if BIDI_FAILS_REQ2.match?(string)
-        raise BidiStringError.new(
-          BIDI_DESC_REQ2, string: string, profile: profile,
-        )
-      elsif BIDI_FAILS_REQ3.match?(string)
-        raise BidiStringError.new(
-          BIDI_DESC_REQ3, string: string, profile: profile,
-        )
-      end
-    end
-
-  end
 end

--- a/lib/net/imap/stringprep.rb
+++ b/lib/net/imap/stringprep.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+module Net
+  class IMAP < Protocol
+
+    # Regexps and utility methods for implementing stringprep profiles.  The
+    # \StringPrep algorithm is defined by
+    # {RFC-3454}[https://www.rfc-editor.org/rfc/rfc3454.html].  Each
+    # codepoint table defined in the RFC-3454 appendices is matched by a Regexp
+    # defined in this module.
+    module StringPrep
+      autoload :SASLprep, File.expand_path("stringprep/saslprep", __dir__)
+      autoload :Tables,   File.expand_path("stringprep/tables",   __dir__)
+
+      # ArgumentError raised when +string+ is invalid for the stringprep
+      # +profile+.
+      class StringPrepError < ArgumentError
+        attr_reader :string, :profile
+
+        def initialize(*args, string: nil, profile: nil)
+          @string  = -string.to_str  unless string.nil?
+          @profile = -profile.to_str unless profile.nil?
+          super(*args)
+        end
+      end
+
+      # StringPrepError raised when +string+ contains a codepoint prohibited by
+      # +table+.
+      class ProhibitedCodepoint < StringPrepError
+        attr_reader :table
+
+        def initialize(table, *args, **kwargs)
+          @table  = table
+          details = (title = Tables::TITLES[table]) ?
+            "%s [%s]" % [title, table] : table
+          message = "String contains a prohibited codepoint: %s" % [details]
+          super(message, *args, **kwargs)
+        end
+      end
+
+      # StringPrepError raised when +string+ contains bidirectional characters
+      # which violate the StringPrep requirements.
+      class BidiStringError < StringPrepError
+      end
+
+      # Returns a Regexp matching the given +table+ name.
+      def self.[](table)
+        Tables::REGEXPS.fetch(table)
+      end
+
+      module_function
+
+      # Checks +string+ for any codepoint in +tables+. Raises a
+      # ProhibitedCodepoint describing the first matching table.
+      #
+      # Also checks bidirectional characters, when <tt>bidi: true</tt>, which may
+      # raise a BidiStringError.
+      #
+      # +profile+ is an optional string which will be added to any exception that
+      # is raised (it does not affect behavior).
+      def check_prohibited!(string, *tables, bidi: false, profile: nil)
+        tables = TABLE_TITLES.keys.grep(/^C/) if tables.empty?
+        tables |= %w[C.8] if bidi
+        table = tables.find {|t| Tables::REGEXPS[t].match?(string) }
+        raise ProhibitedCodepoint.new(
+          table, string: string, profile: nil
+        ) if table
+        check_bidi!(string, profile: profile) if bidi
+      end
+
+      # Checks that +string+ obeys all of the "Bidirectional Characters"
+      # requirements in RFC-3454, §6:
+      #
+      # * The characters in \StringPrep\[\"C.8\"] MUST be prohibited
+      # * If a string contains any RandALCat character, the string MUST NOT
+      #   contain any LCat character.
+      # * If a string contains any RandALCat character, a RandALCat
+      #   character MUST be the first character of the string, and a
+      #   RandALCat character MUST be the last character of the string.
+      #
+      # This is usually combined with #check_prohibited!, so table "C.8" is only
+      # checked when <tt>c_8: true</tt>.
+      #
+      # Raises either ProhibitedCodepoint or BidiStringError unless all
+      # requirements are met.  +profile+ is an optional string which will be
+      # added to any exception that is raised (it does not affect behavior).
+      def check_bidi!(string, c_8: false, profile: nil)
+        check_prohibited!(string, "C.8", profile: profile) if c_8
+        if Tables::BIDI_FAILS_REQ2.match?(string)
+          raise BidiStringError.new(
+            Tables::BIDI_DESC_REQ2, string: string, profile: profile,
+          )
+        elsif Tables::BIDI_FAILS_REQ3.match?(string)
+          raise BidiStringError.new(
+            Tables::BIDI_DESC_REQ3, string: string, profile: profile,
+          )
+        end
+      end
+
+    end
+  end
+end

--- a/lib/net/imap/stringprep/saslprep.rb
+++ b/lib/net/imap/stringprep/saslprep.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require_relative "saslprep_tables"
-
-module Net::IMAP::SASL
+module Net
+  class IMAP
+    module StringPrep
 
   # SASLprep#saslprep can be used to prepare a string according to [RFC4013].
   #
@@ -15,6 +15,16 @@ module Net::IMAP::SASL
 
     # Used to short-circuit strings that don't need preparation.
     ASCII_NO_CTRLS = /\A[\x20-\x7e]*\z/u.freeze
+
+    # Avoid loading these tables unless they are needed (they are only
+    # needed for non-ASCII).
+    saslprep_tables = File.expand_path("saslprep_tables", __dir__)
+    autoload :MAP_TO_NOTHING,           saslprep_tables
+    autoload :MAP_TO_SPACE,             saslprep_tables
+    autoload :PROHIBITED,               saslprep_tables
+    autoload :PROHIBITED_STORED,        saslprep_tables
+    autoload :TABLES_PROHIBITED,        saslprep_tables
+    autoload :TABLES_PROHIBITED_STORED, saslprep_tables
 
     module_function
 
@@ -40,7 +50,7 @@ module Net::IMAP::SASL
       # raise helpful errors to indicate *why* it failed:
       tables = stored ? TABLES_PROHIBITED_STORED : TABLES_PROHIBITED
       StringPrep.check_prohibited! str, *tables, bidi: true, profile: "SASLprep"
-      raise StringPrep::InvalidStringError.new(
+      raise InvalidStringError.new(
         "unknown error", string: string, profile: "SASLprep"
       )
     rescue ArgumentError, Encoding::CompatibilityError => ex
@@ -51,5 +61,8 @@ module Net::IMAP::SASL
       raise ex
     end
 
+  end
+
+    end
   end
 end

--- a/lib/net/imap/stringprep/saslprep.rb
+++ b/lib/net/imap/stringprep/saslprep.rb
@@ -4,64 +4,65 @@ module Net
   class IMAP
     module StringPrep
 
-  # SASLprep#saslprep can be used to prepare a string according to [RFC4013].
-  #
-  # \SASLprep maps characters three ways: to nothing, to space, and Unicode
-  # normalization form KC.  \SASLprep prohibits codepoints from nearly all
-  # standard StringPrep tables (RFC3454, Appendix "C"), and uses \StringPrep's
-  # standard bidirectional characters requirements (Appendix "D").  \SASLprep
-  # also uses \StringPrep's definition of "Unassigned" codepoints (Appendix "A").
-  module SASLprep
+      # SASLprep#saslprep can be used to prepare a string according to [RFC4013].
+      #
+      # \SASLprep maps characters three ways: to nothing, to space, and Unicode
+      # normalization form KC.  \SASLprep prohibits codepoints from nearly all
+      # standard StringPrep tables (RFC3454, Appendix "C"), and uses
+      # \StringPrep's standard bidirectional characters requirements (Appendix
+      # "D").  \SASLprep also uses \StringPrep's definition of "Unassigned"
+      # codepoints (Appendix "A").
+      module SASLprep
 
-    # Used to short-circuit strings that don't need preparation.
-    ASCII_NO_CTRLS = /\A[\x20-\x7e]*\z/u.freeze
+        # Used to short-circuit strings that don't need preparation.
+        ASCII_NO_CTRLS = /\A[\x20-\x7e]*\z/u.freeze
 
-    # Avoid loading these tables unless they are needed (they are only
-    # needed for non-ASCII).
-    saslprep_tables = File.expand_path("saslprep_tables", __dir__)
-    autoload :MAP_TO_NOTHING,           saslprep_tables
-    autoload :MAP_TO_SPACE,             saslprep_tables
-    autoload :PROHIBITED,               saslprep_tables
-    autoload :PROHIBITED_STORED,        saslprep_tables
-    autoload :TABLES_PROHIBITED,        saslprep_tables
-    autoload :TABLES_PROHIBITED_STORED, saslprep_tables
+        # Avoid loading these tables unless they are needed (they are only
+        # needed for non-ASCII).
+        saslprep_tables = File.expand_path("saslprep_tables", __dir__)
+        autoload :MAP_TO_NOTHING,           saslprep_tables
+        autoload :MAP_TO_SPACE,             saslprep_tables
+        autoload :PROHIBITED,               saslprep_tables
+        autoload :PROHIBITED_STORED,        saslprep_tables
+        autoload :TABLES_PROHIBITED,        saslprep_tables
+        autoload :TABLES_PROHIBITED_STORED, saslprep_tables
 
-    module_function
+        module_function
 
-    # Prepares a UTF-8 +string+ for comparison, using the \SASLprep profile
-    # RFC4013 of the StringPrep algorithm RFC3454.
-    #
-    # By default, prohibited strings will return +nil+.  When +exception+ is
-    # +true+, a StringPrepError describing the violation will be raised.
-    #
-    # When +stored+ is +true+, "unassigned" codepoints will be prohibited. For
-    # \StringPrep and the \SASLprep profile, "unassigned" refers to Unicode 3.2,
-    # and not later versions.  See RFC3454 §7 for more information.
-    #
-    def saslprep(str, stored: false, exception: false)
-      return str if ASCII_NO_CTRLS.match?(str) # raises on incompatible encoding
-      str = str.encode("UTF-8") # also dups (and raises for invalid encoding)
-      str.gsub!(MAP_TO_SPACE, " ")
-      str.gsub!(MAP_TO_NOTHING, "")
-      str.unicode_normalize!(:nfkc)
-      # These regexps combine the prohibited and bidirectional checks
-      return str unless str.match?(stored ? PROHIBITED_STORED : PROHIBITED)
-      return nil unless exception
-      # raise helpful errors to indicate *why* it failed:
-      tables = stored ? TABLES_PROHIBITED_STORED : TABLES_PROHIBITED
-      StringPrep.check_prohibited! str, *tables, bidi: true, profile: "SASLprep"
-      raise InvalidStringError.new(
-        "unknown error", string: string, profile: "SASLprep"
-      )
-    rescue ArgumentError, Encoding::CompatibilityError => ex
-      if /invalid byte sequence|incompatible encoding/.match? ex.message
-        return nil unless exception
-        raise StringPrepError.new(ex.message, string: str, profile: "saslprep")
+        # Prepares a UTF-8 +string+ for comparison, using the \SASLprep profile
+        # RFC4013 of the StringPrep algorithm RFC3454.
+        #
+        # By default, prohibited strings will return +nil+.  When +exception+ is
+        # +true+, a StringPrepError describing the violation will be raised.
+        #
+        # When +stored+ is +true+, "unassigned" codepoints will be prohibited.
+        # For \StringPrep and the \SASLprep profile, "unassigned" refers to
+        # Unicode 3.2, and not later versions.  See RFC3454 §7 for more
+        # information.
+        def saslprep(str, stored: false, exception: false)
+          return str if ASCII_NO_CTRLS.match?(str) # incompatible encoding raises
+          str = str.encode("UTF-8") # also dups (and raises for invalid encoding)
+          str.gsub!(MAP_TO_SPACE, " ")
+          str.gsub!(MAP_TO_NOTHING, "")
+          str.unicode_normalize!(:nfkc)
+          # These regexps combine the prohibited and bidirectional checks
+          return str unless str.match?(stored ? PROHIBITED_STORED : PROHIBITED)
+          return nil unless exception
+          # raise helpful errors to indicate *why* it failed:
+          tables = stored ? TABLES_PROHIBITED_STORED : TABLES_PROHIBITED
+          StringPrep.check_prohibited! str, *tables, bidi: true, profile: "SASLprep"
+          raise InvalidStringError.new(
+            "unknown error", string: string, profile: "SASLprep"
+          )
+        rescue ArgumentError, Encoding::CompatibilityError => ex
+          if /invalid byte sequence|incompatible encoding/.match? ex.message
+            return nil unless exception
+            raise StringPrepError.new(ex.message, string: str, profile: "saslprep")
+          end
+          raise ex
+        end
+
       end
-      raise ex
-    end
-
-  end
 
     end
   end

--- a/lib/net/imap/stringprep/saslprep_tables.rb
+++ b/lib/net/imap/stringprep/saslprep_tables.rb
@@ -4,7 +4,7 @@
 # This file is generated from RFC3454, by rake.  Don't edit directly.
 #++
 
-module Net::IMAP::SASL
+module Net::IMAP::StringPrep
 
   module SASLprep
 

--- a/lib/net/imap/stringprep/tables.rb
+++ b/lib/net/imap/stringprep/tables.rb
@@ -4,9 +4,9 @@
 # This file is generated from RFC3454, by rake.  Don't edit directly.
 #++
 
-module Net::IMAP::SASL
+module Net::IMAP::StringPrep
 
-  module StringPrep
+  module Tables
 
     # Unassigned code points in Unicode 3.2 \StringPrep\[\"A.1\"]
     IN_A_1 = /\p{^AGE=3.2}/.freeze
@@ -106,7 +106,7 @@ module Net::IMAP::SASL
     )/mx.freeze
 
     # Names of each codepoint table in the RFC-3454 appendices
-    TABLE_TITLES = {
+    TITLES = {
       "A.1" => "Unassigned code points in Unicode 3.2",
       "B.1" => "Commonly mapped to nothing",
       "B.2" => "Mapping for case-folding used with NFKC",
@@ -129,7 +129,7 @@ module Net::IMAP::SASL
     }.freeze
 
     # Regexps matching each codepoint table in the RFC-3454 appendices
-    TABLE_REGEXPS = {
+    REGEXPS = {
       "A.1" => IN_A_1,
       "B.1" => IN_B_1,
       "B.2" => IN_B_2,

--- a/rakelib/saslprep.rake
+++ b/rakelib/saslprep.rake
@@ -10,17 +10,17 @@ end
 
 directory "lib/net/imap/sasl"
 
-file "lib/net/imap/sasl/stringprep_tables.rb" => generator.rb_deps do |t|
+file "lib/net/imap/stringprep/tables.rb" => generator.rb_deps do |t|
   File.write t.name, generator.stringprep_rb
 end
 
-file "lib/net/imap/sasl/saslprep_tables.rb" => generator.rb_deps do |t|
+file "lib/net/imap/stringprep/saslprep_tables.rb" => generator.rb_deps do |t|
   File.write t.name, generator.saslprep_rb
 end
 
 GENERATED_RUBY = FileList.new(
-  "lib/net/imap/sasl/stringprep_tables.rb",
-  "lib/net/imap/sasl/saslprep_tables.rb",
+  "lib/net/imap/stringprep/tables.rb",
+  "lib/net/imap/stringprep/saslprep_tables.rb",
 )
 
 CLEAN.include   generator.clean_deps

--- a/rakelib/string_prep_tables_generator.rb
+++ b/rakelib/string_prep_tables_generator.rb
@@ -62,9 +62,9 @@ class StringPrepTablesGenerator
       # This file is generated from RFC3454, by rake.  Don't edit directly.
       #++
 
-      module Net::IMAP::SASL
+      module Net::IMAP::StringPrep
 
-        module StringPrep
+        module Tables
 
           #{asgn_table "A.1"}
 
@@ -122,12 +122,12 @@ class StringPrepTablesGenerator
           BIDI_FAILURE = #{bidi_failure_regexp.inspect}.freeze
 
           # Names of each codepoint table in the RFC-3454 appendices
-          TABLE_TITLES = {
+          TITLES = {
             #{table_titles_rb}
           }.freeze
 
           # Regexps matching each codepoint table in the RFC-3454 appendices
-          TABLE_REGEXPS = {
+          REGEXPS = {
             #{table_regexps_rb}
           }.freeze
 
@@ -157,7 +157,7 @@ class StringPrepTablesGenerator
       # This file is generated from RFC3454, by rake.  Don't edit directly.
       #++
 
-      module Net::IMAP::SASL
+      module Net::IMAP::StringPrep
 
         module SASLprep
 

--- a/test/net/imap/test_saslprep.rb
+++ b/test/net/imap/test_saslprep.rb
@@ -4,7 +4,7 @@ require "net/imap"
 require "test/unit"
 
 class SASLprepTest < Test::Unit::TestCase
-  include Net::IMAP::SASL
+  include Net::IMAP::StringPrep
 
   # Test cases from RFC-4013 §3:
   #

--- a/test/net/imap/test_stringprep_tables.rb
+++ b/test/net/imap/test_stringprep_tables.rb
@@ -7,8 +7,8 @@ require "set"
 
 require_relative "../../../rakelib/string_prep_tables_generator"
 
-class StringPrepTest < Test::Unit::TestCase
-  include Net::IMAP::SASL
+class StringPrepTablesTest < Test::Unit::TestCase
+  include Net::IMAP::StringPrep
 
   # Surrogates are excluded.  They are handled by enforcing valid UTF8 encoding.
   VALID_CODEPOINTS = (0..0x10_ffff).map{|cp| cp.chr("UTF-8") rescue nil}.compact
@@ -49,9 +49,9 @@ class StringPrepTest < Test::Unit::TestCase
   def test_rfc3454_table_D_2;   assert_rfc3454_table_compliance "D.2"   end
 
   def assert_rfc3454_table_compliance(name)
-    set     = RFC3454_TABLE_SETS       .fetch(name)
-    regexp  = RFC3454_TABLE_REGEXPS    .fetch(name)
-    coded   = StringPrep::TABLE_REGEXPS.fetch(name)
+    set     = RFC3454_TABLE_SETS   .fetch(name)
+    regexp  = RFC3454_TABLE_REGEXPS.fetch(name)
+    coded   = Tables::REGEXPS      .fetch(name)
     matched_set = VALID_CODEPOINTS
       .map{|cp| cp.unpack1 "U"}
       .grep(set)


### PR DESCRIPTION
Some simple code reorg, prior to adding the `trace` stringprep for `ANONYMOUS` SASL.  I'm leaving aliases from the current locations, so it should be compatible with the currently documented API.

I'm also moving to use `autoload` with the SASL and StringPrep code as much as possible.  Most Net::IMAP users will never need to load the stringprep tables.