### PR TITLE
✅ 📈 Move most parser tests to yaml, add more tests, and add parser benchmarks

### DIFF
--- a/benchmarks/generate_parser_benchmarks
+++ b/benchmarks/generate_parser_benchmarks
@@ -1,0 +1,51 @@
+#!/usr/bin/env ruby
+
+require "yaml"
+require "pathname"
+require "net/imap"
+
+path = Pathname.new(__dir__) / "../test/net/imap/fixtures/response_parser"
+files = path.glob("*.yml")
+tests = files.flat_map {|file|
+  file.to_s
+    .then { YAML.unsafe_load_file _1 }
+    .fetch(:tests)
+    .select {|test_name, test|
+      :parser_assert_equal == test.fetch(:test_type) {
+        test.key?(:expected) ? :parser_assert_equal : :parser_pending
+      }
+    }
+    .map {|test_name, _|
+      [
+        file.relative_path_from(__dir__).to_s,
+        test_name.to_s,
+      ]
+    }
+}
+
+init = <<RUBY
+  require "yaml"
+  require "net/imap"
+
+  def load_response(file, name)
+    YAML.unsafe_load_file(file).dig(:tests, name, :response) \\
+      or abort "ERRORO: missing %p fixture data in %p" % [name, file]
+  end
+
+  parser   = Net::IMAP::ResponseParser.new
+RUBY
+
+prelude = <<RUBY
+  response = load_response(%p,
+                           %p)
+RUBY
+script = "parser.parse(response)"
+
+benchmarks = tests.map {|file, fixture_name|
+  name = fixture_name.delete_prefix("test_")
+  {name:, prelude: prelude % [file, fixture_name], script:}
+    .transform_keys(&:to_s)
+}
+  .sort_by { _1["name"] }
+
+puts YAML.dump({"prelude" => init, "benchmark" => benchmarks})

--- a/benchmarks/parser.yml
+++ b/benchmarks/parser.yml
@@ -1,0 +1,567 @@
+---
+prelude: |2
+    require "yaml"
+    require "net/imap"
+
+    def load_response(file, name)
+      YAML.unsafe_load_file(file).dig(:tests, name, :response) \
+        or abort "ERRORO: missing %p fixture data in %p" % [name, file]
+    end
+
+    parser   = Net::IMAP::ResponseParser.new
+benchmark:
+- name: NAMESPACE_rfc2342_example_5.1
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/namespace_responses.yml",
+                               "NAMESPACE_rfc2342_example_5.1")
+  script: parser.parse(response)
+- name: NAMESPACE_rfc2342_example_5.2
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/namespace_responses.yml",
+                               "NAMESPACE_rfc2342_example_5.2")
+  script: parser.parse(response)
+- name: NAMESPACE_rfc2342_example_5.3
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/namespace_responses.yml",
+                               "NAMESPACE_rfc2342_example_5.3")
+  script: parser.parse(response)
+- name: NAMESPACE_rfc2342_example_5.4
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/namespace_responses.yml",
+                               "NAMESPACE_rfc2342_example_5.4")
+  script: parser.parse(response)
+- name: NAMESPACE_rfc2342_example_5.5
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/namespace_responses.yml",
+                               "NAMESPACE_rfc2342_example_5.5")
+  script: parser.parse(response)
+- name: NAMESPACE_rfc2342_example_5.6
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/namespace_responses.yml",
+                               "NAMESPACE_rfc2342_example_5.6")
+  script: parser.parse(response)
+- name: NAMESPACE_rfc2342_example_5.7
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/namespace_responses.yml",
+                               "NAMESPACE_rfc2342_example_5.7")
+  script: parser.parse(response)
+- name: NAMESPACE_rfc2342_example_5.9
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/namespace_responses.yml",
+                               "NAMESPACE_rfc2342_example_5.9")
+  script: parser.parse(response)
+- name: NAMESPACE_rfc9051_6.3.10_example_8
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/namespace_responses.yml",
+                               "NAMESPACE_rfc9051_6.3.10_example_8")
+  script: parser.parse(response)
+- name: acl_response
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/acl_responses.yml",
+                               "test_acl_response")
+  script: parser.parse(response)
+- name: bodystructure_bug11128_ext_mpart_without_lang
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/body_structure_responses.yml",
+                               "test_bodystructure_bug11128_ext_mpart_without_lang")
+  script: parser.parse(response)
+- name: bodystructure_bug7146_msg_delivery_status
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/body_structure_responses.yml",
+                               "test_bodystructure_bug7146_msg_delivery_status")
+  script: parser.parse(response)
+- name: bodystructure_bug7147_message_rfc822_attachment
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/body_structure_responses.yml",
+                               "test_bodystructure_bug7147_message_rfc822_attachment")
+  script: parser.parse(response)
+- name: bodystructure_bug8167_delivery_status_with_extra_data
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/body_structure_responses.yml",
+                               "test_bodystructure_bug8167_delivery_status_with_extra_data")
+  script: parser.parse(response)
+- name: bodystructure_mixed_boundary
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/body_structure_responses.yml",
+                               "test_bodystructure_mixed_boundary")
+  script: parser.parse(response)
+- name: continuation_request_without_response_text
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/continuation_requests.yml",
+                               "test_continuation_request_without_response_text")
+  script: parser.parse(response)
+- name: fetch_msg_att_flags_and_uid
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/fetch_responses.yml",
+                               "test_fetch_msg_att_flags_and_uid")
+  script: parser.parse(response)
+- name: fetch_msg_att_modseq
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/fetch_responses.yml",
+                               "test_fetch_msg_att_modseq")
+  script: parser.parse(response)
+- name: fetch_msg_att_rfc822
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/fetch_responses.yml",
+                               "test_fetch_msg_att_rfc822")
+  script: parser.parse(response)
+- name: fetch_msg_att_uid
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/fetch_responses.yml",
+                               "test_fetch_msg_att_uid")
+  script: parser.parse(response)
+- name: id_gmail
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/id_responses.yml",
+                               "test_id_gmail")
+  script: parser.parse(response)
+- name: id_rfc2971_example_3.1_nil
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/id_responses.yml",
+                               "test_id_rfc2971_example_3.1_nil")
+  script: parser.parse(response)
+- name: id_rfc2971_example_3.2_cyrus
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/id_responses.yml",
+                               "test_id_rfc2971_example_3.2_cyrus")
+  script: parser.parse(response)
+- name: invalid_bodystructure_bug7153_mixed
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/body_structure_responses.yml",
+                               "test_invalid_bodystructure_bug7153_mixed")
+  script: parser.parse(response)
+- name: invalid_bodystructure_message_sent_as_basic
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/body_structure_responses.yml",
+                               "test_invalid_bodystructure_message_sent_as_basic")
+  script: parser.parse(response)
+- name: invalid_capability_extra_space_at_end
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/capability_responses.yml",
+                               "test_invalid_capability_extra_space_at_end")
+  script: parser.parse(response)
+- name: invalid_fetch_msg_att_extra_space
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/fetch_responses.yml",
+                               "test_invalid_fetch_msg_att_extra_space")
+  script: parser.parse(response)
+- name: invalid_fetch_msg_att_rfc822_with_brackets
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/fetch_responses.yml",
+                               "test_invalid_fetch_msg_att_rfc822_with_brackets")
+  script: parser.parse(response)
+- name: invalid_noop_response_is_ignored
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/quirky_behaviors.yml",
+                               "test_invalid_noop_response_is_ignored")
+  script: parser.parse(response)
+- name: invalid_search_response_multiple_result_with_trailing_space
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/search_responses.yml",
+                               "test_invalid_search_response_multiple_result_with_trailing_space")
+  script: parser.parse(response)
+- name: invalid_search_response_single_result_with_trailing_space
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/search_responses.yml",
+                               "test_invalid_search_response_single_result_with_trailing_space")
+  script: parser.parse(response)
+- name: invalid_status_response_trailing_space
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/status_responses.yml",
+                               "test_invalid_status_response_trailing_space")
+  script: parser.parse(response)
+- name: invalid_thread_empty_response
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/thread_responses.yml",
+                               "test_invalid_thread_empty_response")
+  script: parser.parse(response)
+- name: list_with_various_flag_types_and_capitalizations
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/list_responses.yml",
+                               "test_list_with_various_flag_types_and_capitalizations")
+  script: parser.parse(response)
+- name: resp_code_ALREADYEXISTS_rfc9051_7.1_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_code_examples.yml",
+                               "test_resp_code_ALREADYEXISTS_rfc9051_7.1_example")
+  script: parser.parse(response)
+- name: resp_code_APPENDUID_rfc9051_6.3.12_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/uidplus_extension.yml",
+                               "test_resp_code_APPENDUID_rfc9051_6.3.12_example")
+  script: parser.parse(response)
+- name: resp_code_APPENDUID_with_MULTIAPPEND_compatibility
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/uidplus_extension.yml",
+                               "test_resp_code_APPENDUID_with_MULTIAPPEND_compatibility")
+  script: parser.parse(response)
+- name: resp_code_AUTHENTICATIONFAILED_rfc9051_7.1_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_code_examples.yml",
+                               "test_resp_code_AUTHENTICATIONFAILED_rfc9051_7.1_example")
+  script: parser.parse(response)
+- name: resp_code_AUTHORIZATIONFAILED_rfc9051_7.1_example_1
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_code_examples.yml",
+                               "test_resp_code_AUTHORIZATIONFAILED_rfc9051_7.1_example_1")
+  script: parser.parse(response)
+- name: resp_code_AUTHORIZATIONFAILED_rfc9051_7.1_example_2
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_code_examples.yml",
+                               "test_resp_code_AUTHORIZATIONFAILED_rfc9051_7.1_example_2")
+  script: parser.parse(response)
+- name: resp_code_BADCHARSET_rfc9051_6.4.4.4_example_modified
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_code_examples.yml",
+                               "test_resp_code_BADCHARSET_rfc9051_6.4.4.4_example_modified")
+  script: parser.parse(response)
+- name: resp_code_BADCHARSET_with_astrings
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_code_examples.yml",
+                               "test_resp_code_BADCHARSET_with_astrings")
+  script: parser.parse(response)
+- name: resp_code_CANNOT_rfc9051_7.1_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_code_examples.yml",
+                               "test_resp_code_CANNOT_rfc9051_7.1_example")
+  script: parser.parse(response)
+- name: resp_code_CAPABILITY_rfc9051_6.2.2_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_code_examples.yml",
+                               "test_resp_code_CAPABILITY_rfc9051_6.2.2_example")
+  script: parser.parse(response)
+- name: resp_code_CAPABILITY_with_valid_atoms
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_code_examples.yml",
+                               "test_resp_code_CAPABILITY_with_valid_atoms")
+  script: parser.parse(response)
+- name: resp_code_CLIENTBUG_rfc9051_7.1_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_code_examples.yml",
+                               "test_resp_code_CLIENTBUG_rfc9051_7.1_example")
+  script: parser.parse(response)
+- name: resp_code_CLOSED
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_code_examples.yml",
+                               "test_resp_code_CLOSED")
+  script: parser.parse(response)
+- name: resp_code_CONTACTADMIN_rfc9051_7.1_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_code_examples.yml",
+                               "test_resp_code_CONTACTADMIN_rfc9051_7.1_example")
+  script: parser.parse(response)
+- name: resp_code_COPYUID_rfc9051_6.3.12_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/uidplus_extension.yml",
+                               "test_resp_code_COPYUID_rfc9051_6.3.12_example")
+  script: parser.parse(response)
+- name: resp_code_COPYUID_with_reversed_ranges_and_mixed_case
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/uidplus_extension.yml",
+                               "test_resp_code_COPYUID_with_reversed_ranges_and_mixed_case")
+  script: parser.parse(response)
+- name: resp_code_CORRUPTION_rfc9051_7.1_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_code_examples.yml",
+                               "test_resp_code_CORRUPTION_rfc9051_7.1_example")
+  script: parser.parse(response)
+- name: resp_code_EXPIRED_rfc9051_7.1_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_code_examples.yml",
+                               "test_resp_code_EXPIRED_rfc9051_7.1_example")
+  script: parser.parse(response)
+- name: resp_code_EXPUNGEISSUED_rfc9051_7.1_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_code_examples.yml",
+                               "test_resp_code_EXPUNGEISSUED_rfc9051_7.1_example")
+  script: parser.parse(response)
+- name: resp_code_HASCHILDREN_rfc9051_7.1_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_code_examples.yml",
+                               "test_resp_code_HASCHILDREN_rfc9051_7.1_example")
+  script: parser.parse(response)
+- name: resp_code_INUSE_rfc9051_7.1_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_code_examples.yml",
+                               "test_resp_code_INUSE_rfc9051_7.1_example")
+  script: parser.parse(response)
+- name: resp_code_LIMIT_rfc9051_7.1_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_code_examples.yml",
+                               "test_resp_code_LIMIT_rfc9051_7.1_example")
+  script: parser.parse(response)
+- name: resp_code_NONEXISTENT_rfc9051_7.1_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_code_examples.yml",
+                               "test_resp_code_NONEXISTENT_rfc9051_7.1_example")
+  script: parser.parse(response)
+- name: resp_code_NOPERM_rfc9051_7.1_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_code_examples.yml",
+                               "test_resp_code_NOPERM_rfc9051_7.1_example")
+  script: parser.parse(response)
+- name: resp_code_OVERQUOTA_rfc9051_7.1_example_1
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_code_examples.yml",
+                               "test_resp_code_OVERQUOTA_rfc9051_7.1_example_1")
+  script: parser.parse(response)
+- name: resp_code_OVERQUOTA_rfc9051_7.1_example_2
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_code_examples.yml",
+                               "test_resp_code_OVERQUOTA_rfc9051_7.1_example_2")
+  script: parser.parse(response)
+- name: resp_code_PERMANENTFLAGS_rfc3501_6.3.1_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_code_examples.yml",
+                               "test_resp_code_PERMANENTFLAGS_rfc3501_6.3.1_example")
+  script: parser.parse(response)
+- name: resp_code_PERMANENTFLAGS_rfc3501_6.3.2_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_code_examples.yml",
+                               "test_resp_code_PERMANENTFLAGS_rfc3501_6.3.2_example")
+  script: parser.parse(response)
+- name: resp_code_PRIVACYREQUIRED_rfc9051_7.1_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_code_examples.yml",
+                               "test_resp_code_PRIVACYREQUIRED_rfc9051_7.1_example")
+  script: parser.parse(response)
+- name: resp_code_READ-ONLY_rfc3501_6.3.2_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_code_examples.yml",
+                               "test_resp_code_READ-ONLY_rfc3501_6.3.2_example")
+  script: parser.parse(response)
+- name: resp_code_READ-WRITE_rfc3501_6.3.1_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_code_examples.yml",
+                               "test_resp_code_READ-WRITE_rfc3501_6.3.1_example")
+  script: parser.parse(response)
+- name: resp_code_SERVERBUG_rfc9051_7.1_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_code_examples.yml",
+                               "test_resp_code_SERVERBUG_rfc9051_7.1_example")
+  script: parser.parse(response)
+- name: resp_code_UIDNEXT_rfc3501_6.3.1_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_code_examples.yml",
+                               "test_resp_code_UIDNEXT_rfc3501_6.3.1_example")
+  script: parser.parse(response)
+- name: resp_code_UIDVALIDITY_rfc3501_6.3.1_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_code_examples.yml",
+                               "test_resp_code_UIDVALIDITY_rfc3501_6.3.1_example")
+  script: parser.parse(response)
+- name: resp_code_UNAVAILABLE_rfc9051_7.1_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_code_examples.yml",
+                               "test_resp_code_UNAVAILABLE_rfc9051_7.1_example")
+  script: parser.parse(response)
+- name: resp_code_UNSEEN_rfc3501_6.3.1_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_code_examples.yml",
+                               "test_resp_code_UNSEEN_rfc3501_6.3.1_example")
+  script: parser.parse(response)
+- name: resp_text_with_T_LBRA
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_text_responses.yml",
+                               "test_resp_text_with_T_LBRA")
+  script: parser.parse(response)
+- name: rfc3501_6.1.1_example_1_capability_response
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/capability_responses.yml",
+                               "rfc3501_6.1.1_example_1_capability_response")
+  script: parser.parse(response)
+- name: rfc3501_6.1.1_example_2_capability_response
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/capability_responses.yml",
+                               "rfc3501_6.1.1_example_2_capability_response")
+  script: parser.parse(response)
+- name: rfc3501_6.2.2_example_continuation_request
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/continuation_requests.yml",
+                               "rfc3501_6.2.2_example_continuation_request")
+  script: parser.parse(response)
+- name: rfc3501_6.3.11_example_continuation_request
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/continuation_requests.yml",
+                               "rfc3501_6.3.11_example_continuation_request")
+  script: parser.parse(response)
+- name: rfc3501_7.1.1_OK_response_example_1
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_cond_examples.yml",
+                               "rfc3501_7.1.1_OK_response_example_1")
+  script: parser.parse(response)
+- name: rfc3501_7.1.1_OK_response_example_2
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_cond_examples.yml",
+                               "rfc3501_7.1.1_OK_response_example_2")
+  script: parser.parse(response)
+- name: rfc3501_7.1.1_OK_response_example_3
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_cond_examples.yml",
+                               "rfc3501_7.1.1_OK_response_example_3")
+  script: parser.parse(response)
+- name: rfc3501_7.1.2_NO_response_example_1
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_cond_examples.yml",
+                               "rfc3501_7.1.2_NO_response_example_1")
+  script: parser.parse(response)
+- name: rfc3501_7.1.2_NO_response_example_4
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_cond_examples.yml",
+                               "rfc3501_7.1.2_NO_response_example_4")
+  script: parser.parse(response)
+- name: rfc3501_7.1.3_BAD_response_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_cond_examples.yml",
+                               "rfc3501_7.1.3_BAD_response_example")
+  script: parser.parse(response)
+- name: rfc3501_7.1.4_PREAUTH_response_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_cond_examples.yml",
+                               "rfc3501_7.1.4_PREAUTH_response_example")
+  script: parser.parse(response)
+- name: rfc3501_7.1.5_BYE_response_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_cond_examples.yml",
+                               "rfc3501_7.1.5_BYE_response_example")
+  script: parser.parse(response)
+- name: rfc3501_7.2.1_CAPABILITY_response_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/capability_responses.yml",
+                               "rfc3501_7.2.1_CAPABILITY_response_example")
+  script: parser.parse(response)
+- name: rfc3501_7.2.2_LIST_response_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/list_responses.yml",
+                               "rfc3501_7.2.2_LIST_response_example")
+  script: parser.parse(response)
+- name: rfc3501_7.2.3_LSUB_response_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/list_responses.yml",
+                               "rfc3501_7.2.3_LSUB_response_example")
+  script: parser.parse(response)
+- name: rfc3501_7.2.4_STATUS_response_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/status_responses.yml",
+                               "rfc3501_7.2.4_STATUS_response_example")
+  script: parser.parse(response)
+- name: rfc3501_7.2.5_SEARCH_response_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/search_responses.yml",
+                               "rfc3501_7.2.5_SEARCH_response_example")
+  script: parser.parse(response)
+- name: rfc3501_7.2.6_FLAGS_response_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/flags_responses.yml",
+                               "rfc3501_7.2.6_FLAGS_response_example")
+  script: parser.parse(response)
+- name: rfc3501_7.3.1_EXISTS_response_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/mailbox_size_responses.yml",
+                               "rfc3501_7.3.1_EXISTS_response_example")
+  script: parser.parse(response)
+- name: rfc3501_7.3.2_RECENT_response_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/mailbox_size_responses.yml",
+                               "rfc3501_7.3.2_RECENT_response_example")
+  script: parser.parse(response)
+- name: rfc3501_7.4.1_EXPUNGE_response_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/expunge_responses.yml",
+                               "rfc3501_7.4.1_EXPUNGE_response_example")
+  script: parser.parse(response)
+- name: rfc3501_7.4.2_FETCH_response_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/fetch_responses.yml",
+                               "rfc3501_7.4.2_FETCH_response_example")
+  script: parser.parse(response)
+- name: rfc3501_7.5_continuation_request_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/continuation_requests.yml",
+                               "rfc3501_7.5_continuation_request_example")
+  script: parser.parse(response)
+- name: rfc3501_8_example_1_UNSEEN_response_code
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/rfc3501_examples.yml",
+                               "rfc3501_8_example_1_UNSEEN_response_code")
+  script: parser.parse(response)
+- name: rfc3501_8_example_2_UIDVALIDITY_response_code
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/rfc3501_examples.yml",
+                               "rfc3501_8_example_2_UIDVALIDITY_response_code")
+  script: parser.parse(response)
+- name: rfc3501_8_example_3_FETCH_ENVELOPE
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/rfc3501_examples.yml",
+                               "rfc3501_8_example_3_FETCH_ENVELOPE")
+  script: parser.parse(response)
+- name: rfc3501_8_example_4_FETCH_BODY[HEADER]
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/rfc3501_examples.yml",
+                               "rfc3501_8_example_4_FETCH_BODY[HEADER]")
+  script: parser.parse(response)
+- name: rfc9051_7.2.1_ENABLED_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/enabled_responses.yml",
+                               "rfc9051_7.2.1_ENABLED_example")
+  script: parser.parse(response)
+- name: rfc9051_7.2.2_capability_example
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/capability_responses.yml",
+                               "rfc9051_7.2.2_capability_example")
+  script: parser.parse(response)
+- name: search_response_empty
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/search_responses.yml",
+                               "test_search_response_empty")
+  script: parser.parse(response)
+- name: search_response_multiple_seq_nums_returned
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/search_responses.yml",
+                               "test_search_response_multiple_seq_nums_returned")
+  script: parser.parse(response)
+- name: search_response_single_seq_nums_returned
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/search_responses.yml",
+                               "test_search_response_single_seq_nums_returned")
+  script: parser.parse(response)
+- name: search_response_with_condstore_modseq
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/search_responses.yml",
+                               "test_search_response_with_condstore_modseq")
+  script: parser.parse(response)
+- name: status_response_uidnext_uidvalidity
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/status_responses.yml",
+                               "test_status_response_uidnext_uidvalidity")
+  script: parser.parse(response)
+- name: thread_rfc5256_example1
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/thread_responses.yml",
+                               "thread_rfc5256_example1")
+  script: parser.parse(response)
+- name: thread_rfc5256_example2
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/thread_responses.yml",
+                               "thread_rfc5256_example2")
+  script: parser.parse(response)
+- name: thread_rfc5256_example3
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/thread_responses.yml",
+                               "thread_rfc5256_example3")
+  script: parser.parse(response)
+- name: thread_rfc5256_example4
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/thread_responses.yml",
+                               "thread_rfc5256_example4")
+  script: parser.parse(response)
+- name: thread_rfc5256_example5
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/thread_responses.yml",
+                               "thread_rfc5256_example5")
+  script: parser.parse(response)
+- name: xlist_inbox
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/list_responses.yml",
+                               "test_xlist_inbox")
+  script: parser.parse(response)

--- a/lib/net/imap/response_parser.rb
+++ b/lib/net/imap/response_parser.rb
@@ -36,30 +36,31 @@ module Net
 
       # :stopdoc:
 
-      EXPR_BEG          = :EXPR_BEG
-      EXPR_DATA         = :EXPR_DATA
-      EXPR_TEXT         = :EXPR_TEXT
-      EXPR_RTEXT        = :EXPR_RTEXT
-      EXPR_CTEXT        = :EXPR_CTEXT
+      EXPR_BEG   = :EXPR_BEG     # the default, used in most places
+      EXPR_DATA  = :EXPR_DATA    # envelope, body(structure), namespaces
+      EXPR_TEXT  = :EXPR_TEXT    # text, after 'resp-text-code "]"'
+      EXPR_RTEXT = :EXPR_RTEXT   # resp-text, before "["
+      EXPR_CTEXT = :EXPR_CTEXT   # resp-text-code, after 'atom SP'
 
-      T_SPACE   = :SPACE
-      T_NIL     = :NIL
-      T_NUMBER  = :NUMBER
-      T_ATOM    = :ATOM
-      T_QUOTED  = :QUOTED
-      T_LPAR    = :LPAR
-      T_RPAR    = :RPAR
-      T_BSLASH  = :BSLASH
-      T_STAR    = :STAR
-      T_LBRA    = :LBRA
-      T_RBRA    = :RBRA
-      T_LITERAL = :LITERAL
-      T_PLUS    = :PLUS
-      T_PERCENT = :PERCENT
-      T_CRLF    = :CRLF
-      T_EOF     = :EOF
-      T_TEXT    = :TEXT
+      T_SPACE    = :SPACE        # atom special
+      T_ATOM     = :ATOM         # atom (subset of astring chars)
+      T_NIL      = :NIL          # subset of atom and label
+      T_NUMBER   = :NUMBER       # subset of atom
+      T_LBRA     = :LBRA         # subset of atom
+      T_PLUS     = :PLUS         # subset of atom; tag special
+      T_RBRA     = :RBRA         # atom special; resp_special; valid astring char
+      T_QUOTED   = :QUOTED       # starts/end with atom special
+      T_BSLASH   = :BSLASH       # atom special; quoted special
+      T_LPAR     = :LPAR         # atom special; paren list delimiter
+      T_RPAR     = :RPAR         # atom special; paren list delimiter
+      T_STAR     = :STAR         # atom special; list wildcard
+      T_PERCENT  = :PERCENT      # atom special; list wildcard
+      T_LITERAL  = :LITERAL      # starts with atom special
+      T_CRLF     = :CRLF         # atom special; text special; quoted special
+      T_TEXT     = :TEXT         # any char except CRLF
+      T_EOF      = :EOF          # end of response string
 
+      # the default, used in most places
       BEG_REGEXP = /\G(?:\
 (?# 1:  SPACE   )( +)|\
 (?# 2:  NIL     )(NIL)(?=[\x80-\xff(){ \x00-\x1f\x7f%*"\\\[\]+])|\
@@ -78,6 +79,7 @@ module Net
 (?# 15: CRLF    )(\r\n)|\
 (?# 16: EOF     )(\z))/ni
 
+      # envelope, body(structure), namespaces
       DATA_REGEXP = /\G(?:\
 (?# 1:  SPACE   )( )|\
 (?# 2:  NIL     )(NIL)|\
@@ -87,13 +89,16 @@ module Net
 (?# 6:  LPAR    )(\()|\
 (?# 7:  RPAR    )(\)))/ni
 
+      # text, after 'resp-text-code "]"'
       TEXT_REGEXP = /\G(?:\
 (?# 1:  TEXT    )([^\x00\r\n]*))/ni
 
+      # resp-text, before "["
       RTEXT_REGEXP = /\G(?:\
 (?# 1:  LBRA    )(\[)|\
 (?# 2:  TEXT    )([^\x00\r\n]*))/ni
 
+      # resp-text-code, after 'atom SP'
       CTEXT_REGEXP = /\G(?:\
 (?# 1:  TEXT    )([^\x00\r\n\]]*))/ni
 

--- a/test/net/imap/fixtures/response_parser/acl_responses.yml
+++ b/test/net/imap/fixtures/response_parser/acl_responses.yml
@@ -1,0 +1,16 @@
+---
+:tests:
+  test_acl_response:
+    :comment: |
+      [Bug #8281]
+    :response: "* ACL \"INBOX/share\" \"imshare2copy1366146467@xxxxxxxxxxxxxxxxxx.com\"
+      lrswickxteda\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: ACL
+      data:
+      - !ruby/struct:Net::IMAP::MailboxACLItem
+        user: imshare2copy1366146467@xxxxxxxxxxxxxxxxxx.com
+        rights: lrswickxteda
+        mailbox: INBOX/share
+      raw_data: "* ACL \"INBOX/share\" \"imshare2copy1366146467@xxxxxxxxxxxxxxxxxx.com\"
+        lrswickxteda\r\n"

--- a/test/net/imap/fixtures/response_parser/body_structure_responses.yml
+++ b/test/net/imap/fixtures/response_parser/body_structure_responses.yml
@@ -1,0 +1,525 @@
+---
+:tests:
+
+  test_bodystructure_bug7146_msg_delivery_status:
+    :comment: |
+      [Bug #7146]
+      This was part of a larger response that caused crashes, but this was the
+      minimal test case to demonstrate it
+    :response: "* 4902 FETCH (BODY ((\"MESSAGE\" \"DELIVERY-STATUS\" NIL NIL NIL \"7BIT\"
+      324) \"REPORT\"))\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: FETCH
+      data: !ruby/struct:Net::IMAP::FetchData
+        seqno: 4902
+        attr:
+          BODY: !ruby/struct:Net::IMAP::BodyTypeMultipart
+            media_type: MULTIPART
+            subtype: REPORT
+            parts:
+            - !ruby/struct:Net::IMAP::BodyTypeExtension
+              media_type: MESSAGE
+              subtype: DELIVERY-STATUS
+              params:
+              content_id:
+              description:
+              encoding: 7BIT
+              size: 324
+            param:
+            disposition:
+            language:
+            extension:
+      raw_data: "* 4902 FETCH (BODY ((\"MESSAGE\" \"DELIVERY-STATUS\" NIL NIL NIL \"7BIT\" 324) \"REPORT\"))\r\n"
+
+  test_bodystructure_bug7147_message_rfc822_attachment:
+    :comments: |
+      [Bug #7147]
+    :response: "* 5441 FETCH (BODY (((\"TEXT\" \"PLAIN\" (\"CHARSET\" \"iso-8859-1\")
+      NIL NIL \"QUOTED-PRINTABLE\" 69 1)(\"TEXT\" \"HTML\" (\"CHARSET\" \"iso-8859-1\")
+      NIL NIL \"QUOTED-PRINTABLE\" 455 12) \"ALTERNATIVE\")(\"MESSAGE\" \"RFC822\"
+      (\"NAME\" \"ATT00026.eml\") NIL NIL \"7BIT\" 4079755) \"MIXED\"))\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: FETCH
+      data: !ruby/struct:Net::IMAP::FetchData
+        seqno: 5441
+        attr:
+          BODY: !ruby/struct:Net::IMAP::BodyTypeMultipart
+            media_type: MULTIPART
+            subtype: MIXED
+            parts:
+            - !ruby/struct:Net::IMAP::BodyTypeMultipart
+              media_type: MULTIPART
+              subtype: ALTERNATIVE
+              parts:
+              - !ruby/struct:Net::IMAP::BodyTypeText
+                media_type: TEXT
+                subtype: PLAIN
+                param:
+                  CHARSET: iso-8859-1
+                content_id:
+                description:
+                encoding: QUOTED-PRINTABLE
+                size: 69
+                lines: 1
+                md5:
+                disposition:
+                language:
+                extension:
+              - !ruby/struct:Net::IMAP::BodyTypeText
+                media_type: TEXT
+                subtype: HTML
+                param:
+                  CHARSET: iso-8859-1
+                content_id:
+                description:
+                encoding: QUOTED-PRINTABLE
+                size: 455
+                lines: 12
+                md5:
+                disposition:
+                language:
+                extension:
+              param:
+              disposition:
+              language:
+              extension:
+            - !ruby/struct:Net::IMAP::BodyTypeMessage
+              media_type: MESSAGE
+              subtype: RFC822
+              param:
+                NAME: ATT00026.eml
+              content_id:
+              description:
+              encoding: 7BIT
+              size: 4079755
+              envelope:
+              body:
+              lines:
+              md5:
+              disposition:
+              language:
+              extension:
+            param:
+            disposition:
+            language:
+            extension:
+      raw_data: "* 5441 FETCH (BODY (((\"TEXT\" \"PLAIN\" (\"CHARSET\" \"iso-8859-1\")
+        NIL NIL \"QUOTED-PRINTABLE\" 69 1)(\"TEXT\" \"HTML\" (\"CHARSET\" \"iso-8859-1\")
+        NIL NIL \"QUOTED-PRINTABLE\" 455 12) \"ALTERNATIVE\")(\"MESSAGE\" \"RFC822\"
+        (\"NAME\" \"ATT00026.eml\") NIL NIL \"7BIT\" 4079755) \"MIXED\"))\r\n"
+
+  test_invalid_bodystructure_bug7153_mixed:
+    :comments: |
+      [Bug #7153]
+    :response: "* 1038 FETCH (BODY (\"MIXED\"))\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: FETCH
+      data: !ruby/struct:Net::IMAP::FetchData
+        seqno: 1038
+        attr:
+          BODY: !ruby/struct:Net::IMAP::BodyTypeBasic
+            media_type: MULTIPART
+            subtype: MIXED
+            param:
+            content_id:
+            description:
+            encoding:
+            size:
+            md5:
+            disposition:
+            language:
+            extension:
+      raw_data: "* 1038 FETCH (BODY (\"MIXED\"))\r\n"
+
+  test_bodystructure_bug8167_delivery_status_with_extra_data:
+    :comment: |
+      [Bug #8167]
+    :response: &bug8167 "* 29021 FETCH (RFC822.SIZE 3162 UID 113622 RFC822.HEADER {1155}\r\nReturn-path:
+      <>\r\nEnvelope-to: info@xxxxxxxx.si\r\nDelivery-date: Tue, 26 Mar 2013 12:42:58
+      +0100\r\nReceived: from mail by xxxx.xxxxxxxxxxx.net with spam-scanned (Exim
+      4.76)\r\n\tid 1UKSHI-000Cwl-AR\r\n\tfor info@xxxxxxxx.si; Tue, 26 Mar 2013 12:42:58
+      +0100\r\nX-Spam-Checker-Version: SpamAssassin 3.3.1 (2010-03-16) on xxxx.xxxxxxxxxxx.net\r\nX-Spam-Level:
+      **\r\nX-Spam-Status: No, score=2.1 required=7.0 tests=DKIM_ADSP_NXDOMAIN,RDNS_NONE\r\n\tautolearn=no
+      version=3.3.1\r\nReceived: from [xx.xxx.xxx.xx] (port=56890 helo=xxxxxx.localdomain)\r\n\tby
+      xxxx.xxxxxxxxxxx.net with esmtp (Exim 4.76)\r\n\tid 1UKSHI-000Cwi-9j\r\n\tfor
+      info@xxxxxxxx.si; Tue, 26 Mar 2013 12:42:56 +0100\r\nReceived: by xxxxxx.localdomain
+      (Postfix)\r\n\tid 72725BEA64A; Tue, 26 Mar 2013 12:42:55 +0100 (CET)\r\nDate:
+      Tue, 26 Mar 2013 12:42:55 +0100 (CET)\r\nFrom: MAILER-DAEMON@xxxxxx.localdomain
+      (Mail Delivery System)\r\nSubject: Undelivered Mail Returned to Sender\r\nTo:
+      info@xxxxxxxx.si\r\nAuto-Submitted: auto-replied\r\nMIME-Version: 1.0\r\nContent-Type:
+      multipart/report; report-type=delivery-status;\r\n\tboundary=\"27797BEA649.1364298175/xxxxxx.localdomain\"\r\nMessage-Id:
+      <20130326114255.72725BEA64A@xxxxxx.localdomain>\r\n\r\n BODYSTRUCTURE ((\"text\"
+      \"plain\" (\"charset\" \"us-ascii\") NIL \"Notification\" \"7bit\" 510 14 NIL
+      NIL NIL NIL)(\"message\" \"delivery-status\" NIL NIL \"Delivery report\" \"7bit\"
+      410 NIL NIL NIL NIL)(\"text\" \"rfc822-headers\" (\"charset\" \"us-ascii\")
+      NIL \"Undelivered Message Headers\" \"7bit\" 612 15 NIL NIL NIL NIL) \"report\"
+      (\"report-type\" \"delivery-status\" \"boundary\" \"27797BEA649.1364298175/xxxxxx.localdomain\")
+      NIL NIL NIL))\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: FETCH
+      data: !ruby/struct:Net::IMAP::FetchData
+        seqno: 29021
+        attr:
+          RFC822.SIZE: 3162
+          UID: 113622
+          RFC822.HEADER: "Return-path: <>\r\nEnvelope-to: info@xxxxxxxx.si\r\nDelivery-date:
+            Tue, 26 Mar 2013 12:42:58 +0100\r\nReceived: from mail by xxxx.xxxxxxxxxxx.net
+            with spam-scanned (Exim 4.76)\r\n\tid 1UKSHI-000Cwl-AR\r\n\tfor info@xxxxxxxx.si;
+            Tue, 26 Mar 2013 12:42:58 +0100\r\nX-Spam-Checker-Version: SpamAssassin
+            3.3.1 (2010-03-16) on xxxx.xxxxxxxxxxx.net\r\nX-Spam-Level: **\r\nX-Spam-Status:
+            No, score=2.1 required=7.0 tests=DKIM_ADSP_NXDOMAIN,RDNS_NONE\r\n\tautolearn=no
+            version=3.3.1\r\nReceived: from [xx.xxx.xxx.xx] (port=56890 helo=xxxxxx.localdomain)\r\n\tby
+            xxxx.xxxxxxxxxxx.net with esmtp (Exim 4.76)\r\n\tid 1UKSHI-000Cwi-9j\r\n\tfor
+            info@xxxxxxxx.si; Tue, 26 Mar 2013 12:42:56 +0100\r\nReceived: by xxxxxx.localdomain
+            (Postfix)\r\n\tid 72725BEA64A; Tue, 26 Mar 2013 12:42:55 +0100 (CET)\r\nDate:
+            Tue, 26 Mar 2013 12:42:55 +0100 (CET)\r\nFrom: MAILER-DAEMON@xxxxxx.localdomain
+            (Mail Delivery System)\r\nSubject: Undelivered Mail Returned to Sender\r\nTo:
+            info@xxxxxxxx.si\r\nAuto-Submitted: auto-replied\r\nMIME-Version: 1.0\r\nContent-Type:
+            multipart/report; report-type=delivery-status;\r\n\tboundary=\"27797BEA649.1364298175/xxxxxx.localdomain\"\r\nMessage-Id:
+            <20130326114255.72725BEA64A@xxxxxx.localdomain>\r\n\r\n"
+          BODYSTRUCTURE: !ruby/struct:Net::IMAP::BodyTypeMultipart
+            media_type: MULTIPART
+            subtype: REPORT
+            parts:
+            - !ruby/struct:Net::IMAP::BodyTypeText
+              media_type: TEXT
+              subtype: PLAIN
+              param:
+                CHARSET: us-ascii
+              content_id:
+              description: Notification
+              encoding: 7BIT
+              size: 510
+              lines: 14
+              md5:
+              disposition:
+              language:
+              extension:
+              -
+            - !ruby/struct:Net::IMAP::BodyTypeMessage
+              media_type: MESSAGE
+              subtype: DELIVERY-STATUS
+              param:
+              content_id:
+              description: Delivery report
+              encoding: 7BIT
+              size: 410
+              envelope:
+              body:
+              lines:
+              md5:
+              disposition:
+              language:
+              extension:
+            - !ruby/struct:Net::IMAP::BodyTypeText
+              media_type: TEXT
+              subtype: RFC822-HEADERS
+              param:
+                CHARSET: us-ascii
+              content_id:
+              description: Undelivered Message Headers
+              encoding: 7BIT
+              size: 612
+              lines: 15
+              md5:
+              disposition:
+              language:
+              extension:
+              -
+            param:
+              REPORT-TYPE: delivery-status
+              BOUNDARY: 27797BEA649.1364298175/xxxxxx.localdomain
+            disposition:
+            language:
+            extension:
+            -
+      raw_data: *bug8167
+
+  test_bodystructure_bug11128_ext_mpart_without_lang:
+    :comment: |
+      [Bug #11128]
+    :response: "* 4 FETCH (BODY (((\"text\" \"plain\" (\"charset\" \"utf-8\") NIL
+      NIL \"7bit\" 257 9 NIL NIL NIL NIL)(\"text\" \"html\" (\"charset\" \"utf-8\")
+      NIL NIL \"quoted-printable\" 655 9 NIL NIL NIL NIL) \"alternative\" (\"boundary\"
+      \"001a1137a5047848dd05157ddaa1\") NIL)(\"application\" \"pdf\" (\"name\" \"test.xml\"
+      \"x-apple-part-url\" \"9D00D9A2-98AB-4EFB-85BA-FB255F8BF3D7\") NIL NIL \"base64\"
+      4383638 NIL (\"attachment\" (\"filename\" \"test.xml\")) NIL NIL) \"mixed\"
+      (\"boundary\" \"001a1137a5047848e405157ddaa3\") NIL))\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: FETCH
+      data: !ruby/struct:Net::IMAP::FetchData
+        seqno: 4
+        attr:
+          BODY: !ruby/struct:Net::IMAP::BodyTypeMultipart
+            media_type: MULTIPART
+            subtype: MIXED
+            parts:
+            - !ruby/struct:Net::IMAP::BodyTypeMultipart
+              media_type: MULTIPART
+              subtype: ALTERNATIVE
+              parts:
+              - !ruby/struct:Net::IMAP::BodyTypeText
+                media_type: TEXT
+                subtype: PLAIN
+                param:
+                  CHARSET: utf-8
+                content_id:
+                description:
+                encoding: 7BIT
+                size: 257
+                lines: 9
+                md5:
+                disposition:
+                language:
+                extension:
+                -
+              - !ruby/struct:Net::IMAP::BodyTypeText
+                media_type: TEXT
+                subtype: HTML
+                param:
+                  CHARSET: utf-8
+                content_id:
+                description:
+                encoding: QUOTED-PRINTABLE
+                size: 655
+                lines: 9
+                md5:
+                disposition:
+                language:
+                extension:
+                -
+              param:
+                BOUNDARY: 001a1137a5047848dd05157ddaa1
+              disposition:
+              language:
+              extension:
+            - !ruby/struct:Net::IMAP::BodyTypeBasic
+              media_type: APPLICATION
+              subtype: PDF
+              param:
+                NAME: test.xml
+                X-APPLE-PART-URL: 9D00D9A2-98AB-4EFB-85BA-FB255F8BF3D7
+              content_id:
+              description:
+              encoding: BASE64
+              size: 4383638
+              md5:
+              disposition: !ruby/struct:Net::IMAP::ContentDisposition
+                dsp_type: ATTACHMENT
+                param:
+                  FILENAME: test.xml
+              language:
+              extension:
+              -
+            param:
+              BOUNDARY: 001a1137a5047848e405157ddaa3
+            disposition:
+            language:
+            extension:
+      raw_data: "* 4 FETCH (BODY (((\"text\" \"plain\" (\"charset\" \"utf-8\") NIL
+        NIL \"7bit\" 257 9 NIL NIL NIL NIL)(\"text\" \"html\" (\"charset\" \"utf-8\")
+        NIL NIL \"quoted-printable\" 655 9 NIL NIL NIL NIL) \"alternative\" (\"boundary\"
+        \"001a1137a5047848dd05157ddaa1\") NIL)(\"application\" \"pdf\" (\"name\" \"test.xml\"
+        \"x-apple-part-url\" \"9D00D9A2-98AB-4EFB-85BA-FB255F8BF3D7\") NIL NIL \"base64\"
+        4383638 NIL (\"attachment\" (\"filename\" \"test.xml\")) NIL NIL) \"mixed\"
+        (\"boundary\" \"001a1137a5047848e405157ddaa3\") NIL))\r\n"
+
+  test_bodystructure_mixed_boundary:
+    :response: &mixed "* 2688 FETCH (UID 179161 BODYSTRUCTURE ((\"TEXT\" \"PLAIN\" (\"CHARSET\"
+      \"iso-8859-1\") NIL NIL \"QUOTED-PRINTABLE\" 200 4 NIL NIL NIL)(\"MESSAGE\"
+      \"DELIVERY-STATUS\" NIL NIL NIL \"7BIT\" 318 NIL NIL NIL)(\"MESSAGE\" \"RFC822\"
+      NIL NIL NIL \"7BIT\" 2177 (\"Tue, 11 May 2010 18:28:16 -0400\" \"Re: Welcome
+      letter\" ((\"David\" NIL \"info\" \"xxxxxxxx.si\")) ((\"David\" NIL \"info\"
+      \"xxxxxxxx.si\")) ((\"David\" NIL \"info\" \"xxxxxxxx.si\")) ((\"Doretha\" NIL
+      \"doretha.info\" \"xxxxxxxx.si\")) NIL NIL \"<AC1D15E06EA82F47BDE18E851CC32F330717704E@localdomain>\"
+      \"<AANLkTikKMev1I73L2E7XLjRs67IHrEkb23f7ZPmD4S_9@localdomain>\") (\"MIXED\"
+      (\"BOUNDARY\" \"000e0cd29212e3e06a0486590ae2\") NIL NIL) 37 NIL NIL NIL) \"REPORT\"
+      (\"BOUNDARY\" \"16DuG.4XbaNOvCi.9ggvq.8Ipnyp3\" \"REPORT-TYPE\" \"delivery-status\")
+      NIL NIL))\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: FETCH
+      data: !ruby/struct:Net::IMAP::FetchData
+        seqno: 2688
+        attr:
+          UID: 179161
+          BODYSTRUCTURE: !ruby/struct:Net::IMAP::BodyTypeMultipart
+            media_type: MULTIPART
+            subtype: REPORT
+            parts:
+            - !ruby/struct:Net::IMAP::BodyTypeText
+              media_type: TEXT
+              subtype: PLAIN
+              param:
+                CHARSET: iso-8859-1
+              content_id:
+              description:
+              encoding: QUOTED-PRINTABLE
+              size: 200
+              lines: 4
+              md5:
+              disposition:
+              language:
+              extension:
+            - !ruby/struct:Net::IMAP::BodyTypeMessage
+              media_type: MESSAGE
+              subtype: DELIVERY-STATUS
+              param:
+              content_id:
+              description:
+              encoding: 7BIT
+              size: 318
+              envelope:
+              body:
+              lines:
+              md5:
+              disposition:
+              language:
+              extension:
+            - !ruby/struct:Net::IMAP::BodyTypeMessage
+              media_type: MESSAGE
+              subtype: RFC822
+              param:
+              content_id:
+              description:
+              encoding: 7BIT
+              size: 2177
+              envelope: !ruby/struct:Net::IMAP::Envelope
+                date: Tue, 11 May 2010 18:28:16 -0400
+                subject: 'Re: Welcome letter'
+                from:
+                - !ruby/struct:Net::IMAP::Address
+                  name: David
+                  route:
+                  mailbox: info
+                  host: xxxxxxxx.si
+                sender:
+                - !ruby/struct:Net::IMAP::Address
+                  name: David
+                  route:
+                  mailbox: info
+                  host: xxxxxxxx.si
+                reply_to:
+                - !ruby/struct:Net::IMAP::Address
+                  name: David
+                  route:
+                  mailbox: info
+                  host: xxxxxxxx.si
+                to:
+                - !ruby/struct:Net::IMAP::Address
+                  name: Doretha
+                  route:
+                  mailbox: doretha.info
+                  host: xxxxxxxx.si
+                cc:
+                bcc:
+                in_reply_to: "<AC1D15E06EA82F47BDE18E851CC32F330717704E@localdomain>"
+                message_id: "<AANLkTikKMev1I73L2E7XLjRs67IHrEkb23f7ZPmD4S_9@localdomain>"
+              body: !ruby/struct:Net::IMAP::BodyTypeBasic
+                media_type: MULTIPART
+                subtype: MIXED
+                param:
+                  BOUNDARY: 000e0cd29212e3e06a0486590ae2
+                content_id:
+                description:
+                encoding:
+                size:
+                md5:
+                disposition:
+                language:
+                extension:
+              lines: 37
+              md5:
+              disposition:
+              language:
+              extension:
+            param:
+              BOUNDARY: 16DuG.4XbaNOvCi.9ggvq.8Ipnyp3
+              REPORT-TYPE: delivery-status
+            disposition:
+            language:
+            extension:
+      raw_data: *mixed
+
+  test_invalid_bodystructure_message_sent_as_basic:
+    :comment: |
+      [Bug #6397] [ruby-core:44849]
+    :response: &attachment "* 980 FETCH (UID 2862 BODYSTRUCTURE (((\"TEXT\" \"PLAIN\" (\"CHARSET\"
+      \"iso-8859-1\") NIL NIL \"7BIT\" 416 21 NIL NIL NIL)(\"TEXT\" \"HTML\" (\"CHARSET\"
+      \"iso-8859-1\") NIL NIL \"7BIT\" 1493 32 NIL NIL NIL) \"ALTERNATIVE\" (\"BOUNDARY\"
+      \"Boundary_(ID_IaecgfnXwG5bn3x8lIeGIQ)\") NIL NIL)(\"MESSAGE\" \"RFC822\" (\"NAME\"
+      \"Fw_ ____ _____ ____.eml\") NIL NIL \"7BIT\" 1980088 NIL (\"ATTACHMENT\" (\"FILENAME\"
+      \"Fw_ ____ _____ ____.eml\")) NIL) \"MIXED\" (\"BOUNDARY\" \"Boundary_(ID_eDdLc/j0mBIzIlR191pHjA)\")
+      NIL NIL))\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: FETCH
+      data: !ruby/struct:Net::IMAP::FetchData
+        seqno: 980
+        attr:
+          UID: 2862
+          BODYSTRUCTURE: !ruby/struct:Net::IMAP::BodyTypeMultipart
+            media_type: MULTIPART
+            subtype: MIXED
+            parts:
+            - !ruby/struct:Net::IMAP::BodyTypeMultipart
+              media_type: MULTIPART
+              subtype: ALTERNATIVE
+              parts:
+              - !ruby/struct:Net::IMAP::BodyTypeText
+                media_type: TEXT
+                subtype: PLAIN
+                param:
+                  CHARSET: iso-8859-1
+                content_id:
+                description:
+                encoding: 7BIT
+                size: 416
+                lines: 21
+                md5:
+                disposition:
+                language:
+                extension:
+              - !ruby/struct:Net::IMAP::BodyTypeText
+                media_type: TEXT
+                subtype: HTML
+                param:
+                  CHARSET: iso-8859-1
+                content_id:
+                description:
+                encoding: 7BIT
+                size: 1493
+                lines: 32
+                md5:
+                disposition:
+                language:
+                extension:
+              param:
+                BOUNDARY: Boundary_(ID_IaecgfnXwG5bn3x8lIeGIQ)
+              disposition:
+              language:
+              extension:
+            - !ruby/struct:Net::IMAP::BodyTypeMessage
+              media_type: MESSAGE
+              subtype: RFC822
+              param:
+                NAME: Fw_ ____ _____ ____.eml
+              content_id:
+              description:
+              encoding: 7BIT
+              size: 1980088
+              envelope:
+              body: !ruby/struct:Net::IMAP::BodyTypeAttachment
+                dsp_type: ATTACHMENT
+                _unused_:
+                param:
+                  FILENAME: Fw_ ____ _____ ____.eml
+              lines:
+              md5:
+              disposition:
+              language:
+              extension:
+            param:
+              BOUNDARY: Boundary_(ID_eDdLc/j0mBIzIlR191pHjA)
+            disposition:
+            language:
+            extension:
+      raw_data: *attachment

--- a/test/net/imap/fixtures/response_parser/capability_responses.yml
+++ b/test/net/imap/fixtures/response_parser/capability_responses.yml
@@ -1,7 +1,20 @@
 ---
 :tests:
 
-  test_capability_rfc3501_6.1.1_example_1:
+  # 6.1.1.  CAPABILITY Command
+  #
+  #    Example:    C: abcd CAPABILITY
+  #                S: * CAPABILITY IMAP4rev1 STARTTLS AUTH=GSSAPI
+  #                LOGINDISABLED
+  #                S: abcd OK CAPABILITY completed
+  #                C: efgh STARTTLS
+  #                S: efgh OK STARTLS completed
+  #                <TLS negotiation, further commands are under [TLS] layer>
+  #                C: ijkl CAPABILITY
+  #                S: * CAPABILITY IMAP4rev1 AUTH=GSSAPI AUTH=PLAIN
+  #                S: ijkl OK CAPABILITY completed
+
+  rfc3501_6.1.1_example_1_capability_response:
     :response: "* CAPABILITY IMAP4rev1 STARTTLS AUTH=GSSAPI LOGINDISABLED\r\n"
     :expected: !ruby/struct:Net::IMAP::UntaggedResponse
       name: CAPABILITY
@@ -12,7 +25,7 @@
       - LOGINDISABLED
       raw_data: "* CAPABILITY IMAP4rev1 STARTTLS AUTH=GSSAPI LOGINDISABLED\r\n"
 
-  test_capability_rfc3501_6.1.1_example_2:
+  rfc3501_6.1.1_example_2_capability_response:
     :response: "* CAPABILITY IMAP4rev1 AUTH=GSSAPI AUTH=PLAIN\r\n"
     :expected: !ruby/struct:Net::IMAP::UntaggedResponse
       name: CAPABILITY
@@ -21,6 +34,34 @@
       - AUTH=GSSAPI
       - AUTH=PLAIN
       raw_data: "* CAPABILITY IMAP4rev1 AUTH=GSSAPI AUTH=PLAIN\r\n"
+
+  # 7.2.1.  CAPABILITY Response
+  #
+  #    Example:    S: * CAPABILITY IMAP4rev1 STARTTLS AUTH=GSSAPI XPIG-LATIN
+  rfc3501_7.2.1_CAPABILITY_response_example:
+    :response: "* CAPABILITY IMAP4rev1 STARTTLS AUTH=GSSAPI XPIG-LATIN\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: CAPABILITY
+      data:
+      - IMAP4REV1
+      - STARTTLS
+      - AUTH=GSSAPI
+      - XPIG-LATIN
+      raw_data: "* CAPABILITY IMAP4rev1 STARTTLS AUTH=GSSAPI XPIG-LATIN\r\n"
+
+  # The RFC9051 examples aren't significantly different from RFC3501.
+  # Including only this one, for completeness:
+  rfc9051_7.2.2_capability_example:
+    :response: "* CAPABILITY STARTTLS AUTH=GSSAPI IMAP4rev2 LOGINDISABLED XPIG-LATIN\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: CAPABILITY
+      data:
+      - STARTTLS
+      - AUTH=GSSAPI
+      - IMAP4REV2
+      - LOGINDISABLED
+      - XPIG-LATIN
+      raw_data: "* CAPABILITY STARTTLS AUTH=GSSAPI IMAP4rev2 LOGINDISABLED XPIG-LATIN\r\n"
 
   test_invalid_capability_extra_space_at_end:
     :comment: |
@@ -41,24 +82,3 @@
       - AUTH=PLAIN
       raw_data: "* CAPABILITY st11p00mm-iscream009 1Q49 XAPPLEPUSHSERVICE IMAP4 IMAP4rev1
         SASL-IR AUTH=ATOKEN AUTH=PLAIN \r\n"
-
-  test_capability_response_code_with_valid_atoms:
-    :response: "* OK [CAPABILITY IMAP4rev1 SASL-IR 1234 NIL THIS+THAT + AUTH=PLAIN
-      ID] IMAP4rev1 Hello\r\n"
-    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
-      name: OK
-      data: !ruby/struct:Net::IMAP::ResponseText
-        code: !ruby/struct:Net::IMAP::ResponseCode
-          name: CAPABILITY
-          data:
-          - IMAP4REV1
-          - SASL-IR
-          - '1234'
-          - NIL
-          - THIS+THAT
-          - "+"
-          - AUTH=PLAIN
-          - ID
-        text: IMAP4rev1 Hello
-      raw_data: "* OK [CAPABILITY IMAP4rev1 SASL-IR 1234 NIL THIS+THAT + AUTH=PLAIN
-        ID] IMAP4rev1 Hello\r\n"

--- a/test/net/imap/fixtures/response_parser/capability_responses.yml
+++ b/test/net/imap/fixtures/response_parser/capability_responses.yml
@@ -1,0 +1,64 @@
+---
+:tests:
+
+  test_capability_rfc3501_6.1.1_example_1:
+    :response: "* CAPABILITY IMAP4rev1 STARTTLS AUTH=GSSAPI LOGINDISABLED\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: CAPABILITY
+      data:
+      - IMAP4REV1
+      - STARTTLS
+      - AUTH=GSSAPI
+      - LOGINDISABLED
+      raw_data: "* CAPABILITY IMAP4rev1 STARTTLS AUTH=GSSAPI LOGINDISABLED\r\n"
+
+  test_capability_rfc3501_6.1.1_example_2:
+    :response: "* CAPABILITY IMAP4rev1 AUTH=GSSAPI AUTH=PLAIN\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: CAPABILITY
+      data:
+      - IMAP4REV1
+      - AUTH=GSSAPI
+      - AUTH=PLAIN
+      raw_data: "* CAPABILITY IMAP4rev1 AUTH=GSSAPI AUTH=PLAIN\r\n"
+
+  test_invalid_capability_extra_space_at_end:
+    :comment: |
+      [Bug #8415]
+    :quirky_server: Apple iCloud
+    :response: "* CAPABILITY st11p00mm-iscream009 1Q49 XAPPLEPUSHSERVICE IMAP4 IMAP4rev1
+      SASL-IR AUTH=ATOKEN AUTH=PLAIN \r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: CAPABILITY
+      data:
+      - ST11P00MM-ISCREAM009
+      - 1Q49
+      - XAPPLEPUSHSERVICE
+      - IMAP4
+      - IMAP4REV1
+      - SASL-IR
+      - AUTH=ATOKEN
+      - AUTH=PLAIN
+      raw_data: "* CAPABILITY st11p00mm-iscream009 1Q49 XAPPLEPUSHSERVICE IMAP4 IMAP4rev1
+        SASL-IR AUTH=ATOKEN AUTH=PLAIN \r\n"
+
+  test_capability_response_code_with_valid_atoms:
+    :response: "* OK [CAPABILITY IMAP4rev1 SASL-IR 1234 NIL THIS+THAT + AUTH=PLAIN
+      ID] IMAP4rev1 Hello\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: OK
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: CAPABILITY
+          data:
+          - IMAP4REV1
+          - SASL-IR
+          - '1234'
+          - NIL
+          - THIS+THAT
+          - "+"
+          - AUTH=PLAIN
+          - ID
+        text: IMAP4rev1 Hello
+      raw_data: "* OK [CAPABILITY IMAP4rev1 SASL-IR 1234 NIL THIS+THAT + AUTH=PLAIN
+        ID] IMAP4rev1 Hello\r\n"

--- a/test/net/imap/fixtures/response_parser/continuation_requests.yml
+++ b/test/net/imap/fixtures/response_parser/continuation_requests.yml
@@ -1,0 +1,34 @@
+---
+:tests:
+
+  test_continuation_request_rfc3501_6.2.2_example:
+    :response: "+ YDMGCSqGSIb3EgECAgIBAAD/////6jcyG4GE3KkTzBeBiVHeceP2CWY0SR0fAQAgAAQEBAQ=\r\n"
+    :expected: !ruby/struct:Net::IMAP::ContinuationRequest
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code:
+        text: "YDMGCSqGSIb3EgECAgIBAAD/////6jcyG4GE3KkTzBeBiVHeceP2CWY0SR0fAQAgAAQEBAQ="
+      raw_data: "+ YDMGCSqGSIb3EgECAgIBAAD/////6jcyG4GE3KkTzBeBiVHeceP2CWY0SR0fAQAgAAQEBAQ=\r\n"
+
+  test_continuation_request_rfc3501_6.3.11_example:
+    :response: "+ Ready for literal data\r\n"
+    :expected: !ruby/struct:Net::IMAP::ContinuationRequest
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code:
+        text: "Ready for literal data"
+      raw_data: "+ Ready for literal data\r\n"
+
+  test_continuation_request_rfc3501_7.5_example:
+    :response: "+ Ready for additional command text\r\n"
+    :expected: !ruby/struct:Net::IMAP::ContinuationRequest
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code:
+        text: "Ready for additional command text"
+      raw_data: "+ Ready for additional command text\r\n"
+
+  test_continuation_request_without_response_text:
+    :response: "+\r\n"
+    :expected: !ruby/struct:Net::IMAP::ContinuationRequest
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code:
+        text: ''
+      raw_data: "+\r\n"

--- a/test/net/imap/fixtures/response_parser/continuation_requests.yml
+++ b/test/net/imap/fixtures/response_parser/continuation_requests.yml
@@ -1,15 +1,16 @@
 ---
 :tests:
+  # n.b: The RFC9051 examples would be identical to these RFC3501 examples.
 
-  test_continuation_request_rfc3501_6.2.2_example:
-    :response: "+ YDMGCSqGSIb3EgECAgIBAAD/////6jcyG4GE3KkTzBeBiVHeceP2CWY0SR0fAQAgAAQEBAQ=\r\n"
+  rfc3501_6.2.2_example_continuation_request:
+    :response: "+ YGgGCSqGSIb3EgECAgIAb1kwV6ADAgEFoQMCAQ+iSzBJoAMCAQGiQgRAtHTEuOP2BXb9sBYFR4SJlDZxmg39IxmRBOhXRKdDA0uHTCOT9Bq3OsUTXUlk0CsFLoa8j+gvGDlgHuqzWHPSQg==\r\n"
     :expected: !ruby/struct:Net::IMAP::ContinuationRequest
       data: !ruby/struct:Net::IMAP::ResponseText
         code:
-        text: "YDMGCSqGSIb3EgECAgIBAAD/////6jcyG4GE3KkTzBeBiVHeceP2CWY0SR0fAQAgAAQEBAQ="
-      raw_data: "+ YDMGCSqGSIb3EgECAgIBAAD/////6jcyG4GE3KkTzBeBiVHeceP2CWY0SR0fAQAgAAQEBAQ=\r\n"
+        text: "YGgGCSqGSIb3EgECAgIAb1kwV6ADAgEFoQMCAQ+iSzBJoAMCAQGiQgRAtHTEuOP2BXb9sBYFR4SJlDZxmg39IxmRBOhXRKdDA0uHTCOT9Bq3OsUTXUlk0CsFLoa8j+gvGDlgHuqzWHPSQg=="
+      raw_data: "+ YGgGCSqGSIb3EgECAgIAb1kwV6ADAgEFoQMCAQ+iSzBJoAMCAQGiQgRAtHTEuOP2BXb9sBYFR4SJlDZxmg39IxmRBOhXRKdDA0uHTCOT9Bq3OsUTXUlk0CsFLoa8j+gvGDlgHuqzWHPSQg==\r\n"
 
-  test_continuation_request_rfc3501_6.3.11_example:
+  rfc3501_6.3.11_example_continuation_request:
     :response: "+ Ready for literal data\r\n"
     :expected: !ruby/struct:Net::IMAP::ContinuationRequest
       data: !ruby/struct:Net::IMAP::ResponseText
@@ -17,7 +18,22 @@
         text: "Ready for literal data"
       raw_data: "+ Ready for literal data\r\n"
 
-  test_continuation_request_rfc3501_7.5_example:
+  # 7.5.    Server Responses - Command Continuation Request
+  #
+  #    The command continuation request response is indicated by a "+" token
+  #    instead of a tag.  This form of response indicates that the server is
+  #    ready to accept the continuation of a command from the client.  The
+  #    remainder of this response is a line of text.
+  # ...
+  #    Example:    C: A001 LOGIN {11}
+  #                S: + Ready for additional command text
+  #                C: FRED FOOBAR {7}
+  #                S: + Ready for additional command text
+  #                C: fat man
+  #                S: A001 OK LOGIN completed
+  #                C: A044 BLURDYBLOOP {102856}
+  #                S: A044 BAD No such command as "BLURDYBLOOP"
+  rfc3501_7.5_continuation_request_example:
     :response: "+ Ready for additional command text\r\n"
     :expected: !ruby/struct:Net::IMAP::ContinuationRequest
       data: !ruby/struct:Net::IMAP::ResponseText

--- a/test/net/imap/fixtures/response_parser/enabled_responses.yml
+++ b/test/net/imap/fixtures/response_parser/enabled_responses.yml
@@ -1,0 +1,11 @@
+---
+:tests:
+
+  rfc9051_7.2.1_ENABLED_example:
+    :response: "* ENABLED CONDSTORE QRESYNC\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: ENABLED
+      data:
+      - CONDSTORE
+      - QRESYNC
+      :raw_data: "* ENABLED CONDSTORE QRESYNC\r\n"

--- a/test/net/imap/fixtures/response_parser/expunge_responses.yml
+++ b/test/net/imap/fixtures/response_parser/expunge_responses.yml
@@ -1,0 +1,12 @@
+---
+:tests:
+
+  # 7.4.1.  EXPUNGE Response
+  #
+  #    Example:    S: * 44 EXPUNGE
+  rfc3501_7.4.1_EXPUNGE_response_example:
+    :response: "* 44 EXPUNGE\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: EXPUNGE
+      data: 44
+      raw_data: "* 44 EXPUNGE\r\n"

--- a/test/net/imap/fixtures/response_parser/fetch_responses.yml
+++ b/test/net/imap/fixtures/response_parser/fetch_responses.yml
@@ -1,0 +1,76 @@
+---
+:tests:
+  test_fetch_msg_att_uid:
+    :response: "* 1 FETCH (UID 92285)\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: FETCH
+      data: !ruby/struct:Net::IMAP::FetchData
+        seqno: 1
+        attr:
+          UID: 92285
+      raw_data: "* 1 FETCH (UID 92285)\r\n"
+
+  test_fetch_msg_att_flags_and_uid:
+    :response: "* 1 FETCH (FLAGS (\\Seen $MDNSent \\Flagged Custom) UID 5)\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: FETCH
+      data: !ruby/struct:Net::IMAP::FetchData
+        seqno: 1
+        attr:
+          FLAGS:
+          - :Seen
+          - "$MDNSent"
+          - :Flagged
+          - Custom
+          UID: 5
+      raw_data: "* 1 FETCH (FLAGS (\\Seen $MDNSent \\Flagged Custom) UID 5)\r\n"
+
+  test_invalid_fetch_msg_att_extra_space:
+    :response: "* 1 FETCH (UID 92285 )\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: FETCH
+      data: !ruby/struct:Net::IMAP::FetchData
+        seqno: 1
+        attr:
+          UID: 92285
+      raw_data: "* 1 FETCH (UID 92285 )\r\n"
+
+  test_fetch_msg_att_modseq:
+    :comments: |
+      [Bug #10119]
+    :response: "* 1 FETCH (FLAGS (Seen) MODSEQ (12345) UID 5)\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: FETCH
+      data: !ruby/struct:Net::IMAP::FetchData
+        seqno: 1
+        attr:
+          FLAGS:
+          - Seen
+          MODSEQ: 12345
+          UID: 5
+      raw_data: "* 1 FETCH (FLAGS (Seen) MODSEQ (12345) UID 5)\r\n"
+
+  test_fetch_msg_att_rfc822:
+    :response: "* 123 FETCH (RFC822 {5}\r\nfoo\r\n)\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: FETCH
+      data: !ruby/struct:Net::IMAP::FetchData
+        seqno: 123
+        attr:
+          RFC822: "foo\r\n"
+      raw_data: "* 123 FETCH (RFC822 {5}\r\nfoo\r\n)\r\n"
+
+  test_invalid_fetch_msg_att_rfc822_with_brackets:
+    :response: "* 123 FETCH (RFC822[] {5}\r\nfoo\r\n)\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: FETCH
+      data: !ruby/struct:Net::IMAP::FetchData
+        seqno: 123
+        attr:
+          RFC822: "foo\r\n"
+      raw_data: "* 123 FETCH (RFC822[] {5}\r\nfoo\r\n)\r\n"
+
+  test_invalid_fetch_msg_att_unknown_fails:
+    :test_type: :assert_parse_failure
+    :response: "* 123 FETCH (UNKNOWN 92285)\r\n"
+    :message: !ruby/regexp / for \{123\}/

--- a/test/net/imap/fixtures/response_parser/fetch_responses.yml
+++ b/test/net/imap/fixtures/response_parser/fetch_responses.yml
@@ -1,5 +1,20 @@
 ---
 :tests:
+  # 7.4.2.  FETCH Response
+  #
+  #    Example:    S: * 23 FETCH (FLAGS (\Seen) RFC822.SIZE 44827)
+  rfc3501_7.4.2_FETCH_response_example:
+    :response: "* 23 FETCH (FLAGS (\\Seen) RFC822.SIZE 44827)\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: FETCH
+      data: !ruby/struct:Net::IMAP::FetchData
+        seqno: 23
+        attr:
+          FLAGS:
+          - :Seen
+          RFC822.SIZE: 44827
+      raw_data: "* 23 FETCH (FLAGS (\\Seen) RFC822.SIZE 44827)\r\n"
+
   test_fetch_msg_att_uid:
     :response: "* 1 FETCH (UID 92285)\r\n"
     :expected: !ruby/struct:Net::IMAP::UntaggedResponse

--- a/test/net/imap/fixtures/response_parser/flags_responses.yml
+++ b/test/net/imap/fixtures/response_parser/flags_responses.yml
@@ -1,0 +1,16 @@
+---
+:tests:
+  # 7.2.6.  FLAGS Response
+  #
+  #    Example:    S: * FLAGS (\Answered \Flagged \Deleted \Seen \Draft)
+  rfc3501_7.2.6_FLAGS_response_example:
+    :response: "* FLAGS (\\Answered \\Flagged \\Deleted \\Seen \\Draft)\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: FLAGS
+      data:
+      - :Answered
+      - :Flagged
+      - :Deleted
+      - :Seen
+      - :Draft
+      raw_data: "* FLAGS (\\Answered \\Flagged \\Deleted \\Seen \\Draft)\r\n"

--- a/test/net/imap/fixtures/response_parser/id_responses.yml
+++ b/test/net/imap/fixtures/response_parser/id_responses.yml
@@ -1,0 +1,30 @@
+---
+:tests:
+  test_id_rfc2971_example_3.1_nil:
+    :response: "* ID NIL\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: ID
+      data:
+      raw_data: "* ID NIL\r\n"
+  test_id_rfc2971_example_3.2_cyrus:
+    :response: "* ID (\"name\" \"Cyrus\" \"version\" \"1.5\" \"os\" \"sunos\" \"os-version\" \"5.5\" \"support-url\" \"mailto:cyrus-bugs+@andrew.cmu.edu\")\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: ID
+      data:
+        name: Cyrus
+        version: "1.5"
+        os: sunos
+        os-version: "5.5"
+        support-url: "mailto:cyrus-bugs+@andrew.cmu.edu"
+      raw_data: "* ID (\"name\" \"Cyrus\" \"version\" \"1.5\" \"os\" \"sunos\" \"os-version\" \"5.5\" \"support-url\" \"mailto:cyrus-bugs+@andrew.cmu.edu\")\r\n"
+  test_id_gmail:
+    :response: "* ID (\"name\" \"GImap\" \"vendor\" \"Google, Inc.\" \"support-url\"
+      NIL)\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: ID
+      data:
+        name: GImap
+        vendor: Google, Inc.
+        support-url:
+      raw_data: "* ID (\"name\" \"GImap\" \"vendor\" \"Google, Inc.\" \"support-url\"
+        NIL)\r\n"

--- a/test/net/imap/fixtures/response_parser/list_responses.yml
+++ b/test/net/imap/fixtures/response_parser/list_responses.yml
@@ -1,0 +1,27 @@
+---
+:tests:
+
+  test_list_with_various_flag_types_and_capitalizations:
+    :response: "* LIST (\\foo bAR $Etc \\baz) \".\" \"INBOX\"\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: LIST
+      data: !ruby/struct:Net::IMAP::MailboxList
+        attr:
+        - :Foo
+        - bAR
+        - $Etc
+        - :Baz
+        delim: "."
+        name: INBOX
+      raw_data: "* LIST (\\foo bAR $Etc \\baz) \".\" \"INBOX\"\r\n"
+
+  test_xlist_inbox:
+    :response: "* XLIST (\\Inbox) \".\" \"INBOX\"\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: XLIST
+      data: !ruby/struct:Net::IMAP::MailboxList
+        attr:
+        - :Inbox
+        delim: "."
+        name: INBOX
+      raw_data: "* XLIST (\\Inbox) \".\" \"INBOX\"\r\n"

--- a/test/net/imap/fixtures/response_parser/list_responses.yml
+++ b/test/net/imap/fixtures/response_parser/list_responses.yml
@@ -1,6 +1,39 @@
 ---
 :tests:
 
+  # 7.2.    Server Responses - Server and Mailbox Status
+  #
+  #    These responses are always untagged.  This is how server and mailbox
+  #    status data are transmitted from the server to the client.  Many of
+  #    these responses typically result from a command with the same name.
+
+  # 7.2.2.  LIST Response
+  #
+  #    Example:    S: * LIST (\Noselect) "/" ~/Mail/foo
+  rfc3501_7.2.2_LIST_response_example:
+    :response: "* LIST (\\Noselect) \"/\" ~/Mail/foo\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: LIST
+      data: !ruby/struct:Net::IMAP::MailboxList
+        attr:
+        - :Noselect
+        delim: "/"
+        name: "~/Mail/foo"
+      raw_data: "* LIST (\\Noselect) \"/\" ~/Mail/foo\r\n"
+
+  # 7.2.3.  LSUB Response
+  #
+  #    Example:    S: * LSUB () "." #news.comp.mail.misc
+  rfc3501_7.2.3_LSUB_response_example:
+    :response: "* LSUB () \".\" #news.comp.mail.misc\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: LSUB
+      data: !ruby/struct:Net::IMAP::MailboxList
+        attr: []
+        delim: "."
+        name: "#news.comp.mail.misc"
+      raw_data: "* LSUB () \".\" #news.comp.mail.misc\r\n"
+
   test_list_with_various_flag_types_and_capitalizations:
     :response: "* LIST (\\foo bAR $Etc \\baz) \".\" \"INBOX\"\r\n"
     :expected: !ruby/struct:Net::IMAP::UntaggedResponse

--- a/test/net/imap/fixtures/response_parser/mailbox_size_responses.yml
+++ b/test/net/imap/fixtures/response_parser/mailbox_size_responses.yml
@@ -1,0 +1,28 @@
+---
+:tests:
+  # 7.3.    Server Responses - Mailbox Size
+  #
+  #    These responses are always untagged.  This is how changes in the size
+  #    of the mailbox are transmitted from the server to the client.
+  #    Immediately following the "*" token is a number that represents a
+  #    message count.
+
+  # 7.3.1.  EXISTS Response
+  #
+  #    Example:    S: * 23 EXISTS
+  rfc3501_7.3.1_EXISTS_response_example:
+    :response: "* 23 EXISTS\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: EXISTS
+      data: 23
+      raw_data: "* 23 EXISTS\r\n"
+
+  # 7.3.2.  RECENT Response
+  #
+  #    Example:    S: * 5 RECENT
+  rfc3501_7.3.2_RECENT_response_example:
+    :response: "* 5 RECENT\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: RECENT
+      data: 5
+      raw_data: "* 5 RECENT\r\n"

--- a/test/net/imap/fixtures/response_parser/namespace_responses.yml
+++ b/test/net/imap/fixtures/response_parser/namespace_responses.yml
@@ -1,0 +1,177 @@
+---
+:tests:
+
+  # The same examples are used by RFC9051 §6.3.10
+  NAMESPACE_rfc2342_example_5.1:
+    :response: &rfc2342_ex5_1 "* NAMESPACE ((\"\" \"/\")) NIL NIL\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: NAMESPACE
+      data: !ruby/struct:Net::IMAP::Namespaces
+        personal:
+        - !ruby/struct:Net::IMAP::Namespace
+          prefix: ''
+          delim: "/"
+          extensions: {}
+        other: []
+        shared: []
+      raw_data: *rfc2342_ex5_1
+
+  NAMESPACE_rfc2342_example_5.2:
+    :response: &rfc2342_ex5_2 "* NAMESPACE NIL NIL ((\"\" \".\"))\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: NAMESPACE
+      data: !ruby/struct:Net::IMAP::Namespaces
+        personal: []
+        other: []
+        shared:
+        - !ruby/struct:Net::IMAP::Namespace
+          prefix: ''
+          delim: "."
+          extensions: {}
+      raw_data: *rfc2342_ex5_2
+
+  NAMESPACE_rfc2342_example_5.3:
+    :response: &rfc2342_ex5_3 "* NAMESPACE ((\"\" \"/\")) NIL ((\"Public Folders/\" \"/\"))\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: NAMESPACE
+      data: !ruby/struct:Net::IMAP::Namespaces
+        personal:
+        - !ruby/struct:Net::IMAP::Namespace
+          prefix: ''
+          delim: "/"
+          extensions: {}
+        other: []
+        shared:
+        - !ruby/struct:Net::IMAP::Namespace
+          prefix: Public Folders/
+          delim: "/"
+          extensions: {}
+      raw_data: *rfc2342_ex5_3
+
+  NAMESPACE_rfc2342_example_5.4:
+    # WARNING: this example is wrong and will be fixed soon...
+    :response: &rfc2342_ex5_4 "* NAMESPACE ((\"\" \"/\")) ((\"~\" \"/\")) ((\"#shared/\" \"/\") (\"#public/\"
+      \"/\") (\"#ftp/\" \"/\") (\"#news.\" \".\"))\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: NAMESPACE
+      data: !ruby/struct:Net::IMAP::Namespaces
+        personal:
+        - !ruby/struct:Net::IMAP::Namespace
+          prefix: ''
+          delim: "/"
+          extensions: {}
+        other:
+        - !ruby/struct:Net::IMAP::Namespace
+          prefix: "~"
+          delim: "/"
+          extensions: {}
+        shared:
+        - !ruby/struct:Net::IMAP::Namespace
+          prefix: "#shared/"
+          delim: "/"
+          extensions: {}
+        - !ruby/struct:Net::IMAP::Namespace
+          prefix: "#public/"
+          delim: "/"
+          extensions: {}
+        - !ruby/struct:Net::IMAP::Namespace
+          prefix: "#ftp/"
+          delim: "/"
+          extensions: {}
+        - !ruby/struct:Net::IMAP::Namespace
+          prefix: "#news."
+          delim: "."
+          extensions: {}
+      raw_data: *rfc2342_ex5_4
+
+  NAMESPACE_rfc2342_example_5.5:
+    # FYI: it looks like both RFCs contain an extra SP char in this example
+    :response: &rfc2342_ex5_5 "* NAMESPACE ((\"INBOX.\" \".\")) NIL NIL\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: NAMESPACE
+      data: !ruby/struct:Net::IMAP::Namespaces
+        personal:
+        - !ruby/struct:Net::IMAP::Namespace
+          prefix: INBOX.
+          delim: "."
+          extensions: {}
+        other: []
+        shared: []
+      raw_data: *rfc2342_ex5_5
+
+  NAMESPACE_rfc2342_example_5.6:
+    :response: &rfc2342_ex5_6 "* NAMESPACE ((\"\" \"/\") (\"#mh/\" \"/\" \"X-PARAM\" (\"FLAG1\" \"FLAG2\")))
+      NIL NIL\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: NAMESPACE
+      data: !ruby/struct:Net::IMAP::Namespaces
+        personal:
+        - !ruby/struct:Net::IMAP::Namespace
+          prefix: ''
+          delim: "/"
+          extensions: {}
+        - !ruby/struct:Net::IMAP::Namespace
+          prefix: "#mh/"
+          delim: "/"
+          extensions:
+            X-PARAM:
+            - FLAG1
+            - FLAG2
+        other: []
+        shared: []
+      raw_data: *rfc2342_ex5_6
+
+  NAMESPACE_rfc2342_example_5.7:
+    :response: &rfc2342_ex5_7 "* NAMESPACE ((\"\" \"/\")) ((\"Other Users/\" \"/\")) NIL\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: NAMESPACE
+      data: !ruby/struct:Net::IMAP::Namespaces
+        personal:
+        - !ruby/struct:Net::IMAP::Namespace
+          prefix: ''
+          delim: "/"
+          extensions: {}
+        other:
+        - !ruby/struct:Net::IMAP::Namespace
+          prefix: Other Users/
+          delim: "/"
+          extensions: {}
+        shared: []
+      raw_data: *rfc2342_ex5_7
+
+  NAMESPACE_rfc9051_6.3.10_example_8:
+    :response: &rfc9051_6_3_10_ex8 "* NAMESPACE ((\"\" \"/\")) ((\"#Users/\" \"/\")) NIL\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: NAMESPACE
+      data: !ruby/struct:Net::IMAP::Namespaces
+        personal:
+        - !ruby/struct:Net::IMAP::Namespace
+          prefix: ''
+          delim: "/"
+          extensions: {}
+        other:
+        - !ruby/struct:Net::IMAP::Namespace
+          prefix: "#Users/"
+          delim: "/"
+          extensions: {}
+        shared: []
+      raw_data: *rfc9051_6_3_10_ex8
+      raw_data: "* NAMESPACE ((\"\" \"/\")) ((\"#Users/\" \"/\")) NIL\r\n"
+
+  NAMESPACE_rfc2342_example_5.9:
+    :response: &rfc2342_ex5_9 "* NAMESPACE ((\"\" \"/\")) ((\"~\" \"/\")) NIL\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: NAMESPACE
+      data: !ruby/struct:Net::IMAP::Namespaces
+        personal:
+        - !ruby/struct:Net::IMAP::Namespace
+          prefix: ''
+          delim: "/"
+          extensions: {}
+        other:
+        - !ruby/struct:Net::IMAP::Namespace
+          prefix: "~"
+          delim: "/"
+          extensions: {}
+        shared: []
+      raw_data: "* NAMESPACE ((\"\" \"/\")) ((\"~\" \"/\")) NIL\r\n"

--- a/test/net/imap/fixtures/response_parser/quirky_behaviors.yml
+++ b/test/net/imap/fixtures/response_parser/quirky_behaviors.yml
@@ -1,0 +1,9 @@
+---
+:tests:
+  test_invalid_noop_response_is_ignored:
+    :comment: |
+      This should probably use UntaggedResponse, perhaps with an
+      UnparsedResponseData object for its #data.
+    :response: "* NOOP\r\n"
+    :expected: !ruby/struct:Net::IMAP::IgnoredResponse
+      raw_data: "* NOOP\r\n"

--- a/test/net/imap/fixtures/response_parser/resp_code_examples.yml
+++ b/test/net/imap/fixtures/response_parser/resp_code_examples.yml
@@ -1,0 +1,404 @@
+---
+:tests:
+
+  test_resp_code_CAPABILITY_rfc9051_6.2.2_example:
+    :response: "* OK [CAPABILITY IMAP4rev2 STARTTLS AUTH=GSSAPI] Capabilities\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: OK
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: CAPABILITY
+          data:
+          - IMAP4REV2
+          - STARTTLS
+          - AUTH=GSSAPI
+        text: Capabilities
+      raw_data: "* OK [CAPABILITY IMAP4rev2 STARTTLS AUTH=GSSAPI] Capabilities\r\n"
+
+  test_resp_code_UNSEEN_rfc3501_6.3.1_example:
+    :response: "* OK [UNSEEN 12] Message 12 is first unseen\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: OK
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: UNSEEN
+          data: 12
+        text: Message 12 is first unseen
+      raw_data: "* OK [UNSEEN 12] Message 12 is first unseen\r\n"
+
+  test_resp_code_UIDVALIDITY_rfc3501_6.3.1_example:
+    :response: "* OK [UIDVALIDITY 3857529045] UIDs valid\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: OK
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: UIDVALIDITY
+          data: 3857529045
+        text: UIDs valid
+      raw_data: "* OK [UIDVALIDITY 3857529045] UIDs valid\r\n"
+
+  test_resp_code_UIDNEXT_rfc3501_6.3.1_example:
+    :response: "* OK [UIDNEXT 4392] Predicted next UID\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: OK
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: UIDNEXT
+          data: 4392
+        text: Predicted next UID
+      raw_data: "* OK [UIDNEXT 4392] Predicted next UID\r\n"
+
+  test_resp_code_PERMANENTFLAGS_rfc3501_6.3.1_example:
+    :response: "* OK [PERMANENTFLAGS (\\Deleted \\Seen \\*)] Limited\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: OK
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: PERMANENTFLAGS
+          data:
+          - :Deleted
+          - :Seen
+          - :*
+        text: Limited
+      raw_data: "* OK [PERMANENTFLAGS (\\Deleted \\Seen \\*)] Limited\r\n"
+
+  # demonstrates when PERMANENTFLAGS is empty
+  test_resp_code_READ-WRITE_rfc3501_6.3.1_example:
+    :response: "A142 OK [READ-WRITE] SELECT completed\r\n"
+    :expected: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: A142
+      name: OK
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: READ-WRITE
+          data:
+        text: SELECT completed
+      raw_data: "A142 OK [READ-WRITE] SELECT completed\r\n"
+
+  test_resp_code_PERMANENTFLAGS_rfc3501_6.3.2_example:
+    :response: "* OK [PERMANENTFLAGS ()] No permanent flags permitted\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: OK
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: PERMANENTFLAGS
+          data: []
+        text: No permanent flags permitted
+      raw_data: "* OK [PERMANENTFLAGS ()] No permanent flags permitted\r\n"
+
+  test_resp_code_READ-ONLY_rfc3501_6.3.2_example:
+    :response: "A932 OK [READ-ONLY] EXAMINE completed\r\n"
+    :expected: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: A932
+      name: OK
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: READ-ONLY
+          data:
+        text: EXAMINE completed
+      raw_data: "A932 OK [READ-ONLY] EXAMINE completed\r\n"
+
+  # The example in the RFC doesn't follow the formal syntax!
+  # Errata submitted: https://www.rfc-editor.org/errata/eid7323 :)
+  #
+  # test_resp_code_BADCHARSET_rfc9051_6.4.4.4_example:
+  #   :response: "B283 NO [BADCHARSET UTF-8] KOI8-R is not supported\r\n"
+  test_resp_code_BADCHARSET_rfc9051_6.4.4.4_example_modified:
+    :response: "B283 NO [BADCHARSET (UTF-8)] KOI8-R is not supported\r\n"
+    :expected: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: B283
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: BADCHARSET
+          data:
+          - UTF-8
+        text: KOI8-R is not supported
+      raw_data: "B283 NO [BADCHARSET (UTF-8)] KOI8-R is not supported\r\n"
+
+  test_resp_code_BADCHARSET_with_astrings:
+    :response: "t BAD [BADCHARSET (US-ASCII \"[astring with brackets]\")] unsupported
+      charset foo.\r\n"
+    :expected: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: t
+      name: BAD
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: BADCHARSET
+          data:
+          - US-ASCII
+          - "[astring with brackets]"
+        text: unsupported charset foo.
+      raw_data: "t BAD [BADCHARSET (US-ASCII \"[astring with brackets]\")] unsupported
+        charset foo.\r\n"
+
+  test_resp_code_ALREADYEXISTS_rfc9051_7.1_example:
+    :response: "o356 NO [ALREADYEXISTS] Mailbox \"that\" already exists\r\n"
+    :expected: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: o356
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: ALREADYEXISTS
+          data:
+        text: Mailbox "that" already exists
+      raw_data: "o356 NO [ALREADYEXISTS] Mailbox \"that\" already exists\r\n"
+
+  test_resp_code_AUTHENTICATIONFAILED_rfc9051_7.1_example:
+    :response: "b NO [AUTHENTICATIONFAILED] Authentication failed\r\n"
+    :expected: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: b
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: AUTHENTICATIONFAILED
+          data:
+        text: Authentication failed
+      raw_data: "b NO [AUTHENTICATIONFAILED] Authentication failed\r\n"
+
+  test_resp_code_AUTHORIZATIONFAILED_rfc9051_7.1_example_1:
+    :response: "c1 NO [AUTHORIZATIONFAILED] No such authorization-ID\r\n"
+    :expected: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: c1
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: AUTHORIZATIONFAILED
+          data:
+        text: No such authorization-ID
+      raw_data: "c1 NO [AUTHORIZATIONFAILED] No such authorization-ID\r\n"
+
+  test_resp_code_AUTHORIZATIONFAILED_rfc9051_7.1_example_2:
+    :response: "c2 NO [AUTHORIZATIONFAILED] Authenticator is not an admin\r\n"
+    :expected: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: c2
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: AUTHORIZATIONFAILED
+          data:
+        text: Authenticator is not an admin
+      raw_data: "c2 NO [AUTHORIZATIONFAILED] Authenticator is not an admin\r\n"
+
+  test_resp_code_CANNOT_rfc9051_7.1_example:
+    :response: "l NO [CANNOT] Adjacent slashes are not supported\r\n"
+    :expected: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: l
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: CANNOT
+          data:
+        text: Adjacent slashes are not supported
+      raw_data: "l NO [CANNOT] Adjacent slashes are not supported\r\n"
+
+  test_resp_code_CLIENTBUG_rfc9051_7.1_example:
+    :response: "k2 OK [CLIENTBUG] Done\r\n"
+    :expected: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: k2
+      name: OK
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: CLIENTBUG
+          data:
+        text: Done
+      raw_data: "k2 OK [CLIENTBUG] Done\r\n"
+
+  test_resp_code_CONTACTADMIN_rfc9051_7.1_example:
+    :response: "e NO [CONTACTADMIN]\r\n"
+    :expected: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: e
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: CONTACTADMIN
+          data:
+        text: ''
+      raw_data: "e NO [CONTACTADMIN]\r\n"
+
+  test_resp_code_CORRUPTION_rfc9051_7.1_example:
+    :response: "i NO [CORRUPTION] Cannot open mailbox\r\n"
+    :expected: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: i
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: CORRUPTION
+          data:
+        text: Cannot open mailbox
+      raw_data: "i NO [CORRUPTION] Cannot open mailbox\r\n"
+
+  test_resp_code_EXPIRED_rfc9051_7.1_example:
+    :response: "d NO [EXPIRED] That password isn't valid any more\r\n"
+    :expected: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: d
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: EXPIRED
+          data:
+        text: That password isn't valid any more
+      raw_data: "d NO [EXPIRED] That password isn't valid any more\r\n"
+
+  test_resp_code_EXPUNGEISSUED_rfc9051_7.1_example:
+    :response: "h OK [EXPUNGEISSUED] Search completed\r\n"
+    :expected: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: h
+      name: OK
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: EXPUNGEISSUED
+          data:
+        text: Search completed
+      raw_data: "h OK [EXPUNGEISSUED] Search completed\r\n"
+
+  test_resp_code_HASCHILDREN_rfc9051_7.1_example:
+    :response: "o356 NO [HASCHILDREN] Mailbox \"Notes\" has children\r\n"
+    :expected: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: o356
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: HASCHILDREN
+          data:
+        text: Mailbox "Notes" has children
+      raw_data: "o356 NO [HASCHILDREN] Mailbox \"Notes\" has children\r\n"
+
+  test_resp_code_INUSE_rfc9051_7.1_example:
+    :response: "g NO [INUSE] Mailbox in use\r\n"
+    :expected: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: g
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: INUSE
+          data:
+        text: Mailbox in use
+      raw_data: "g NO [INUSE] Mailbox in use\r\n"
+
+  test_resp_code_LIMIT_rfc9051_7.1_example:
+    :response: "m NO [LIMIT] At most 32 flags in one mailbox supported\r\n"
+    :expected: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: m
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: LIMIT
+          data:
+        text: At most 32 flags in one mailbox supported
+      raw_data: "m NO [LIMIT] At most 32 flags in one mailbox supported\r\n"
+
+  test_resp_code_NONEXISTENT_rfc9051_7.1_example:
+    :response: "p NO [NONEXISTENT] No such mailbox\r\n"
+    :expected: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: p
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: NONEXISTENT
+          data:
+        text: No such mailbox
+      raw_data: "p NO [NONEXISTENT] No such mailbox\r\n"
+
+  test_resp_code_NOPERM_rfc9051_7.1_example:
+    :response: "f NO [NOPERM] Access denied\r\n"
+    :expected: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: f
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: NOPERM
+          data:
+        text: Access denied
+      raw_data: "f NO [NOPERM] Access denied\r\n"
+
+  test_resp_code_OVERQUOTA_rfc9051_7.1_example_1:
+    :response: "n1 NO [OVERQUOTA] Sorry\r\n"
+    :expected: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: n1
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: OVERQUOTA
+          data:
+        text: Sorry
+      raw_data: "n1 NO [OVERQUOTA] Sorry\r\n"
+
+  test_resp_code_OVERQUOTA_rfc9051_7.1_example_2:
+    :response: "n2 OK [OVERQUOTA] You are now over your soft quota\r\n"
+    :expected: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: n2
+      name: OK
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: OVERQUOTA
+          data:
+        text: You are now over your soft quota
+      raw_data: "n2 OK [OVERQUOTA] You are now over your soft quota\r\n"
+
+  test_resp_code_PRIVACYREQUIRED_rfc9051_7.1_example:
+    :response: "d NO [PRIVACYREQUIRED] Connection offers no privacy\r\n"
+    :expected: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: d
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: PRIVACYREQUIRED
+          data:
+        text: Connection offers no privacy
+      raw_data: "d NO [PRIVACYREQUIRED] Connection offers no privacy\r\n"
+
+  test_resp_code_SERVERBUG_rfc9051_7.1_example:
+    :response: "j NO [SERVERBUG] This should not happen\r\n"
+    :expected: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: j
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: SERVERBUG
+          data:
+        text: This should not happen
+      raw_data: "j NO [SERVERBUG] This should not happen\r\n"
+
+  test_resp_code_UNAVAILABLE_rfc9051_7.1_example:
+    :response: "a NO [UNAVAILABLE] User's backend down for maintenance\r\n"
+    :expected: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: a
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: UNAVAILABLE
+          data:
+        text: User's backend down for maintenance
+      raw_data: "a NO [UNAVAILABLE] User's backend down for maintenance\r\n"
+
+  test_resp_code_CAPABILITY_with_valid_atoms:
+    :response: "* OK [CAPABILITY IMAP4rev1 SASL-IR 1234 NIL THIS+THAT + AUTH=PLAIN ID] IMAP4rev1 Hello\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: OK
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: CAPABILITY
+          data:
+          - IMAP4REV1
+          - SASL-IR
+          - '1234'
+          - NIL
+          - THIS+THAT
+          - "+"
+          - AUTH=PLAIN
+          - ID
+        text: IMAP4rev1 Hello
+      raw_data: "* OK [CAPABILITY IMAP4rev1 SASL-IR 1234 NIL THIS+THAT + AUTH=PLAIN
+        ID] IMAP4rev1 Hello\r\n"
+
+  test_resp_code_CLOSED:
+    :response: "* OK [CLOSED] Previous mailbox closed.\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: OK
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: CLOSED
+          data:
+        text: Previous mailbox closed.
+      raw_data: "* OK [CLOSED] Previous mailbox closed.\r\n"

--- a/test/net/imap/fixtures/response_parser/resp_cond_examples.yml
+++ b/test/net/imap/fixtures/response_parser/resp_cond_examples.yml
@@ -1,0 +1,119 @@
+---
+:tests:
+  # The RFC9051 examples aren't significantly different from RFC3501.
+
+  # 7.1.    Server Responses - Status Responses
+  #
+  #    Status responses are OK, NO, BAD, PREAUTH and BYE.  OK, NO, and BAD
+  #    can be tagged or untagged.  PREAUTH and BYE are always untagged.
+
+  # 7.1.1.  OK Response
+  #
+  # Example:    S: * OK IMAP4rev1 server ready
+  #             C: A001 LOGIN fred blurdybloop
+  #             S: * OK [ALERT] System shutdown in 10 minutes
+  #             S: A001 OK LOGIN Completed
+
+  rfc3501_7.1.1_OK_response_example_1:
+    :response: "* OK IMAP4rev1 server ready\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: OK
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code:
+        text: "IMAP4rev1 server ready"
+      raw_data: "* OK IMAP4rev1 server ready\r\n"
+
+  rfc3501_7.1.1_OK_response_example_2:
+    :response: "* OK [ALERT] System shutdown in 10 minutes\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: OK
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: ALERT
+          data:
+        text: "System shutdown in 10 minutes"
+      raw_data: "* OK [ALERT] System shutdown in 10 minutes\r\n"
+
+  rfc3501_7.1.1_OK_response_example_3:
+    :response: "A001 OK LOGIN Completed\r\n"
+    :expected: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: A001
+      name: OK
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code:
+        text: "LOGIN Completed"
+      raw_data: "A001 OK LOGIN Completed\r\n"
+
+  # 7.1.2.  NO Response
+  #
+  # S: * NO Disk is 98% full, please delete unnecessary data
+  # S: A222 OK COPY completed
+  # C: A223 COPY 3:200 blurdybloop
+  # S: * NO Disk is 98% full, please delete unnecessary data
+  # S: * NO Disk is 99% full, please delete unnecessary data
+  # S: A223 NO COPY failed: disk is full
+
+  rfc3501_7.1.2_NO_response_example_1:
+    :response: "* NO Disk is 98% full, please delete unnecessary data\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: "NO"
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code:
+        text: "Disk is 98% full, please delete unnecessary data"
+      raw_data: "* NO Disk is 98% full, please delete unnecessary data\r\n"
+
+  rfc3501_7.1.2_NO_response_example_4:
+    :response: "A223 NO COPY failed: disk is full\r\n"
+    :expected: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: A223
+      name: "NO"
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code:
+        text: "COPY failed: disk is full"
+      raw_data: "A223 NO COPY failed: disk is full\r\n"
+
+  # 7.1.3.  BAD Response
+  #
+  # Example:    C: ...very long command line...
+  #             S: * BAD Command line too long
+  #             C: ...empty line...
+  #             S: * BAD Empty command line
+  #             C: A443 EXPUNGE
+  #             S: * BAD Disk crash, attempting salvage to a new disk!
+  #             S: * OK Salvage successful, no data lost
+  #             S: A443 OK Expunge completed
+
+  rfc3501_7.1.3_BAD_response_example:
+    :response: "* BAD Disk crash, attempting salvage to a new disk!\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: BAD
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code:
+        text: "Disk crash, attempting salvage to a new disk!"
+      raw_data: "* BAD Disk crash, attempting salvage to a new disk!\r\n"
+
+  # 7.1.4.  PREAUTH Response
+  #
+  # Example:    S: * PREAUTH IMAP4rev1 server logged in as Smith
+
+  rfc3501_7.1.4_PREAUTH_response_example:
+    :response: "* PREAUTH IMAP4rev1 server logged in as Smith\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: PREAUTH
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code:
+        text: "IMAP4rev1 server logged in as Smith"
+      raw_data: "* PREAUTH IMAP4rev1 server logged in as Smith\r\n"
+
+  # 7.1.5.  BYE Response
+  #
+  # Example:    S: * BYE Autologout; idle for too long
+
+  rfc3501_7.1.5_BYE_response_example:
+    :response: "* BYE Autologout; idle for too long\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: BYE
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code:
+        text: "Autologout; idle for too long"
+      raw_data: "* BYE Autologout; idle for too long\r\n"

--- a/test/net/imap/fixtures/response_parser/resp_text_responses.yml
+++ b/test/net/imap/fixtures/response_parser/resp_text_responses.yml
@@ -1,0 +1,40 @@
+---
+:tests:
+  test_resp_text_with_code:
+    :response: "* OK [CLOSED] Previous mailbox closed.\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: OK
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: CLOSED
+          data:
+        text: Previous mailbox closed.
+      raw_data: "* OK [CLOSED] Previous mailbox closed.\r\n"
+
+  test_resp_text_with_T_LBRA:
+    :response: "RUBY0004 OK [READ-WRITE] [Gmail]/Sent Mail selected. (Success)\r\n"
+    :expected: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0004
+      name: OK
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: READ-WRITE
+          data:
+        text: "[Gmail]/Sent Mail selected. (Success)"
+      raw_data: "RUBY0004 OK [READ-WRITE] [Gmail]/Sent Mail selected. (Success)\r\n"
+
+  test_resp_text_with_BADCHARSET_astrings:
+    :response: "t BAD [BADCHARSET (US-ASCII \"[astring with brackets]\")] unsupported
+      charset foo.\r\n"
+    :expected: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: t
+      name: BAD
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: BADCHARSET
+          data:
+          - US-ASCII
+          - "[astring with brackets]"
+        text: unsupported charset foo.
+      raw_data: "t BAD [BADCHARSET (US-ASCII \"[astring with brackets]\")] unsupported
+        charset foo.\r\n"

--- a/test/net/imap/fixtures/response_parser/resp_text_responses.yml
+++ b/test/net/imap/fixtures/response_parser/resp_text_responses.yml
@@ -1,15 +1,5 @@
 ---
 :tests:
-  test_resp_text_with_code:
-    :response: "* OK [CLOSED] Previous mailbox closed.\r\n"
-    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
-      name: OK
-      data: !ruby/struct:Net::IMAP::ResponseText
-        code: !ruby/struct:Net::IMAP::ResponseCode
-          name: CLOSED
-          data:
-        text: Previous mailbox closed.
-      raw_data: "* OK [CLOSED] Previous mailbox closed.\r\n"
 
   test_resp_text_with_T_LBRA:
     :response: "RUBY0004 OK [READ-WRITE] [Gmail]/Sent Mail selected. (Success)\r\n"
@@ -22,19 +12,3 @@
           data:
         text: "[Gmail]/Sent Mail selected. (Success)"
       raw_data: "RUBY0004 OK [READ-WRITE] [Gmail]/Sent Mail selected. (Success)\r\n"
-
-  test_resp_text_with_BADCHARSET_astrings:
-    :response: "t BAD [BADCHARSET (US-ASCII \"[astring with brackets]\")] unsupported
-      charset foo.\r\n"
-    :expected: !ruby/struct:Net::IMAP::TaggedResponse
-      tag: t
-      name: BAD
-      data: !ruby/struct:Net::IMAP::ResponseText
-        code: !ruby/struct:Net::IMAP::ResponseCode
-          name: BADCHARSET
-          data:
-          - US-ASCII
-          - "[astring with brackets]"
-        text: unsupported charset foo.
-      raw_data: "t BAD [BADCHARSET (US-ASCII \"[astring with brackets]\")] unsupported
-        charset foo.\r\n"

--- a/test/net/imap/fixtures/response_parser/rfc3501_examples.yml
+++ b/test/net/imap/fixtures/response_parser/rfc3501_examples.yml
@@ -1,0 +1,190 @@
+---
+:tests:
+
+  # 8.      Sample IMAP4rev1 connection
+  #
+  #    The following is a transcript of an IMAP4rev1 connection.  A long
+  #    line in this sample is broken for editorial clarity.
+  #
+  # S:   * OK IMAP4rev1 Service Ready
+  # C:   a001 login mrc secret
+  # S:   a001 OK LOGIN completed
+  # C:   a002 select inbox
+  # S:   * 18 EXISTS
+  # S:   * FLAGS (\Answered \Flagged \Deleted \Seen \Draft)
+  # S:   * 2 RECENT
+  # S:   * OK [UNSEEN 17] Message 17 is the first unseen message
+  # S:   * OK [UIDVALIDITY 3857529045] UIDs valid
+  # S:   a002 OK [READ-WRITE] SELECT completed
+  # C:   a003 fetch 12 full
+  # S:   * 12 FETCH (FLAGS (\Seen) INTERNALDATE "17-Jul-1996 02:44:25 -0700"
+  #       RFC822.SIZE 4286 ENVELOPE ("Wed, 17 Jul 1996 02:23:25 -0700 (PDT)"
+  #       "IMAP4rev1 WG mtg summary and minutes"
+  #       (("Terry Gray" NIL "gray" "cac.washington.edu"))
+  #       (("Terry Gray" NIL "gray" "cac.washington.edu"))
+  #       (("Terry Gray" NIL "gray" "cac.washington.edu"))
+  #       ((NIL NIL "imap" "cac.washington.edu"))
+  #       ((NIL NIL "minutes" "CNRI.Reston.VA.US")
+  #       ("John Klensin" NIL "KLENSIN" "MIT.EDU")) NIL NIL
+  #       "<B27397-0100000@cac.washington.edu>")
+  #        BODY ("TEXT" "PLAIN" ("CHARSET" "US-ASCII") NIL NIL "7BIT" 3028
+  #        92))
+  # S:    a003 OK FETCH completed
+  # C:    a004 fetch 12 body[header]
+  # S:    * 12 FETCH (BODY[HEADER] {342}
+  # S:    Date: Wed, 17 Jul 1996 02:23:25 -0700 (PDT)
+  # S:    From: Terry Gray <gray@cac.washington.edu>
+  # S:    Subject: IMAP4rev1 WG mtg summary and minutes
+  # S:    To: imap@cac.washington.edu
+  # S:    cc: minutes@CNRI.Reston.VA.US, John Klensin <KLENSIN@MIT.EDU>
+  # S:    Message-Id: <B27397-0100000@cac.washington.edu>
+  # S:    MIME-Version: 1.0
+  # S:    Content-Type: TEXT/PLAIN; CHARSET=US-ASCII
+  # S:
+  # S:    )
+  # S:    a004 OK FETCH completed
+  # C:    a005 store 12 +flags \deleted
+  # S:    * 12 FETCH (FLAGS (\Seen \Deleted))
+  # S:    a005 OK +FLAGS completed
+  # C:    a006 logout
+  # S:    * BYE IMAP4rev1 server terminating connection
+  # S:    a006 OK LOGOUT completed
+
+  # S:   * OK [UNSEEN 17] Message 17 is the first unseen message
+  rfc3501_8_example_1_UNSEEN_response_code:
+    :response: "* OK [UNSEEN 17] Message 17 is the first unseen message\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: OK
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: UNSEEN
+          data: 17
+        text: Message 17 is the first unseen message
+      raw_data: "* OK [UNSEEN 17] Message 17 is the first unseen message\r\n"
+
+  # S:   * OK [UIDVALIDITY 3857529045] UIDs valid
+  rfc3501_8_example_2_UIDVALIDITY_response_code:
+    :response: "* OK [UIDVALIDITY 3857529045] UIDs valid\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: OK
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: UIDVALIDITY
+          data: 3857529045
+        text: UIDs valid
+      raw_data: "* OK [UIDVALIDITY 3857529045] UIDs valid\r\n"
+
+  # S:   * 12 FETCH (FLAGS (\Seen) INTERNALDATE "17-Jul-1996 02:44:25 -0700"
+  #       RFC822.SIZE 4286 ENVELOPE ("Wed, 17 Jul 1996 02:23:25 -0700 (PDT)"
+  #       "IMAP4rev1 WG mtg summary and minutes"
+  #       (("Terry Gray" NIL "gray" "cac.washington.edu"))
+  #       (("Terry Gray" NIL "gray" "cac.washington.edu"))
+  #       (("Terry Gray" NIL "gray" "cac.washington.edu"))
+  #       ((NIL NIL "imap" "cac.washington.edu"))
+  #       ((NIL NIL "minutes" "CNRI.Reston.VA.US")
+  #       ("John Klensin" NIL "KLENSIN" "MIT.EDU")) NIL NIL
+  #       "<B27397-0100000@cac.washington.edu>")
+  #        BODY ("TEXT" "PLAIN" ("CHARSET" "US-ASCII") NIL NIL "7BIT" 3028
+  #        92))
+  rfc3501_8_example_3_FETCH_ENVELOPE:
+    :response: "* 12 FETCH (FLAGS (\\Seen) INTERNALDATE \"17-Jul-1996 02:44:25 -0700\" RFC822.SIZE 4286 ENVELOPE (\"Wed, 17 Jul 1996 02:23:25 -0700 (PDT)\" \"IMAP4rev1 WG mtg summary and minutes\" ((\"Terry Gray\" NIL \"gray\" \"cac.washington.edu\")) ((\"Terry Gray\" NIL \"gray\" \"cac.washington.edu\")) ((\"Terry Gray\" NIL \"gray\" \"cac.washington.edu\")) ((NIL NIL \"imap\" \"cac.washington.edu\")) ((NIL NIL \"minutes\" \"CNRI.Reston.VA.US\")(\"John Klensin\" NIL \"KLENSIN\" \"MIT.EDU\")) NIL NIL \"<B27397-0100000@cac.washington.edu>\") BODY (\"TEXT\" \"PLAIN\" (\"CHARSET\" \"US-ASCII\") NIL NIL \"7BIT\" 3028 92))\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: FETCH
+      data: !ruby/struct:Net::IMAP::FetchData
+        seqno: 12
+        attr:
+          FLAGS:
+          - :Seen
+          INTERNALDATE: 17-Jul-1996 02:44:25 -0700
+          RFC822.SIZE: 4286
+          ENVELOPE: !ruby/struct:Net::IMAP::Envelope
+            date: Wed, 17 Jul 1996 02:23:25 -0700 (PDT)
+            subject: IMAP4rev1 WG mtg summary and minutes
+            from:
+            - !ruby/struct:Net::IMAP::Address
+              name: Terry Gray
+              route:
+              mailbox: gray
+              host: cac.washington.edu
+            sender:
+            - !ruby/struct:Net::IMAP::Address
+              name: Terry Gray
+              route:
+              mailbox: gray
+              host: cac.washington.edu
+            reply_to:
+            - !ruby/struct:Net::IMAP::Address
+              name: Terry Gray
+              route:
+              mailbox: gray
+              host: cac.washington.edu
+            to:
+            - !ruby/struct:Net::IMAP::Address
+              name:
+              route:
+              mailbox: imap
+              host: cac.washington.edu
+            cc:
+            - !ruby/struct:Net::IMAP::Address
+              name:
+              route:
+              mailbox: minutes
+              host: CNRI.Reston.VA.US
+            - !ruby/struct:Net::IMAP::Address
+              name: John Klensin
+              route:
+              mailbox: KLENSIN
+              host: MIT.EDU
+            bcc:
+            in_reply_to:
+            message_id: "<B27397-0100000@cac.washington.edu>"
+          BODY: !ruby/struct:Net::IMAP::BodyTypeText
+            media_type: TEXT
+            subtype: PLAIN
+            param:
+              CHARSET: US-ASCII
+            content_id:
+            description:
+            encoding: 7BIT
+            size: 3028
+            lines: 92
+            md5:
+            disposition:
+            language:
+            extension:
+      raw_data: "* 12 FETCH (FLAGS (\\Seen) INTERNALDATE \"17-Jul-1996 02:44:25 -0700\"
+        RFC822.SIZE 4286 ENVELOPE (\"Wed, 17 Jul 1996 02:23:25 -0700 (PDT)\" \"IMAP4rev1
+        WG mtg summary and minutes\" ((\"Terry Gray\" NIL \"gray\" \"cac.washington.edu\"))
+        ((\"Terry Gray\" NIL \"gray\" \"cac.washington.edu\")) ((\"Terry Gray\" NIL \"gray\"
+        \"cac.washington.edu\")) ((NIL NIL \"imap\" \"cac.washington.edu\")) ((NIL NIL \"minutes\"
+        \"CNRI.Reston.VA.US\")(\"John Klensin\" NIL \"KLENSIN\" \"MIT.EDU\")) NIL NIL \"<B27397-0100000@cac.washington.edu>\")
+        BODY (\"TEXT\" \"PLAIN\" (\"CHARSET\" \"US-ASCII\") NIL NIL \"7BIT\" 3028 92))\r\n"
+
+  # S:    * 12 FETCH (BODY[HEADER] {342}
+  # S:    Date: Wed, 17 Jul 1996 02:23:25 -0700 (PDT)
+  # S:    From: Terry Gray <gray@cac.washington.edu>
+  # S:    Subject: IMAP4rev1 WG mtg summary and minutes
+  # S:    To: imap@cac.washington.edu
+  # S:    cc: minutes@CNRI.Reston.VA.US, John Klensin <KLENSIN@MIT.EDU>
+  # S:    Message-Id: <B27397-0100000@cac.washington.edu>
+  # S:    MIME-Version: 1.0
+  # S:    Content-Type: TEXT/PLAIN; CHARSET=US-ASCII
+  # S:
+  # S:    )
+  rfc3501_8_example_4_FETCH_BODY[HEADER]:
+    :response: "* 12 FETCH (BODY[HEADER] {342}\r\nDate: Wed, 17 Jul 1996 02:23:25 -0700 (PDT)\r\nFrom: Terry Gray <gray@cac.washington.edu>\r\nSubject: IMAP4rev1 WG mtg summary and minutes\r\nTo: imap@cac.washington.edu\r\ncc: minutes@CNRI.Reston.VA.US, John Klensin <KLENSIN@MIT.EDU>\r\nMessage-Id: <B27397-0100000@cac.washington.edu>\r\nMIME-Version: 1.0\r\nContent-Type: TEXT/PLAIN; CHARSET=US-ASCII\r\n\r\n)\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: FETCH
+      data: !ruby/struct:Net::IMAP::FetchData
+        seqno: 12
+        attr:
+          BODY[HEADER]: "Date: Wed, 17 Jul 1996 02:23:25 -0700 (PDT)\r\nFrom: Terry Gray
+            <gray@cac.washington.edu>\r\nSubject: IMAP4rev1 WG mtg summary and minutes\r\nTo:
+            imap@cac.washington.edu\r\ncc: minutes@CNRI.Reston.VA.US, John Klensin <KLENSIN@MIT.EDU>\r\nMessage-Id:
+            <B27397-0100000@cac.washington.edu>\r\nMIME-Version: 1.0\r\nContent-Type: TEXT/PLAIN;
+            CHARSET=US-ASCII\r\n\r\n"
+      raw_data: "* 12 FETCH (BODY[HEADER] {342}\r\nDate: Wed, 17 Jul 1996 02:23:25 -0700
+        (PDT)\r\nFrom: Terry Gray <gray@cac.washington.edu>\r\nSubject: IMAP4rev1 WG mtg
+        summary and minutes\r\nTo: imap@cac.washington.edu\r\ncc: minutes@CNRI.Reston.VA.US,
+        John Klensin <KLENSIN@MIT.EDU>\r\nMessage-Id: <B27397-0100000@cac.washington.edu>\r\nMIME-Version:
+        1.0\r\nContent-Type: TEXT/PLAIN; CHARSET=US-ASCII\r\n\r\n)\r\n"

--- a/test/net/imap/fixtures/response_parser/search_responses.yml
+++ b/test/net/imap/fixtures/response_parser/search_responses.yml
@@ -1,0 +1,76 @@
+---
+:tests:
+  test_search_response_empty:
+    :response: "* SEARCH\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: SEARCH
+      data: []
+      # data: !ruby/array:Net::IMAP::SearchResult
+      #   internal: []
+      #   ivars:
+      #     "@modseq":
+      raw_data: "* SEARCH\r\n"
+
+  test_search_response_single_seq_nums_returned:
+    :response: "* SEARCH 1\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: SEARCH
+      data: # !ruby/array:Net::IMAP::SearchResult
+      #   internal:
+        - 1
+      #   ivars:
+      #     "@modseq":
+      raw_data: "* SEARCH 1\r\n"
+
+  test_search_response_multiple_seq_nums_returned:
+    :response: "* SEARCH 1 2 3\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: SEARCH
+      data: # !ruby/array:Net::IMAP::SearchResult
+        # internal:
+        - 1
+        - 2
+        - 3
+        # ivars:
+          # "@modseq":
+      raw_data: "* SEARCH 1 2 3\r\n"
+
+  test_invalid_search_response_single_result_with_trailing_space:
+    :quirky_servers: Yahoo
+    :response: "* SEARCH 1 \r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: SEARCH
+      data: # !ruby/array:Net::IMAP::SearchResult
+        # internal:
+        - 1
+        # ivars:
+          # "@modseq":
+      raw_data: "* SEARCH 1 \r\n"
+
+  test_invalid_search_response_multiple_result_with_trailing_space:
+    :quirky_servers: Yahoo
+    :response: "* SEARCH 1 2 3 \r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: SEARCH
+      data: # !ruby/array:Net::IMAP::SearchResult
+        # internal:
+        - 1
+        - 2
+        - 3
+        # ivars:
+          # "@modseq":
+      raw_data: "* SEARCH 1 2 3 \r\n"
+
+  test_search_response_with_condstore_modseq:
+    :comment: |
+      [Bug #10112]
+    :response: "* SEARCH 87216 87221 (MODSEQ 7667567)\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: SEARCH
+      data: # !ruby/array:Net::IMAP::SearchResult
+        # internal:
+        - 87216
+        - 87221
+        # ivars:
+          # "@modseq": 7667567
+      raw_data: "* SEARCH 87216 87221 (MODSEQ 7667567)\r\n"

--- a/test/net/imap/fixtures/response_parser/search_responses.yml
+++ b/test/net/imap/fixtures/response_parser/search_responses.yml
@@ -1,5 +1,18 @@
 ---
 :tests:
+  # 7.2.5.  SEARCH Response
+  #
+  #    Example:    S: * SEARCH 2 3 6
+  rfc3501_7.2.5_SEARCH_response_example:
+    :response: "* SEARCH 2 3 6\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: SEARCH
+      data:
+      - 2
+      - 3
+      - 6
+      raw_data: "* SEARCH 2 3 6\r\n"
+
   test_search_response_empty:
     :response: "* SEARCH\r\n"
     :expected: !ruby/struct:Net::IMAP::UntaggedResponse

--- a/test/net/imap/fixtures/response_parser/status_responses.yml
+++ b/test/net/imap/fixtures/response_parser/status_responses.yml
@@ -1,5 +1,19 @@
 ---
 :tests:
+  # 7.2.4   STATUS Response
+  #
+  #    Example:    S: * STATUS blurdybloop (MESSAGES 231 UIDNEXT 44292)
+  rfc3501_7.2.4_STATUS_response_example:
+    :response: "* STATUS blurdybloop (MESSAGES 231 UIDNEXT 44292)\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: STATUS
+      data: !ruby/struct:Net::IMAP::StatusData
+        mailbox: blurdybloop
+        attr:
+          MESSAGES: 231
+          UIDNEXT: 44292
+      raw_data: "* STATUS blurdybloop (MESSAGES 231 UIDNEXT 44292)\r\n"
+
   test_status_response_uidnext_uidvalidity:
     :response: "* STATUS INBOX (UIDNEXT 1 UIDVALIDITY 1234)\r\n"
     :expected: !ruby/struct:Net::IMAP::UntaggedResponse

--- a/test/net/imap/fixtures/response_parser/status_responses.yml
+++ b/test/net/imap/fixtures/response_parser/status_responses.yml
@@ -1,0 +1,25 @@
+---
+:tests:
+  test_status_response_uidnext_uidvalidity:
+    :response: "* STATUS INBOX (UIDNEXT 1 UIDVALIDITY 1234)\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: STATUS
+      data: !ruby/struct:Net::IMAP::StatusData
+        mailbox: INBOX
+        attr:
+          UIDNEXT: 1
+          UIDVALIDITY: 1234
+      raw_data: "* STATUS INBOX (UIDNEXT 1 UIDVALIDITY 1234)\r\n"
+
+  test_invalid_status_response_trailing_space:
+    :comments: |
+      [Bug #13649]
+    :response: "* STATUS INBOX (UIDNEXT 1 UIDVALIDITY 1234) \r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: STATUS
+      data: !ruby/struct:Net::IMAP::StatusData
+        mailbox: INBOX
+        attr:
+          UIDNEXT: 1
+          UIDVALIDITY: 1234
+      raw_data: "* STATUS INBOX (UIDNEXT 1 UIDVALIDITY 1234) \r\n"

--- a/test/net/imap/fixtures/response_parser/thread_responses.yml
+++ b/test/net/imap/fixtures/response_parser/thread_responses.yml
@@ -1,0 +1,347 @@
+---
+:tests:
+  thread_rfc5256_example1:
+    :response: "* THREAD (166)(167)(168)(169)(172)(170)(171)(173)(174 (175)(176)(178)(181)(180))(179)(177(183)(182)(188)(184)(185)(186)(187)(189))(190)(191)(192)(193)(194
+      195)(196 (197)(198))(199)(200 202)(201)(203)(204)(205)(206 207)(208)\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: THREAD
+      data:
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 166
+        children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 167
+        children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 168
+        children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 169
+        children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 172
+        children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 170
+        children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 171
+        children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 173
+        children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 174
+        children:
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 175
+          children: []
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 176
+          children: []
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 178
+          children: []
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 181
+          children: []
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 180
+          children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 179
+        children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 177
+        children:
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 183
+          children: []
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 182
+          children: []
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 188
+          children: []
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 184
+          children: []
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 185
+          children: []
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 186
+          children: []
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 187
+          children: []
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 189
+          children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 190
+        children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 191
+        children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 192
+        children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 193
+        children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 194
+        children:
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 195
+          children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 196
+        children:
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 197
+          children: []
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 198
+          children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 199
+        children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 200
+        children:
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 202
+          children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 201
+        children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 203
+        children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 204
+        children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 205
+        children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 206
+        children:
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 207
+          children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 208
+        children: []
+      raw_data: "* THREAD (166)(167)(168)(169)(172)(170)(171)(173)(174 (175)(176)(178)(181)(180))(179)(177(183)(182)(188)(184)(185)(186)(187)(189))(190)(191)(192)(193)(194
+        195)(196 (197)(198))(199)(200 202)(201)(203)(204)(205)(206 207)(208)\r\n"
+  thread_rfc5256_example2:
+    :response: "* THREAD (166)(167)(168)(169)(172)((170)(179))(171)(173)((174)(175)(176)(178)(181)(180))((177)(183)(182)(188
+      (184)(189))(185 186)(187))(190)(191)(192)(193)((194)(195 196))(197 198)(199)(200
+      202)(201)(203)(204)(205 206 207)(208)\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: THREAD
+      data:
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 166
+        children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 167
+        children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 168
+        children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 169
+        children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 172
+        children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno:
+        children:
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 170
+          children: []
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 179
+          children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 171
+        children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 173
+        children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno:
+        children:
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 174
+          children: []
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 175
+          children: []
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 176
+          children: []
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 178
+          children: []
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 181
+          children: []
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 180
+          children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno:
+        children:
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 177
+          children: []
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 183
+          children: []
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 182
+          children: []
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 188
+          children:
+          - !ruby/struct:Net::IMAP::ThreadMember
+            seqno: 184
+            children: []
+          - !ruby/struct:Net::IMAP::ThreadMember
+            seqno: 189
+            children: []
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 185
+          children:
+          - !ruby/struct:Net::IMAP::ThreadMember
+            seqno: 186
+            children: []
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 187
+          children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 190
+        children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 191
+        children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 192
+        children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 193
+        children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno:
+        children:
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 194
+          children: []
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 195
+          children:
+          - !ruby/struct:Net::IMAP::ThreadMember
+            seqno: 196
+            children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 197
+        children:
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 198
+          children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 199
+        children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 200
+        children:
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 202
+          children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 201
+        children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 203
+        children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 204
+        children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 205
+        children:
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 206
+          children:
+          - !ruby/struct:Net::IMAP::ThreadMember
+            seqno: 207
+            children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 208
+        children: []
+      raw_data: "* THREAD (166)(167)(168)(169)(172)((170)(179))(171)(173)((174)(175)(176)(178)(181)(180))((177)(183)(182)(188
+        (184)(189))(185 186)(187))(190)(191)(192)(193)((194)(195 196))(197 198)(199)(200
+        202)(201)(203)(204)(205 206 207)(208)\r\n"
+  thread_rfc5256_example3:
+    :response: "* THREAD\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: THREAD
+      data: []
+      raw_data: "* THREAD\r\n"
+  test_invalid_thread_empty_response:
+    :response: "* THREAD \r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: THREAD
+      data: []
+      raw_data: "* THREAD \r\n"
+  thread_rfc5256_example4:
+    :response: "* THREAD (2)(3 6 (4 23)(44 7 96))\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: THREAD
+      data:
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 2
+        children: []
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno: 3
+        children:
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 6
+          children:
+          - !ruby/struct:Net::IMAP::ThreadMember
+            seqno: 4
+            children:
+            - !ruby/struct:Net::IMAP::ThreadMember
+              seqno: 23
+              children: []
+          - !ruby/struct:Net::IMAP::ThreadMember
+            seqno: 44
+            children:
+            - !ruby/struct:Net::IMAP::ThreadMember
+              seqno: 7
+              children:
+              - !ruby/struct:Net::IMAP::ThreadMember
+                seqno: 96
+                children: []
+      raw_data: "* THREAD (2)(3 6 (4 23)(44 7 96))\r\n"
+  thread_rfc5256_example5:
+    :response: "* THREAD ((3)(5))\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: THREAD
+      data:
+      - !ruby/struct:Net::IMAP::ThreadMember
+        seqno:
+        children:
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 3
+          children: []
+        - !ruby/struct:Net::IMAP::ThreadMember
+          seqno: 5
+          children: []
+      raw_data: "* THREAD ((3)(5))\r\n"

--- a/test/net/imap/fixtures/response_parser/uidplus_extension.yml
+++ b/test/net/imap/fixtures/response_parser/uidplus_extension.yml
@@ -1,0 +1,89 @@
+---
+:tests:
+  test_uidplus_appenduid:
+    :response: "A003 OK [APPENDUID 38505 3955] APPEND completed\r\n"
+    :expected: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: A003
+      name: OK
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: APPENDUID
+          data: !ruby/struct:Net::IMAP::UIDPlusData
+            uidvalidity: 38505
+            source_uids:
+            assigned_uids:
+            - 3955
+        text: APPEND completed
+      raw_data: "A003 OK [APPENDUID 38505 3955] APPEND completed\r\n"
+  test_uidplus_appenduid_multiappend_compatibility:
+    :response: "A003 OK [APPENDUID 2 4,6:7,9] APPEND completed\r\n"
+    :expected: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: A003
+      name: OK
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: APPENDUID
+          data: !ruby/struct:Net::IMAP::UIDPlusData
+            uidvalidity: 2
+            source_uids:
+            assigned_uids:
+            - 4
+            - 6
+            - 7
+            - 9
+        text: APPEND completed
+      raw_data: "A003 OK [APPENDUID 2 4,6:7,9] APPEND completed\r\n"
+  test_uidplus_copyuid_rfc4315_example_with_mixed_case:
+    :response: "A004 OK [copyUID 38505 304,319:320 3956:3958] Done\r\n"
+    :expected: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: A004
+      name: OK
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: COPYUID
+          data: !ruby/struct:Net::IMAP::UIDPlusData
+            uidvalidity: 38505
+            source_uids:
+            - 304
+            - 319
+            - 320
+            assigned_uids:
+            - 3956
+            - 3957
+            - 3958
+        text: Done
+      raw_data: "A004 OK [copyUID 38505 304,319:320 3956:3958] Done\r\n"
+  test_uidplus_copyuid_with_reversed_ranges:
+    comment: |
+      From RFC4315 ABNF:
+      > and all values between these two *regardless of order*.
+      > Example: 2:4 and 4:2 are equivalent.
+    :response: "A004 OK [copyUID 9999 20:19,500:495 92:97,101:100] Done\r\n"
+    :expected: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: A004
+      name: OK
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: COPYUID
+          data: !ruby/struct:Net::IMAP::UIDPlusData
+            uidvalidity: 9999
+            source_uids:
+            - 19
+            - 20
+            - 495
+            - 496
+            - 497
+            - 498
+            - 499
+            - 500
+            assigned_uids:
+            - 92
+            - 93
+            - 94
+            - 95
+            - 96
+            - 97
+            - 100
+            - 101
+        text: Done
+      raw_data: "A004 OK [copyUID 9999 20:19,500:495 92:97,101:100] Done\r\n"

--- a/test/net/imap/fixtures/response_parser/uidplus_extension.yml
+++ b/test/net/imap/fixtures/response_parser/uidplus_extension.yml
@@ -1,6 +1,8 @@
 ---
 :tests:
-  test_uidplus_appenduid:
+
+  # Identical to the example in RFC4315
+  test_resp_code_APPENDUID_rfc9051_6.3.12_example:
     :response: "A003 OK [APPENDUID 38505 3955] APPEND completed\r\n"
     :expected: !ruby/struct:Net::IMAP::TaggedResponse
       tag: A003
@@ -15,26 +17,10 @@
             - 3955
         text: APPEND completed
       raw_data: "A003 OK [APPENDUID 38505 3955] APPEND completed\r\n"
-  test_uidplus_appenduid_multiappend_compatibility:
-    :response: "A003 OK [APPENDUID 2 4,6:7,9] APPEND completed\r\n"
-    :expected: !ruby/struct:Net::IMAP::TaggedResponse
-      tag: A003
-      name: OK
-      data: !ruby/struct:Net::IMAP::ResponseText
-        code: !ruby/struct:Net::IMAP::ResponseCode
-          name: APPENDUID
-          data: !ruby/struct:Net::IMAP::UIDPlusData
-            uidvalidity: 2
-            source_uids:
-            assigned_uids:
-            - 4
-            - 6
-            - 7
-            - 9
-        text: APPEND completed
-      raw_data: "A003 OK [APPENDUID 2 4,6:7,9] APPEND completed\r\n"
-  test_uidplus_copyuid_rfc4315_example_with_mixed_case:
-    :response: "A004 OK [copyUID 38505 304,319:320 3956:3958] Done\r\n"
+
+  # Identical to the example in RFC4315
+  test_resp_code_COPYUID_rfc9051_6.3.12_example:
+    :response: "A004 OK [COPYUID 38505 304,319:320 3956:3958] Done\r\n"
     :expected: !ruby/struct:Net::IMAP::TaggedResponse
       tag: A004
       name: OK
@@ -52,8 +38,28 @@
             - 3957
             - 3958
         text: Done
-      raw_data: "A004 OK [copyUID 38505 304,319:320 3956:3958] Done\r\n"
-  test_uidplus_copyuid_with_reversed_ranges:
+      raw_data: "A004 OK [COPYUID 38505 304,319:320 3956:3958] Done\r\n"
+
+  test_resp_code_APPENDUID_with_MULTIAPPEND_compatibility:
+    :response: "A003 OK [APPENDUID 2 4,6:7,9] APPEND completed\r\n"
+    :expected: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: A003
+      name: OK
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: APPENDUID
+          data: !ruby/struct:Net::IMAP::UIDPlusData
+            uidvalidity: 2
+            source_uids:
+            assigned_uids:
+            - 4
+            - 6
+            - 7
+            - 9
+        text: APPEND completed
+      raw_data: "A003 OK [APPENDUID 2 4,6:7,9] APPEND completed\r\n"
+
+  test_resp_code_COPYUID_with_reversed_ranges_and_mixed_case:
     comment: |
       From RFC4315 ABNF:
       > and all values between these two *regardless of order*.

--- a/test/net/imap/net_imap_test_helpers.rb
+++ b/test/net/imap/net_imap_test_helpers.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "net/imap"
+require "test/unit"
+require "yaml"
+
+module NetIMAPTestHelpers
+  module TestFixtureGenerators
+
+    attr_reader :fixtures
+
+    def load_fixture_data(*test_fixture_path)
+      dir = self::TEST_FIXTURE_PATH
+      YAML.unsafe_load_file File.join(dir, *test_fixture_path)
+    end
+
+    def generate_tests_from(fixture_data: nil, fixture_file: nil)
+      fixture_data ||= load_fixture_data fixture_file
+      tests = fixture_data.fetch(:tests)
+
+      tests.each do |name, test|
+        type = test.fetch(:test_type) {
+          test.key?(:expected) ? :parser_assert_equal : :parser_pending
+        }
+        name = "test_#{name}" unless name.start_with? "test_"
+        name = name.to_sym
+        raise "#{name} is already defined" if instance_methods.include?(name)
+        # warn "define_method :#{name} = #{type}..."
+
+        case type
+
+        when :parser_assert_equal
+          test => response:, expected:;
+          define_method name do
+            with_debug do
+              parser = Net::IMAP::ResponseParser.new
+              actual = parser.parse response
+              assert_equal expected, actual
+            end
+          end
+
+        when :parser_pending
+          test => response:;
+          define_method name do
+            with_debug do
+              parser = Net::IMAP::ResponseParser.new
+              actual = parser.parse response
+              puts YAML.dump name => {response:, expected: actual}
+              pend "update tests with expected data..."
+            end
+          end
+
+        when :assert_parse_failure
+          test => response:, message:;
+          define_method name do
+            err = assert_raise(Net::IMAP::ResponseParseError) do
+              Net::IMAP::ResponseParser.new.parse response
+            end
+            assert_match(message, err.message)
+          end
+
+        end
+      end
+
+    end
+  end
+
+  def with_debug(bool = true)
+    Net::IMAP.debug, original = bool, Net::IMAP.debug
+    yield
+  ensure
+    Net::IMAP.debug = original
+  end
+
+end

--- a/test/net/imap/test_imap_response_data.rb
+++ b/test/net/imap/test_imap_response_data.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "net/imap"
+require "test/unit"
+
+class IMAPResponseDataTest < Test::Unit::TestCase
+
+  def setup
+    @do_not_reverse_lookup = Socket.do_not_reverse_lookup
+    Socket.do_not_reverse_lookup = true
+  end
+
+  def teardown
+    Socket.do_not_reverse_lookup = @do_not_reverse_lookup
+  end
+
+  def test_uidplus_copyuid__uid_mapping
+    parser = Net::IMAP::ResponseParser.new
+    response = parser.parse(
+      "A004 OK [copyUID 9999 20:19,500:495 92:97,101:100] Done\r\n"
+    )
+    code = response.data.code
+    assert_equal(
+      {
+         19 =>  92,
+         20 =>  93,
+        495 =>  94,
+        496 =>  95,
+        497 =>  96,
+        498 =>  97,
+        499 => 100,
+        500 => 101,
+      },
+      code.data.uid_mapping
+    )
+  end
+
+end

--- a/test/net/imap/test_imap_response_parser.rb
+++ b/test/net/imap/test_imap_response_parser.rb
@@ -42,6 +42,9 @@ class IMAPResponseParserTest < Test::Unit::TestCase
   ############################################################################
   # IMAP extensions, by RFC:
 
+  # RFC 2971: ID response
+  generate_tests_from fixture_file: "id_responses.yml"
+
   # RFC 4315: UIDPLUS extension, APPENDUID and COPYUID response codes
   generate_tests_from fixture_file: "uidplus_extension.yml"
 
@@ -144,18 +147,6 @@ EOF
     assert_equal("ENABLED", response.name)
     assert_equal(1, response.data.length)
     assert_equal("SMTPUTF8", response.data.first)
-  end
-
-  def test_id
-    parser = Net::IMAP::ResponseParser.new
-    response = parser.parse("* ID NIL\r\n")
-    assert_equal("ID", response.name)
-    assert_equal(nil, response.data)
-    response = parser.parse("* ID (\"name\" \"GImap\" \"vendor\" \"Google, Inc.\" \"support-url\" NIL)\r\n")
-    assert_equal("ID", response.name)
-    assert_equal("GImap", response.data["name"])
-    assert_equal("Google, Inc.", response.data["vendor"])
-    assert_equal(nil, response.data.fetch("support-url"))
   end
 
   # [Bug #13649]

--- a/test/net/imap/test_imap_response_parser.rb
+++ b/test/net/imap/test_imap_response_parser.rb
@@ -42,6 +42,9 @@ class IMAPResponseParserTest < Test::Unit::TestCase
   ############################################################################
   # IMAP extensions, by RFC:
 
+  # RFC 4315: UIDPLUS extension, APPENDUID and COPYUID response codes
+  generate_tests_from fixture_file: "uidplus_extension.yml"
+
   # RFC 5256: THREAD response
   generate_tests_from fixture_file: "thread_responses.yml"
 
@@ -206,59 +209,6 @@ EOF
       response = parser.parse("* NOOP\r\n")
     end
     assert_instance_of(Net::IMAP::IgnoredResponse, response)
-  end
-
-  def test_uidplus_appenduid
-    parser = Net::IMAP::ResponseParser.new
-    # RFC4315 example
-    response = parser.parse(
-      "A003 OK [APPENDUID 38505 3955] APPEND completed\r\n"
-    )
-    code = response.data.code
-    assert_equal   "APPENDUID", code.name
-    assert_kind_of Net::IMAP::UIDPlusData, code.data
-    assert_equal   Net::IMAP::UIDPlusData.new(38505, nil, [3955]), code.data
-    assert_equal   "APPENDUID", code.name
-    assert_kind_of Net::IMAP::UIDPlusData, code.data
-    assert_equal   Net::IMAP::UIDPlusData.new(38505, nil, [3955]), code.data
-    # MULTIAPPEND compatibility:
-    response = parser.parse(
-      "A003 OK [APPENDUID 2 4,6:7,9] APPEND completed\r\n"
-    )
-    code = response.data.code
-    assert_equal   "APPENDUID", code.name
-    assert_kind_of Net::IMAP::UIDPlusData, code.data
-    assert_equal   Net::IMAP::UIDPlusData.new(2, nil, [4, 6, 7, 9]), code.data
-  end
-
-  def test_uidplus_copyuid
-    parser = Net::IMAP::ResponseParser.new
-    # RFC4315 example, but using mixed case "copyUID".
-    response = parser.parse(
-      "A004 OK [copyUID 38505 304,319:320 3956:3958] Done\r\n"
-    )
-    code = response.data.code
-    assert_equal   "COPYUID", code.name
-    assert_kind_of Net::IMAP::UIDPlusData, code.data
-    assert_equal   Net::IMAP::UIDPlusData.new(
-      38505, [304, 319, 320], [3956, 3957, 3958]
-    ), code.data
-  end
-
-  # From RFC4315 ABNF:
-  # > and all values between these two *regardless of order*.
-  # > Example: 2:4 and 4:2 are equivalent.
-  def test_uidplus_copyuid__reversed_ranges
-    parser = Net::IMAP::ResponseParser.new
-    response = parser.parse(
-      "A004 OK [copyUID 9999 20:19,500:495 92:97,101:100] Done\r\n"
-    )
-    code = response.data.code
-    assert_equal Net::IMAP::UIDPlusData.new(
-      9999,
-      [19, 20, 495, 496, 497, 498, 499, 500],
-      [92, 93, 94, 95, 96, 97, 100, 101]
-    ), code.data
   end
 
   def test_uidplus_copyuid__uid_mapping

--- a/test/net/imap/test_imap_response_parser.rb
+++ b/test/net/imap/test_imap_response_parser.rb
@@ -33,6 +33,9 @@ class IMAPResponseParserTest < Test::Unit::TestCase
   # §7.2.2: CAPABILITY response
   generate_tests_from fixture_file: "capability_responses.yml"
 
+  # §7.3.1: LIST response (including obsolete LSUB and XLIST responses)
+  generate_tests_from fixture_file: "list_responses.yml"
+
   # §7.3.2: NAMESPACE response (also RFC2342)
   generate_tests_from fixture_file: "namespace_responses.yml"
 
@@ -64,25 +67,6 @@ class IMAPResponseParserTest < Test::Unit::TestCase
   # More interesting tests about the behavior, either of the test or of the
   # response data, should still use normal tests, below
   ############################################################################
-
-  def test_flag_list_many_same_flags
-    parser = Net::IMAP::ResponseParser.new
-    assert_nothing_raised do
-      100.times do
-      parser.parse(<<EOF.gsub(/\n/, "\r\n"))
-* LIST (\\Foo) "." "INBOX"
-EOF
-      end
-    end
-  end
-
-  def test_flag_xlist_inbox
-    parser = Net::IMAP::ResponseParser.new
-    response = parser.parse(<<EOF.gsub(/\n/, "\r\n"))
-* XLIST (\\Inbox) "." "INBOX"
-EOF
-    assert_equal [:Inbox], response.data.attr
-  end
 
   def test_enable
     parser = Net::IMAP::ResponseParser.new

--- a/test/net/imap/test_imap_response_parser.rb
+++ b/test/net/imap/test_imap_response_parser.rb
@@ -23,7 +23,10 @@ class IMAPResponseParserTest < Test::Unit::TestCase
   # Tests that do no more than parse an example response and assert the result
   # data has the correct values have been moved to yml test fixtures.
   #
-  # TODO: add instructions for how to quickly add or update yaml tests
+  # The simplest way to add or update new test cases is to add only the test
+  # name and response string to the yaml file, and then re-run the tests.  The
+  # test will be marked pending, and the parsed result will be serialized and
+  # printed on stdout.  This can then be copied into the yaml file.
   ############################################################################
   # Core IMAP, by RFC9051 section (w/obsolete in relative RFC3501 section):
   generate_tests_from fixture_file: "rfc3501_examples.yml"
@@ -92,28 +95,5 @@ class IMAPResponseParserTest < Test::Unit::TestCase
   # More interesting tests about the behavior, either of the test or of the
   # response data, should still use normal tests, below
   ############################################################################
-
-  # todo: move this to response data tests file
-  # it's testing the mapping fn, not the parsing.
-  def test_uidplus_copyuid__uid_mapping
-    parser = Net::IMAP::ResponseParser.new
-    response = parser.parse(
-      "A004 OK [copyUID 9999 20:19,500:495 92:97,101:100] Done\r\n"
-    )
-    code = response.data.code
-    assert_equal(
-      {
-         19 =>  92,
-         20 =>  93,
-        495 =>  94,
-        496 =>  95,
-        497 =>  96,
-        498 =>  97,
-        499 => 100,
-        500 => 101,
-      },
-      code.data.uid_mapping
-    )
-  end
 
 end

--- a/test/net/imap/test_imap_response_parser.rb
+++ b/test/net/imap/test_imap_response_parser.rb
@@ -2,8 +2,14 @@
 
 require "net/imap"
 require "test/unit"
+require_relative "net_imap_test_helpers"
 
 class IMAPResponseParserTest < Test::Unit::TestCase
+  TEST_FIXTURE_PATH = File.join(__dir__, "fixtures/response_parser")
+
+  include NetIMAPTestHelpers
+  extend  NetIMAPTestHelpers::TestFixtureGenerators
+
   def setup
     @do_not_reverse_lookup = Socket.do_not_reverse_lookup
     Socket.do_not_reverse_lookup = true
@@ -12,6 +18,22 @@ class IMAPResponseParserTest < Test::Unit::TestCase
   def teardown
     Socket.do_not_reverse_lookup = @do_not_reverse_lookup
   end
+
+  ############################################################################
+  # Tests that do no more than parse an example response and assert the result
+  # data has the correct values have been moved to yml test fixtures.
+  #
+  # TODO: add instructions for how to quickly add or update yaml tests
+  ############################################################################
+  # Core IMAP specs, by RFC9051 section (w/ obsolete listed last):
+
+  ############################################################################
+  # IMAP extensions, by RFC:
+
+  ############################################################################
+  # More interesting tests about the behavior, either of the test or of the
+  # response data, should still use normal tests, below
+  ############################################################################
 
   def test_flag_list_many_same_flags
     parser = Net::IMAP::ResponseParser.new

--- a/test/net/imap/test_imap_response_parser.rb
+++ b/test/net/imap/test_imap_response_parser.rb
@@ -27,6 +27,9 @@ class IMAPResponseParserTest < Test::Unit::TestCase
   ############################################################################
   # Core IMAP, by RFC9051 section (w/obsolete in relative RFC3501 section):
 
+  # §7.2.2: CAPABILITY response
+  generate_tests_from fixture_file: "capability_responses.yml"
+
   # §7.3.2: NAMESPACE response (also RFC2342)
   generate_tests_from fixture_file: "namespace_responses.yml"
 
@@ -127,26 +130,6 @@ EOF
     assert_equal("imshare2copy1366146467@xxxxxxxxxxxxxxxxxx.com",
                  response.data[0].user)
     assert_equal("lrswickxteda", response.data[0].rights)
-  end
-
-  # [Bug #8415]
-  def test_capability
-    parser = Net::IMAP::ResponseParser.new
-    response = parser.parse("* CAPABILITY st11p00mm-iscream009 1Q49 XAPPLEPUSHSERVICE IMAP4 IMAP4rev1 SASL-IR AUTH=ATOKEN AUTH=PLAIN\r\n")
-    assert_equal("CAPABILITY", response.name)
-    assert_equal("AUTH=PLAIN", response.data.last)
-    response = parser.parse("* CAPABILITY st11p00mm-iscream009 1Q49 XAPPLEPUSHSERVICE IMAP4 IMAP4rev1 SASL-IR AUTH=ATOKEN AUTH=PLAIN \r\n")
-    assert_equal("CAPABILITY", response.name)
-    assert_equal("AUTH=PLAIN", response.data.last)
-    response = parser.parse("* OK [CAPABILITY IMAP4rev1 SASL-IR 1234 NIL THIS+THAT + AUTH=PLAIN ID] IMAP4rev1 Hello\r\n")
-    assert_equal("OK", response.name)
-    assert_equal("IMAP4rev1 Hello", response.data.text)
-    code = response.data.code
-    assert_equal("CAPABILITY", code.name)
-    assert_equal(
-      ["IMAP4REV1", "SASL-IR", "1234", "NIL", "THIS+THAT", "+", "AUTH=PLAIN", "ID"],
-      code.data
-    )
   end
 
   def test_enable

--- a/test/net/imap/test_imap_response_parser.rb
+++ b/test/net/imap/test_imap_response_parser.rb
@@ -30,6 +30,9 @@ class IMAPResponseParserTest < Test::Unit::TestCase
   # §7.1: Generic Status Responses (OK, NO, BAD, PREAUTH, BYE, codes, text)
   generate_tests_from fixture_file: "resp_text_responses.yml"
 
+  # §7.2.1: ENABLED response
+  generate_tests_from fixture_file: "enabled_responses.yml"
+
   # §7.2.2: CAPABILITY response
   generate_tests_from fixture_file: "capability_responses.yml"
 
@@ -77,14 +80,6 @@ class IMAPResponseParserTest < Test::Unit::TestCase
   # More interesting tests about the behavior, either of the test or of the
   # response data, should still use normal tests, below
   ############################################################################
-
-  def test_enable
-    parser = Net::IMAP::ResponseParser.new
-    response = parser.parse("* ENABLED SMTPUTF8\r\n")
-    assert_equal("ENABLED", response.name)
-    assert_equal(1, response.data.length)
-    assert_equal("SMTPUTF8", response.data.first)
-  end
 
   # todo: move this to response data tests file
   # it's testing the mapping fn, not the parsing.

--- a/test/net/imap/test_imap_response_parser.rb
+++ b/test/net/imap/test_imap_response_parser.rb
@@ -42,6 +42,9 @@ class IMAPResponseParserTest < Test::Unit::TestCase
   ############################################################################
   # IMAP extensions, by RFC:
 
+  # RFC 5256: THREAD response
+  generate_tests_from fixture_file: "thread_responses.yml"
+
   ############################################################################
   # More interesting tests about the behavior, either of the test or of the
   # response data, should still use normal tests, below

--- a/test/net/imap/test_imap_response_parser.rb
+++ b/test/net/imap/test_imap_response_parser.rb
@@ -45,6 +45,9 @@ class IMAPResponseParserTest < Test::Unit::TestCase
   # RFC 2971: ID response
   generate_tests_from fixture_file: "id_responses.yml"
 
+  # RFC 4314: ACL response (TODO: LISTRIGHTS and MYRIGHTS responses)
+  generate_tests_from fixture_file: "acl_responses.yml"
+
   # RFC 4315: UIDPLUS extension, APPENDUID and COPYUID response codes
   generate_tests_from fixture_file: "uidplus_extension.yml"
 
@@ -125,20 +128,6 @@ EOF
   def assert_parseable(s)
     parser = Net::IMAP::ResponseParser.new
     parser.parse(s.gsub(/\n/, "\r\n"))
-  end
-
-  # [Bug #8281]
-  def test_acl
-    parser = Net::IMAP::ResponseParser.new
-    response = parser.parse(<<EOF.gsub(/\n/, "\r\n"))
-* ACL "INBOX/share" "imshare2copy1366146467@xxxxxxxxxxxxxxxxxx.com" lrswickxteda
-EOF
-    assert_equal("ACL", response.name)
-    assert_equal(1, response.data.length)
-    assert_equal("INBOX/share", response.data[0].mailbox)
-    assert_equal("imshare2copy1366146467@xxxxxxxxxxxxxxxxxx.com",
-                 response.data[0].user)
-    assert_equal("lrswickxteda", response.data[0].rights)
   end
 
   def test_enable

--- a/test/net/imap/test_imap_response_parser.rb
+++ b/test/net/imap/test_imap_response_parser.rb
@@ -51,6 +51,9 @@ class IMAPResponseParserTest < Test::Unit::TestCase
   # §7.5.2: FETCH response, BODYSTRUCTURE msg-att
   generate_tests_from fixture_file: "body_structure_responses.yml"
 
+  # §7.6: Command Continuation Request
+  generate_tests_from fixture_file: "continuation_requests.yml"
+
   ############################################################################
   # IMAP extensions, by RFC:
 
@@ -77,14 +80,6 @@ class IMAPResponseParserTest < Test::Unit::TestCase
     assert_equal("ENABLED", response.name)
     assert_equal(1, response.data.length)
     assert_equal("SMTPUTF8", response.data.first)
-  end
-
-  def test_continuation_request_without_response_text
-    parser = Net::IMAP::ResponseParser.new
-    response = parser.parse("+\r\n")
-    assert_instance_of(Net::IMAP::ContinuationRequest, response)
-    assert_equal(nil, response.data.code)
-    assert_equal("", response.data.text)
   end
 
   def test_ignored_response

--- a/test/net/imap/test_imap_response_parser.rb
+++ b/test/net/imap/test_imap_response_parser.rb
@@ -26,8 +26,11 @@ class IMAPResponseParserTest < Test::Unit::TestCase
   # TODO: add instructions for how to quickly add or update yaml tests
   ############################################################################
   # Core IMAP, by RFC9051 section (w/obsolete in relative RFC3501 section):
+  generate_tests_from fixture_file: "rfc3501_examples.yml"
 
   # §7.1: Generic Status Responses (OK, NO, BAD, PREAUTH, BYE, codes, text)
+  generate_tests_from fixture_file: "resp_code_examples.yml"
+  generate_tests_from fixture_file: "resp_cond_examples.yml"
   generate_tests_from fixture_file: "resp_text_responses.yml"
 
   # §7.2.1: ENABLED response
@@ -47,6 +50,15 @@ class IMAPResponseParserTest < Test::Unit::TestCase
 
   # RFC3501 §7.2.5: SEARCH response (obsolete in IMAP4rev2):
   generate_tests_from fixture_file: "search_responses.yml"
+
+  # §7.3.5: FLAGS response
+  generate_tests_from fixture_file: "flags_responses.yml"
+
+  # §7.4: Mailbox size, EXISTS and RECENT
+  generate_tests_from fixture_file: "mailbox_size_responses.yml"
+
+  # §7.5.1: EXPUNGE response
+  generate_tests_from fixture_file: "expunge_responses.yml"
 
   # §7.5.2: FETCH response, misc msg-att
   generate_tests_from fixture_file: "fetch_responses.yml"

--- a/test/net/imap/test_imap_response_parser.rb
+++ b/test/net/imap/test_imap_response_parser.rb
@@ -39,6 +39,9 @@ class IMAPResponseParserTest < Test::Unit::TestCase
   # §7.3.2: NAMESPACE response (also RFC2342)
   generate_tests_from fixture_file: "namespace_responses.yml"
 
+  # §7.3.3: STATUS response
+  generate_tests_from fixture_file: "status_responses.yml"
+
   # RFC3501 §7.2.5: SEARCH response (obsolete in IMAP4rev2):
   generate_tests_from fixture_file: "search_responses.yml"
 
@@ -74,19 +77,6 @@ class IMAPResponseParserTest < Test::Unit::TestCase
     assert_equal("ENABLED", response.name)
     assert_equal(1, response.data.length)
     assert_equal("SMTPUTF8", response.data.first)
-  end
-
-  # [Bug #13649]
-  def test_status
-    parser = Net::IMAP::ResponseParser.new
-    response = parser.parse("* STATUS INBOX (UIDNEXT 1 UIDVALIDITY 1234)\r\n")
-    assert_equal("STATUS", response.name)
-    assert_equal("INBOX", response.data.mailbox)
-    assert_equal(1234, response.data.attr["UIDVALIDITY"])
-    response = parser.parse("* STATUS INBOX (UIDNEXT 1 UIDVALIDITY 1234) \r\n")
-    assert_equal("STATUS", response.name)
-    assert_equal("INBOX", response.data.mailbox)
-    assert_equal(1234, response.data.attr["UIDVALIDITY"])
   end
 
   def test_continuation_request_without_response_text

--- a/test/net/imap/test_imap_response_parser.rb
+++ b/test/net/imap/test_imap_response_parser.rb
@@ -27,6 +27,9 @@ class IMAPResponseParserTest < Test::Unit::TestCase
   ############################################################################
   # Core IMAP, by RFC9051 section (w/obsolete in relative RFC3501 section):
 
+  # §7.1: Generic Status Responses (OK, NO, BAD, PREAUTH, BYE, codes, text)
+  generate_tests_from fixture_file: "resp_text_responses.yml"
+
   # §7.2.2: CAPABILITY response
   generate_tests_from fixture_file: "capability_responses.yml"
 
@@ -76,14 +79,6 @@ EOF
 * XLIST (\\Inbox) "." "INBOX"
 EOF
     assert_equal [:Inbox], response.data.attr
-  end
-
-  def test_resp_text_code
-    parser = Net::IMAP::ResponseParser.new
-    response = parser.parse(<<EOF.gsub(/\n/, "\r\n"))
-* OK [CLOSED] Previous mailbox closed.
-EOF
-    assert_equal "CLOSED", response.data.code.name
   end
 
   def test_msg_att_extra_space
@@ -156,22 +151,6 @@ EOF
     parser = Net::IMAP::ResponseParser.new
     response = parser.parse("* 1 FETCH (FLAGS (\Seen) MODSEQ (12345) UID 5)\r\n")
     assert_equal(12345, response.data.attr["MODSEQ"])
-  end
-
-  def test_msg_rfc3501_response_text_with_T_LBRA
-    parser = Net::IMAP::ResponseParser.new
-    response = parser.parse("RUBY0004 OK [READ-WRITE] [Gmail]/Sent Mail selected. (Success)\r\n")
-    assert_equal("RUBY0004", response.tag)
-    assert_equal("READ-WRITE", response.data.code.name)
-    assert_equal("[Gmail]/Sent Mail selected. (Success)", response.data.text)
-  end
-
-  def test_msg_rfc3501_response_text_with_BADCHARSET_astrings
-    parser = Net::IMAP::ResponseParser.new
-    response = parser.parse("t BAD [BADCHARSET (US-ASCII \"[astring with brackets]\")] unsupported charset foo.\r\n")
-    assert_equal("t", response.tag)
-    assert_equal("unsupported charset foo.", response.data.text)
-    assert_equal("BADCHARSET", response.data.code.name)
   end
 
   def test_continuation_request_without_response_text

--- a/test/net/imap/test_imap_response_parser.rb
+++ b/test/net/imap/test_imap_response_parser.rb
@@ -70,6 +70,10 @@ class IMAPResponseParserTest < Test::Unit::TestCase
   generate_tests_from fixture_file: "thread_responses.yml"
 
   ############################################################################
+  # Workarounds or unspecified extensions:
+  generate_tests_from fixture_file: "quirky_behaviors.yml"
+
+  ############################################################################
   # More interesting tests about the behavior, either of the test or of the
   # response data, should still use normal tests, below
   ############################################################################
@@ -82,15 +86,8 @@ class IMAPResponseParserTest < Test::Unit::TestCase
     assert_equal("SMTPUTF8", response.data.first)
   end
 
-  def test_ignored_response
-    parser = Net::IMAP::ResponseParser.new
-    response = nil
-    assert_nothing_raised do
-      response = parser.parse("* NOOP\r\n")
-    end
-    assert_instance_of(Net::IMAP::IgnoredResponse, response)
-  end
-
+  # todo: move this to response data tests file
+  # it's testing the mapping fn, not the parsing.
   def test_uidplus_copyuid__uid_mapping
     parser = Net::IMAP::ResponseParser.new
     response = parser.parse(

--- a/test/net/imap/test_imap_response_parser.rb
+++ b/test/net/imap/test_imap_response_parser.rb
@@ -30,6 +30,9 @@ class IMAPResponseParserTest < Test::Unit::TestCase
   # §7.3.2: NAMESPACE response (also RFC2342)
   generate_tests_from fixture_file: "namespace_responses.yml"
 
+  # §7.5.2: FETCH response, BODYSTRUCTURE msg-att
+  generate_tests_from fixture_file: "body_structure_responses.yml"
+
   ############################################################################
   # IMAP extensions, by RFC:
 
@@ -132,85 +135,9 @@ EOF
     assert_equal("foo\r\n", response.data.attr["RFC822"])
   end
 
-  # [Bug #6397] [ruby-core:44849]
-  def test_body_type_attachment
-    parser = Net::IMAP::ResponseParser.new
-    response = parser.parse(<<EOF.gsub(/\n/, "\r\n"))
-* 980 FETCH (UID 2862 BODYSTRUCTURE ((("TEXT" "PLAIN" ("CHARSET" "iso-8859-1") NIL NIL "7BIT" 416 21 NIL NIL NIL)("TEXT" "HTML" ("CHARSET" "iso-8859-1") NIL NIL "7BIT" 1493 32 NIL NIL NIL) "ALTERNATIVE" ("BOUNDARY" "Boundary_(ID_IaecgfnXwG5bn3x8lIeGIQ)") NIL NIL)("MESSAGE" "RFC822" ("NAME" "Fw_ ____ _____ ____.eml") NIL NIL "7BIT" 1980088 NIL ("ATTACHMENT" ("FILENAME" "Fw_ ____ _____ ____.eml")) NIL) "MIXED" ("BOUNDARY" "Boundary_(ID_eDdLc/j0mBIzIlR191pHjA)") NIL NIL))
-EOF
-    assert_equal("Fw_ ____ _____ ____.eml",
-      response.data.attr["BODYSTRUCTURE"].parts[1].body.param["FILENAME"])
-  end
-
   def assert_parseable(s)
     parser = Net::IMAP::ResponseParser.new
     parser.parse(s.gsub(/\n/, "\r\n"))
-  end
-
-  # [Bug #7146]
-  def test_msg_delivery_status
-    # This was part of a larger response that caused crashes, but this was the
-    # minimal test case to demonstrate it
-    assert_parseable <<EOF
-* 4902 FETCH (BODY (("MESSAGE" "DELIVERY-STATUS" NIL NIL NIL "7BIT" 324) "REPORT"))
-EOF
-  end
-
-  # [Bug #7147]
-  def test_msg_with_message_rfc822_attachment
-    assert_parseable <<EOF
-* 5441 FETCH (BODY ((("TEXT" "PLAIN" ("CHARSET" "iso-8859-1") NIL NIL "QUOTED-PRINTABLE" 69 1)("TEXT" "HTML" ("CHARSET" "iso-8859-1") NIL NIL "QUOTED-PRINTABLE" 455 12) "ALTERNATIVE")("MESSAGE" "RFC822" ("NAME" "ATT00026.eml") NIL NIL "7BIT" 4079755) "MIXED"))
-EOF
-  end
-
-  # [Bug #7153]
-  def test_msg_body_mixed
-    assert_parseable <<EOF
-* 1038 FETCH (BODY ("MIXED"))
-EOF
-  end
-
-  # [Bug #8167]
-  def test_msg_delivery_status_with_extra_data
-    parser = Net::IMAP::ResponseParser.new
-    response = parser.parse(<<EOF.gsub(/\n/, "\r\n"))
-* 29021 FETCH (RFC822.SIZE 3162 UID 113622 RFC822.HEADER {1155}
-Return-path: <>
-Envelope-to: info@xxxxxxxx.si
-Delivery-date: Tue, 26 Mar 2013 12:42:58 +0100
-Received: from mail by xxxx.xxxxxxxxxxx.net with spam-scanned (Exim 4.76)
-	id 1UKSHI-000Cwl-AR
-	for info@xxxxxxxx.si; Tue, 26 Mar 2013 12:42:58 +0100
-X-Spam-Checker-Version: SpamAssassin 3.3.1 (2010-03-16) on xxxx.xxxxxxxxxxx.net
-X-Spam-Level: **
-X-Spam-Status: No, score=2.1 required=7.0 tests=DKIM_ADSP_NXDOMAIN,RDNS_NONE
-	autolearn=no version=3.3.1
-Received: from [xx.xxx.xxx.xx] (port=56890 helo=xxxxxx.localdomain)
-	by xxxx.xxxxxxxxxxx.net with esmtp (Exim 4.76)
-	id 1UKSHI-000Cwi-9j
-	for info@xxxxxxxx.si; Tue, 26 Mar 2013 12:42:56 +0100
-Received: by xxxxxx.localdomain (Postfix)
-	id 72725BEA64A; Tue, 26 Mar 2013 12:42:55 +0100 (CET)
-Date: Tue, 26 Mar 2013 12:42:55 +0100 (CET)
-From: MAILER-DAEMON@xxxxxx.localdomain (Mail Delivery System)
-Subject: Undelivered Mail Returned to Sender
-To: info@xxxxxxxx.si
-Auto-Submitted: auto-replied
-MIME-Version: 1.0
-Content-Type: multipart/report; report-type=delivery-status;
-	boundary="27797BEA649.1364298175/xxxxxx.localdomain"
-Message-Id: <20130326114255.72725BEA64A@xxxxxx.localdomain>
-
- BODYSTRUCTURE (("text" "plain" ("charset" "us-ascii") NIL "Notification" "7bit" 510 14 NIL NIL NIL NIL)("message" "delivery-status" NIL NIL "Delivery report" "7bit" 410 NIL NIL NIL NIL)("text" "rfc822-headers" ("charset" "us-ascii") NIL "Undelivered Message Headers" "7bit" 612 15 NIL NIL NIL NIL) "report" ("report-type" "delivery-status" "boundary" "27797BEA649.1364298175/xxxxxx.localdomain") NIL NIL NIL))
-EOF
-    delivery_status = response.data.attr["BODYSTRUCTURE"].parts[1]
-    assert_equal("MESSAGE", delivery_status.media_type)
-    assert_equal("DELIVERY-STATUS", delivery_status.subtype)
-    assert_equal(nil, delivery_status.param)
-    assert_equal(nil, delivery_status.content_id)
-    assert_equal("Delivery report", delivery_status.description)
-    assert_equal("7BIT", delivery_status.encoding)
-    assert_equal(410, delivery_status.size)
   end
 
   # [Bug #8281]
@@ -267,49 +194,12 @@ EOF
     assert_equal(nil, response.data.fetch("support-url"))
   end
 
-  def test_mixed_boundary
-    parser = Net::IMAP::ResponseParser.new
-    response = parser.parse("* 2688 FETCH (UID 179161 BODYSTRUCTURE (" \
-                            "(\"TEXT\" \"PLAIN\" (\"CHARSET\" \"iso-8859-1\") NIL NIL \"QUOTED-PRINTABLE\" 200 4 NIL NIL NIL)" \
-                            "(\"MESSAGE\" \"DELIVERY-STATUS\" NIL NIL NIL \"7BIT\" 318 NIL NIL NIL)" \
-                            "(\"MESSAGE\" \"RFC822\" NIL NIL NIL \"7BIT\" 2177" \
-                            " (\"Tue, 11 May 2010 18:28:16 -0400\" \"Re: Welcome letter\" (" \
-                              "(\"David\" NIL \"info\" \"xxxxxxxx.si\")) " \
-                              "((\"David\" NIL \"info\" \"xxxxxxxx.si\")) " \
-                              "((\"David\" NIL \"info\" \"xxxxxxxx.si\")) " \
-                              "((\"Doretha\" NIL \"doretha.info\" \"xxxxxxxx.si\")) " \
-                              "NIL NIL " \
-                              "\"<AC1D15E06EA82F47BDE18E851CC32F330717704E@localdomain>\" " \
-                              "\"<AANLkTikKMev1I73L2E7XLjRs67IHrEkb23f7ZPmD4S_9@localdomain>\")" \
-                            " (\"MIXED\" (\"BOUNDARY\" \"000e0cd29212e3e06a0486590ae2\") NIL NIL)" \
-                            " 37 NIL NIL NIL)" \
-                            " \"REPORT\" (\"BOUNDARY\" \"16DuG.4XbaNOvCi.9ggvq.8Ipnyp3\" \"REPORT-TYPE\" \"delivery-status\") NIL NIL))\r\n")
-    empty_part = response.data.attr['BODYSTRUCTURE'].parts[2]
-    assert_equal(empty_part.lines, 37)
-    assert_equal(empty_part.body.media_type, 'MULTIPART')
-    assert_equal(empty_part.body.subtype, 'MIXED')
-    assert_equal(empty_part.body.param['BOUNDARY'], '000e0cd29212e3e06a0486590ae2')
-  end
-
   # [Bug #10112]
   def test_search_modseq
     parser = Net::IMAP::ResponseParser.new
     response = parser.parse("* SEARCH 87216 87221 (MODSEQ 7667567)\r\n")
     assert_equal("SEARCH", response.name)
     assert_equal([87216, 87221], response.data)
-  end
-
-  # [Bug #11128]
-  def test_body_ext_mpart_without_lang
-    parser = Net::IMAP::ResponseParser.new
-    response = parser.parse("* 4 FETCH (BODY (((\"text\" \"plain\" (\"charset\" \"utf-8\") NIL NIL \"7bit\" 257 9 NIL NIL NIL NIL)(\"text\" \"html\" (\"charset\" \"utf-8\") NIL NIL \"quoted-printable\" 655 9 NIL NIL NIL NIL) \"alternative\" (\"boundary\" \"001a1137a5047848dd05157ddaa1\") NIL)(\"application\" \"pdf\" (\"name\" \"test.xml\" \"x-apple-part-url\" \"9D00D9A2-98AB-4EFB-85BA-FB255F8BF3D7\") NIL NIL \"base64\" 4383638 NIL (\"attachment\" (\"filename\" \"test.xml\")) NIL NIL) \"mixed\" (\"boundary\" \"001a1137a5047848e405157ddaa3\") NIL))\r\n")
-    assert_equal("FETCH", response.name)
-    body = response.data.attr["BODY"]
-    assert_equal(nil, body.parts[0].disposition)
-    assert_equal(nil, body.parts[0].language)
-    assert_equal("ATTACHMENT", body.parts[1].disposition.dsp_type)
-    assert_equal("test.xml", body.parts[1].disposition.param["FILENAME"])
-    assert_equal(nil, body.parts[1].language)
   end
 
   # [Bug #13649]


### PR DESCRIPTION
The two big motivations for this:
1) ✅ to simplify generation of test data from RFCs or other sources.
2) 📈 to simplify re-use of test data as benchmark data.

Currently defined test types:
* `:parser_assert_equal`: compares parse result to the `expected` data.
* `:parser_pending`: print out yaml which can be inserted into the
  appropriate yaml test fixture file.
* `:assert_parse_failure`: asserts `ResponseParseError` is raised

If there is no explicit test type, but there is a `:response` and an `:expected` key, then `:parser_assert_equal` is assumed.

If there is no explicit test type, but there is a `:response` without an `:expected` key, then `:parser_pending` is assumed.

This _should_ **simplify** adding new examples, but it needs to be documented.  We must not allow it to become a barrier for new contributors.

The benchmark script is very simply generated from all `:parser_assert_equal` tests.

----

TODO: document the simplest way to add new examples.

TODO: I have many more examples, but they need to be in separate PRs... because our current parser can't parse them yet.  😉