### PR TITLE
✨♻️🐛⚡ Support for UTF8, optional text, fix namespace and bodystructure bugs

### DIFF
--- a/benchmarks/generate_parser_benchmarks
+++ b/benchmarks/generate_parser_benchmarks
@@ -28,7 +28,8 @@ init = <<RUBY
   require "net/imap"
 
   def load_response(file, name)
-    YAML.unsafe_load_file(file).dig(:tests, name, :response) \\
+    YAML.unsafe_load_file(file).dig(:tests, name, :response)
+      .force_encoding "ASCII-8BIT" \\
       or abort "ERRORO: missing %p fixture data in %p" % [name, file]
   end
 

--- a/benchmarks/parser.yml
+++ b/benchmarks/parser.yml
@@ -4,7 +4,8 @@ prelude: |2
     require "net/imap"
 
     def load_response(file, name)
-      YAML.unsafe_load_file(file).dig(:tests, name, :response) \
+      YAML.unsafe_load_file(file).dig(:tests, name, :response)
+        .force_encoding "ASCII-8BIT" \
         or abort "ERRORO: missing %p fixture data in %p" % [name, file]
     end
 
@@ -559,6 +560,16 @@ benchmark:
   prelude: |2
       response = load_response("../test/net/imap/fixtures/response_parser/thread_responses.yml",
                                "thread_rfc5256_example5")
+  script: parser.parse(response)
+- name: utf8_in_list_mailbox
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/utf8_responses.yml",
+                               "test_utf8_in_list_mailbox")
+  script: parser.parse(response)
+- name: utf8_in_resp_text
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/utf8_responses.yml",
+                               "test_utf8_in_resp_text")
   script: parser.parse(response)
 - name: xlist_inbox
   prelude: |2

--- a/lib/net/imap/response_parser.rb
+++ b/lib/net/imap/response_parser.rb
@@ -1592,20 +1592,6 @@ module Net
         end
       end
 
-      def parse_error(fmt, *args)
-        if IMAP.debug
-          $stderr.printf("@str: %s\n", @str.dump)
-          $stderr.printf("@pos: %d\n", @pos)
-          $stderr.printf("@lex_state: %s\n", @lex_state)
-          if @token
-            $stderr.printf("@token.symbol: %s\n", @token.symbol)
-            $stderr.printf("@token.value: %s\n", @token.value.inspect)
-          end
-        end
-        raise ResponseParseError, format(fmt, *args)
-      end
     end
-
   end
-
 end

--- a/lib/net/imap/response_parser/parser_utils.rb
+++ b/lib/net/imap/response_parser/parser_utils.rb
@@ -8,26 +8,58 @@ module Net
       # (internal API, subject to change)
       module ParserUtils # :nodoc:
 
+        module Generator
+
+          LOOKAHEAD = "(@token ||= next_token)"
+          SHIFT_TOKEN = "(@token = nil)"
+
+          # we can skip lexer for single character matches, as a shortcut
+          def def_char_matchers(name, char, token)
+            match_name = name.match(/\A[A-Z]/) ? "#{name}!" : name
+            char = char.dump
+            class_eval <<~RUBY, __FILE__, __LINE__ + 1
+              # frozen_string_literal: true
+
+              # like accept(token_symbols); returns token or nil
+              def #{name}?
+                if @token&.symbol == #{token}
+                  #{SHIFT_TOKEN}
+                  #{char}
+                elsif !@token && @str[@pos] == #{char}
+                  @pos += 1
+                  #{char}
+                end
+              end
+
+              # like match(token_symbols); returns token or raises parse_error
+              def #{match_name}
+                if @token&.symbol == #{token}
+                  #{SHIFT_TOKEN}
+                  #{char}
+                elsif !@token && @str[@pos] == #{char}
+                  @pos += 1
+                  #{char}
+                else
+                  parse_error("unexpected %s (expected %p)",
+                              @token&.symbol || @str[@pos].inspect, #{char})
+                end
+              end
+            RUBY
+          end
+
+        end
+
         private
 
-        def match(*args, lex_state: @lex_state)
-          if @token && lex_state != @lex_state
-            parse_error("invalid lex_state change to %s with unconsumed token",
-                        lex_state)
+        def match(*args)
+          token = lookahead
+          unless args.include?(token.symbol)
+            parse_error('unexpected token %s (expected %s)',
+                        token.symbol.id2name,
+                        args.collect {|i| i.id2name}.join(" or "))
           end
-          begin
-            @lex_state, original_lex_state = lex_state, @lex_state
-            token = lookahead
-            unless args.include?(token.symbol)
-              parse_error('unexpected token %s (expected %s)',
-                          token.symbol.id2name,
-                          args.collect {|i| i.id2name}.join(" or "))
-            end
-            shift_token
-            return token
-          ensure
-            @lex_state = original_lex_state
-          end
+          shift_token
+          token
         end
 
         # like match, but does not raise error on failure.
@@ -42,6 +74,14 @@ module Net
           end
         end
 
+        # To be used conditionally:
+        #   assert_no_lookahead if Net::IMAP.debug
+        def assert_no_lookahead
+          @token.nil? or
+            parse_error("assertion failed: expected @token.nil?, actual %s: %p",
+                        @token.symbol, @token.value)
+        end
+
         # like accept, without consuming the token
         def lookahead?(*symbols)
           @token if symbols.include?((@token ||= next_token)&.symbol)
@@ -49,6 +89,22 @@ module Net
 
         def lookahead
           @token ||= next_token
+        end
+
+        def accept_re(re)
+          assert_no_lookahead if Net::IMAP.debug
+          re.match(@str, @pos) and @pos = $~.end(0)
+          $~
+        end
+
+        def match_re(re, name)
+          assert_no_lookahead if Net::IMAP.debug
+          if re.match(@str, @pos)
+            @pos = $~.end(0)
+            $~
+          else
+            parse_error("invalid #{name}")
+          end
         end
 
         def shift_token

--- a/lib/net/imap/response_parser/parser_utils.rb
+++ b/lib/net/imap/response_parser/parser_utils.rb
@@ -20,6 +20,16 @@ module Net
             class_eval <<~RUBY, __FILE__, __LINE__ + 1
               # frozen_string_literal: true
 
+              # force use of #next_token; no string peeking
+              def lookahead_#{name}?
+                #{LOOKAHEAD}&.symbol == #{token}
+              end
+
+              # use token or string peek
+              def peek_#{name}?
+                @token ? @token.symbol == #{token} : @str[@pos] == #{char}
+              end
+
               # like accept(token_symbols); returns token or nil
               def #{name}?
                 if @token&.symbol == #{token}
@@ -147,6 +157,16 @@ module Net
 
         def lookahead
           @token ||= next_token
+        end
+
+        def peek_str?(str)
+          assert_no_lookahead if Net::IMAP.debug
+          @str[@pos, str.length] == str
+        end
+
+        def peek_re(re)
+          assert_no_lookahead if Net::IMAP.debug
+          re.match(@str, @pos)
         end
 
         def accept_re(re)

--- a/lib/net/imap/response_parser/parser_utils.rb
+++ b/lib/net/imap/response_parser/parser_utils.rb
@@ -54,6 +54,31 @@ module Net
         def shift_token
           @token = nil
         end
+
+        def parse_error(fmt, *args)
+          msg = format(fmt, *args)
+          if IMAP.debug
+            local_path = File.dirname(__dir__)
+            tok = @token ? "%s: %p" % [@token.symbol, @token.value] : "nil"
+            warn "%s %s: %s"        % [self.class, __method__, msg]
+            warn "  tokenized : %s" % [@str[...@pos].dump]
+            warn "  remaining : %s" % [@str[@pos..].dump]
+            warn "  @lex_state: %s" % [@lex_state]
+            warn "  @pos      : %d" % [@pos]
+            warn "  @token    : %s" % [tok]
+            caller_locations(1..20).each_with_index do |cloc, idx|
+              next unless cloc.path&.start_with?(local_path)
+              warn "  caller[%2d]: %-30s (%s:%d)" % [
+                idx,
+                cloc.base_label,
+                File.basename(cloc.path, ".rb"),
+                cloc.lineno
+              ]
+            end
+          end
+          raise ResponseParseError, msg
+        end
+
       end
     end
   end

--- a/test/net/imap/fixtures/response_parser/body_structure_responses.yml
+++ b/test/net/imap/fixtures/response_parser/body_structure_responses.yml
@@ -6,28 +6,33 @@
       [Bug #7146]
       This was part of a larger response that caused crashes, but this was the
       minimal test case to demonstrate it
-    :response: "* 4902 FETCH (BODY ((\"MESSAGE\" \"DELIVERY-STATUS\" NIL NIL NIL \"7BIT\"
-      324) \"REPORT\"))\r\n"
+    :response: "* 4902 FETCH (BODY ((\"MESSAGE\" \"DELIVERY-STATUS\" NIL NIL NIL \"7BIT\" 324) \"REPORT\"))\r\n"
     :expected: !ruby/struct:Net::IMAP::UntaggedResponse
       name: FETCH
       data: !ruby/struct:Net::IMAP::FetchData
         seqno: 4902
         attr:
           BODY: !ruby/struct:Net::IMAP::BodyTypeMultipart
-            media_type: MULTIPART
-            subtype: REPORT
+            media_type: "MULTIPART"
+            subtype: "REPORT"
             parts:
-            - !ruby/struct:Net::IMAP::BodyTypeExtension
+            - !ruby/struct:Net::IMAP::BodyTypeBasic
               media_type: MESSAGE
               subtype: DELIVERY-STATUS
-              params:
+              param:
               content_id:
               description:
               encoding: 7BIT
               size: 324
+              md5:
+              disposition:
+              language:
+              location:
+              extension:
             param:
             disposition:
             language:
+            location:
             extension:
       raw_data: "* 4902 FETCH (BODY ((\"MESSAGE\" \"DELIVERY-STATUS\" NIL NIL NIL \"7BIT\" 324) \"REPORT\"))\r\n"
 
@@ -64,6 +69,7 @@
                 md5:
                 disposition:
                 language:
+                location:
                 extension:
               - !ruby/struct:Net::IMAP::BodyTypeText
                 media_type: TEXT
@@ -78,12 +84,14 @@
                 md5:
                 disposition:
                 language:
+                location:
                 extension:
               param:
               disposition:
               language:
+              location:
               extension:
-            - !ruby/struct:Net::IMAP::BodyTypeMessage
+            - !ruby/struct:Net::IMAP::BodyTypeBasic
               media_type: MESSAGE
               subtype: RFC822
               param:
@@ -92,16 +100,15 @@
               description:
               encoding: 7BIT
               size: 4079755
-              envelope:
-              body:
-              lines:
               md5:
               disposition:
               language:
+              location:
               extension:
             param:
             disposition:
             language:
+            location:
             extension:
       raw_data: "* 5441 FETCH (BODY (((\"TEXT\" \"PLAIN\" (\"CHARSET\" \"iso-8859-1\")
         NIL NIL \"QUOTED-PRINTABLE\" 69 1)(\"TEXT\" \"HTML\" (\"CHARSET\" \"iso-8859-1\")
@@ -111,30 +118,31 @@
   test_invalid_bodystructure_bug7153_mixed:
     :comments: |
       [Bug #7153]
+
+      Sometimes servers send multipart/* with no parts as body-type-mpart, but
+      that produces invalid responses.  They probably should have sent it as
+      body-type-1part, but we need to handle it either way.
     :response: "* 1038 FETCH (BODY (\"MIXED\"))\r\n"
     :expected: !ruby/struct:Net::IMAP::UntaggedResponse
       name: FETCH
       data: !ruby/struct:Net::IMAP::FetchData
         seqno: 1038
         attr:
-          BODY: !ruby/struct:Net::IMAP::BodyTypeBasic
-            media_type: MULTIPART
-            subtype: MIXED
+          BODY: !ruby/struct:Net::IMAP::BodyTypeMultipart
+            media_type: "MULTIPART"
+            subtype: "MIXED"
+            parts:
             param:
-            content_id:
-            description:
-            encoding:
-            size:
-            md5:
             disposition:
             language:
+            location:
             extension:
       raw_data: "* 1038 FETCH (BODY (\"MIXED\"))\r\n"
 
   test_bodystructure_bug8167_delivery_status_with_extra_data:
     :comment: |
       [Bug #8167]
-    :response: &bug8167 "* 29021 FETCH (RFC822.SIZE 3162 UID 113622 RFC822.HEADER {1155}\r\nReturn-path:
+    :response: "* 29021 FETCH (RFC822.SIZE 3162 UID 113622 RFC822.HEADER {1155}\r\nReturn-path:
       <>\r\nEnvelope-to: info@xxxxxxxx.si\r\nDelivery-date: Tue, 26 Mar 2013 12:42:58
       +0100\r\nReceived: from mail by xxxx.xxxxxxxxxxx.net with spam-scanned (Exim
       4.76)\r\n\tid 1UKSHI-000Cwl-AR\r\n\tfor info@xxxxxxxx.si; Tue, 26 Mar 2013 12:42:58
@@ -194,9 +202,9 @@
               md5:
               disposition:
               language:
+              location:
               extension:
-              -
-            - !ruby/struct:Net::IMAP::BodyTypeMessage
+            - !ruby/struct:Net::IMAP::BodyTypeBasic
               media_type: MESSAGE
               subtype: DELIVERY-STATUS
               param:
@@ -204,12 +212,10 @@
               description: Delivery report
               encoding: 7BIT
               size: 410
-              envelope:
-              body:
-              lines:
               md5:
               disposition:
               language:
+              location:
               extension:
             - !ruby/struct:Net::IMAP::BodyTypeText
               media_type: TEXT
@@ -224,16 +230,36 @@
               md5:
               disposition:
               language:
+              location:
               extension:
-              -
             param:
               REPORT-TYPE: delivery-status
               BOUNDARY: 27797BEA649.1364298175/xxxxxx.localdomain
             disposition:
             language:
+            location:
             extension:
-            -
-      raw_data: *bug8167
+      raw_data: "* 29021 FETCH (RFC822.SIZE 3162 UID 113622 RFC822.HEADER {1155}\r\nReturn-path:
+        <>\r\nEnvelope-to: info@xxxxxxxx.si\r\nDelivery-date: Tue, 26 Mar 2013 12:42:58
+        +0100\r\nReceived: from mail by xxxx.xxxxxxxxxxx.net with spam-scanned (Exim
+        4.76)\r\n\tid 1UKSHI-000Cwl-AR\r\n\tfor info@xxxxxxxx.si; Tue, 26 Mar 2013
+        12:42:58 +0100\r\nX-Spam-Checker-Version: SpamAssassin 3.3.1 (2010-03-16)
+        on xxxx.xxxxxxxxxxx.net\r\nX-Spam-Level: **\r\nX-Spam-Status: No, score=2.1
+        required=7.0 tests=DKIM_ADSP_NXDOMAIN,RDNS_NONE\r\n\tautolearn=no version=3.3.1\r\nReceived:
+        from [xx.xxx.xxx.xx] (port=56890 helo=xxxxxx.localdomain)\r\n\tby xxxx.xxxxxxxxxxx.net
+        with esmtp (Exim 4.76)\r\n\tid 1UKSHI-000Cwi-9j\r\n\tfor info@xxxxxxxx.si;
+        Tue, 26 Mar 2013 12:42:56 +0100\r\nReceived: by xxxxxx.localdomain (Postfix)\r\n\tid
+        72725BEA64A; Tue, 26 Mar 2013 12:42:55 +0100 (CET)\r\nDate: Tue, 26 Mar 2013
+        12:42:55 +0100 (CET)\r\nFrom: MAILER-DAEMON@xxxxxx.localdomain (Mail Delivery
+        System)\r\nSubject: Undelivered Mail Returned to Sender\r\nTo: info@xxxxxxxx.si\r\nAuto-Submitted:
+        auto-replied\r\nMIME-Version: 1.0\r\nContent-Type: multipart/report; report-type=delivery-status;\r\n\tboundary=\"27797BEA649.1364298175/xxxxxx.localdomain\"\r\nMessage-Id:
+        <20130326114255.72725BEA64A@xxxxxx.localdomain>\r\n\r\n BODYSTRUCTURE ((\"text\"
+        \"plain\" (\"charset\" \"us-ascii\") NIL \"Notification\" \"7bit\" 510 14
+        NIL NIL NIL NIL)(\"message\" \"delivery-status\" NIL NIL \"Delivery report\"
+        \"7bit\" 410 NIL NIL NIL NIL)(\"text\" \"rfc822-headers\" (\"charset\" \"us-ascii\")
+        NIL \"Undelivered Message Headers\" \"7bit\" 612 15 NIL NIL NIL NIL) \"report\"
+        (\"report-type\" \"delivery-status\" \"boundary\" \"27797BEA649.1364298175/xxxxxx.localdomain\")
+        NIL NIL NIL))\r\n"
 
   test_bodystructure_bug11128_ext_mpart_without_lang:
     :comment: |
@@ -271,8 +297,8 @@
                 md5:
                 disposition:
                 language:
+                location:
                 extension:
-                -
               - !ruby/struct:Net::IMAP::BodyTypeText
                 media_type: TEXT
                 subtype: HTML
@@ -286,12 +312,13 @@
                 md5:
                 disposition:
                 language:
+                location:
                 extension:
-                -
               param:
                 BOUNDARY: 001a1137a5047848dd05157ddaa1
               disposition:
               language:
+              location:
               extension:
             - !ruby/struct:Net::IMAP::BodyTypeBasic
               media_type: APPLICATION
@@ -309,12 +336,13 @@
                 param:
                   FILENAME: test.xml
               language:
+              location:
               extension:
-              -
             param:
               BOUNDARY: 001a1137a5047848e405157ddaa3
             disposition:
             language:
+            location:
             extension:
       raw_data: "* 4 FETCH (BODY (((\"text\" \"plain\" (\"charset\" \"utf-8\") NIL
         NIL \"7bit\" 257 9 NIL NIL NIL NIL)(\"text\" \"html\" (\"charset\" \"utf-8\")
@@ -325,7 +353,7 @@
         (\"boundary\" \"001a1137a5047848e405157ddaa3\") NIL))\r\n"
 
   test_bodystructure_mixed_boundary:
-    :response: &mixed "* 2688 FETCH (UID 179161 BODYSTRUCTURE ((\"TEXT\" \"PLAIN\" (\"CHARSET\"
+    :response: "* 2688 FETCH (UID 179161 BODYSTRUCTURE ((\"TEXT\" \"PLAIN\" (\"CHARSET\"
       \"iso-8859-1\") NIL NIL \"QUOTED-PRINTABLE\" 200 4 NIL NIL NIL)(\"MESSAGE\"
       \"DELIVERY-STATUS\" NIL NIL NIL \"7BIT\" 318 NIL NIL NIL)(\"MESSAGE\" \"RFC822\"
       NIL NIL NIL \"7BIT\" 2177 (\"Tue, 11 May 2010 18:28:16 -0400\" \"Re: Welcome
@@ -359,8 +387,9 @@
               md5:
               disposition:
               language:
+              location:
               extension:
-            - !ruby/struct:Net::IMAP::BodyTypeMessage
+            - !ruby/struct:Net::IMAP::BodyTypeBasic
               media_type: MESSAGE
               subtype: DELIVERY-STATUS
               param:
@@ -368,12 +397,10 @@
               description:
               encoding: 7BIT
               size: 318
-              envelope:
-              body:
-              lines:
               md5:
               disposition:
               language:
+              location:
               extension:
             - !ruby/struct:Net::IMAP::BodyTypeMessage
               media_type: MESSAGE
@@ -414,36 +441,49 @@
                 bcc:
                 in_reply_to: "<AC1D15E06EA82F47BDE18E851CC32F330717704E@localdomain>"
                 message_id: "<AANLkTikKMev1I73L2E7XLjRs67IHrEkb23f7ZPmD4S_9@localdomain>"
-              body: !ruby/struct:Net::IMAP::BodyTypeBasic
+              body: !ruby/struct:Net::IMAP::BodyTypeMultipart
                 media_type: MULTIPART
                 subtype: MIXED
+                parts:
                 param:
                   BOUNDARY: 000e0cd29212e3e06a0486590ae2
-                content_id:
-                description:
-                encoding:
-                size:
-                md5:
                 disposition:
                 language:
+                location:
                 extension:
               lines: 37
               md5:
               disposition:
               language:
+              location:
               extension:
             param:
               BOUNDARY: 16DuG.4XbaNOvCi.9ggvq.8Ipnyp3
               REPORT-TYPE: delivery-status
             disposition:
             language:
+            location:
             extension:
-      raw_data: *mixed
+      raw_data: "* 2688 FETCH (UID 179161 BODYSTRUCTURE ((\"TEXT\" \"PLAIN\" (\"CHARSET\"
+        \"iso-8859-1\") NIL NIL \"QUOTED-PRINTABLE\" 200 4 NIL NIL NIL)(\"MESSAGE\"
+        \"DELIVERY-STATUS\" NIL NIL NIL \"7BIT\" 318 NIL NIL NIL)(\"MESSAGE\" \"RFC822\"
+        NIL NIL NIL \"7BIT\" 2177 (\"Tue, 11 May 2010 18:28:16 -0400\" \"Re: Welcome
+        letter\" ((\"David\" NIL \"info\" \"xxxxxxxx.si\")) ((\"David\" NIL \"info\"
+        \"xxxxxxxx.si\")) ((\"David\" NIL \"info\" \"xxxxxxxx.si\")) ((\"Doretha\"
+        NIL \"doretha.info\" \"xxxxxxxx.si\")) NIL NIL \"<AC1D15E06EA82F47BDE18E851CC32F330717704E@localdomain>\"
+        \"<AANLkTikKMev1I73L2E7XLjRs67IHrEkb23f7ZPmD4S_9@localdomain>\") (\"MIXED\"
+        (\"BOUNDARY\" \"000e0cd29212e3e06a0486590ae2\") NIL NIL) 37 NIL NIL NIL) \"REPORT\"
+        (\"BOUNDARY\" \"16DuG.4XbaNOvCi.9ggvq.8Ipnyp3\" \"REPORT-TYPE\" \"delivery-status\")
+        NIL NIL))\r\n"
 
   test_invalid_bodystructure_message_sent_as_basic:
     :comment: |
       [Bug #6397] [ruby-core:44849]
-    :response: &attachment "* 980 FETCH (UID 2862 BODYSTRUCTURE (((\"TEXT\" \"PLAIN\" (\"CHARSET\"
+
+      This was originally the test case for BodyTypeAttachment.  But it has been
+      changed to interpret it as sending body-type-basic when it should have
+      sent body-type-msg.  This makes much more sense of the result.
+    :response: "* 980 FETCH (UID 2862 BODYSTRUCTURE (((\"TEXT\" \"PLAIN\" (\"CHARSET\"
       \"iso-8859-1\") NIL NIL \"7BIT\" 416 21 NIL NIL NIL)(\"TEXT\" \"HTML\" (\"CHARSET\"
       \"iso-8859-1\") NIL NIL \"7BIT\" 1493 32 NIL NIL NIL) \"ALTERNATIVE\" (\"BOUNDARY\"
       \"Boundary_(ID_IaecgfnXwG5bn3x8lIeGIQ)\") NIL NIL)(\"MESSAGE\" \"RFC822\" (\"NAME\"
@@ -477,6 +517,7 @@
                 md5:
                 disposition:
                 language:
+                location:
                 extension:
               - !ruby/struct:Net::IMAP::BodyTypeText
                 media_type: TEXT
@@ -491,13 +532,15 @@
                 md5:
                 disposition:
                 language:
+                location:
                 extension:
               param:
                 BOUNDARY: Boundary_(ID_IaecgfnXwG5bn3x8lIeGIQ)
               disposition:
               language:
+              location:
               extension:
-            - !ruby/struct:Net::IMAP::BodyTypeMessage
+            - !ruby/struct:Net::IMAP::BodyTypeBasic
               media_type: MESSAGE
               subtype: RFC822
               param:
@@ -506,20 +549,24 @@
               description:
               encoding: 7BIT
               size: 1980088
-              envelope:
-              body: !ruby/struct:Net::IMAP::BodyTypeAttachment
+              md5:
+              disposition: !ruby/struct:Net::IMAP::ContentDisposition
                 dsp_type: ATTACHMENT
-                _unused_:
                 param:
                   FILENAME: Fw_ ____ _____ ____.eml
-              lines:
-              md5:
-              disposition:
               language:
+              location:
               extension:
             param:
               BOUNDARY: Boundary_(ID_eDdLc/j0mBIzIlR191pHjA)
             disposition:
             language:
+            location:
             extension:
-      raw_data: *attachment
+      raw_data: "* 980 FETCH (UID 2862 BODYSTRUCTURE (((\"TEXT\" \"PLAIN\" (\"CHARSET\"
+        \"iso-8859-1\") NIL NIL \"7BIT\" 416 21 NIL NIL NIL)(\"TEXT\" \"HTML\" (\"CHARSET\"
+        \"iso-8859-1\") NIL NIL \"7BIT\" 1493 32 NIL NIL NIL) \"ALTERNATIVE\" (\"BOUNDARY\"
+        \"Boundary_(ID_IaecgfnXwG5bn3x8lIeGIQ)\") NIL NIL)(\"MESSAGE\" \"RFC822\"
+        (\"NAME\" \"Fw_ ____ _____ ____.eml\") NIL NIL \"7BIT\" 1980088 NIL (\"ATTACHMENT\"
+        (\"FILENAME\" \"Fw_ ____ _____ ____.eml\")) NIL) \"MIXED\" (\"BOUNDARY\" \"Boundary_(ID_eDdLc/j0mBIzIlR191pHjA)\")
+        NIL NIL))\r\n"

--- a/test/net/imap/fixtures/response_parser/namespace_responses.yml
+++ b/test/net/imap/fixtures/response_parser/namespace_responses.yml
@@ -49,9 +49,7 @@
       raw_data: *rfc2342_ex5_3
 
   NAMESPACE_rfc2342_example_5.4:
-    # WARNING: this example is wrong and will be fixed soon...
-    :response: &rfc2342_ex5_4 "* NAMESPACE ((\"\" \"/\")) ((\"~\" \"/\")) ((\"#shared/\" \"/\") (\"#public/\"
-      \"/\") (\"#ftp/\" \"/\") (\"#news.\" \".\"))\r\n"
+    :response: &rfc2342_ex5_4 "* NAMESPACE ((\"\" \"/\")) ((\"~\" \"/\")) ((\"#shared/\" \"/\")(\"#public/\" \"/\")(\"#ftp/\" \"/\")(\"#news.\" \".\"))\r\n"
     :expected: !ruby/struct:Net::IMAP::UntaggedResponse
       name: NAMESPACE
       data: !ruby/struct:Net::IMAP::Namespaces
@@ -100,7 +98,7 @@
       raw_data: *rfc2342_ex5_5
 
   NAMESPACE_rfc2342_example_5.6:
-    :response: &rfc2342_ex5_6 "* NAMESPACE ((\"\" \"/\") (\"#mh/\" \"/\" \"X-PARAM\" (\"FLAG1\" \"FLAG2\")))
+    :response: &rfc2342_ex5_6 "* NAMESPACE ((\"\" \"/\")(\"#mh/\" \"/\" \"X-PARAM\" (\"FLAG1\" \"FLAG2\")))
       NIL NIL\r\n"
     :expected: !ruby/struct:Net::IMAP::UntaggedResponse
       name: NAMESPACE

--- a/test/net/imap/fixtures/response_parser/utf8_responses.yml
+++ b/test/net/imap/fixtures/response_parser/utf8_responses.yml
@@ -1,0 +1,23 @@
+
+---
+:tests:
+
+  test_utf8_in_list_mailbox:
+    :response: "* LIST () \"/\" \"☃️&☺️\"\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: LIST
+      data: !ruby/struct:Net::IMAP::MailboxList
+        attr: []
+        delim: "/"
+        name: "☃️&☺️"
+      raw_data: !binary |-
+        KiBMSVNUICgpICIvIiAi4piD77iPJuKYuu+4jyINCg==
+
+  test_utf8_in_resp_text:
+    :response: "* OK 𝖀𝖓𝖎𝖈𝖔𝖉𝖊 «α-ω» ほげ ふが ʇɐɥʍ\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: OK
+      data: !ruby/struct:Net::IMAP::ResponseText
+        text: "𝖀𝖓𝖎𝖈𝖔𝖉𝖊 «α-ω» ほげ ふが ʇɐɥʍ"
+      raw_data: !binary |-
+        KiBPSyDwnZaA8J2Wk/Cdlo7wnZaI8J2WlPCdlonwnZaKIMKrzrEtz4nCuyDjgbvjgZIg44G144 GMIMqHyZDJpcqNDQo=

--- a/test/net/imap/net_imap_test_helpers.rb
+++ b/test/net/imap/net_imap_test_helpers.rb
@@ -40,7 +40,7 @@ module NetIMAPTestHelpers
         case type
 
         when :parser_assert_equal
-          response = test.fetch(:response)
+          response = test.fetch(:response).force_encoding "ASCII-8BIT"
           expected = test.fetch(:expected)
 
           define_method name do

--- a/test/net/imap/test_imap_response_parser.rb
+++ b/test/net/imap/test_imap_response_parser.rb
@@ -31,6 +31,9 @@ class IMAPResponseParserTest < Test::Unit::TestCase
   # Core IMAP, by RFC9051 section (w/obsolete in relative RFC3501 section):
   generate_tests_from fixture_file: "rfc3501_examples.yml"
 
+  # §4.3: Strings (also §5.1, §9, and RFC6855):
+  generate_tests_from fixture_file: "utf8_responses.yml"
+
   # §7.1: Generic Status Responses (OK, NO, BAD, PREAUTH, BYE, codes, text)
   generate_tests_from fixture_file: "resp_code_examples.yml"
   generate_tests_from fixture_file: "resp_cond_examples.yml"


### PR DESCRIPTION
These parser updates share some of their foundations, and would have many conflicts in separate PRs.  So, even though it's several different features, bug fixes, or refactorings, it's simplest to combine them.  They also fix some existing issues and lay foundations for various other features I've worked on.

This also showcases the coding style I've been using.  It isn't my normal style... my standard rubocop config would complain! 😉 But I *personally* found that it was much easier to compare code to ABNF this way, while still staying within a simple recursive descent, predictive parser paradigm.  @shugo (and anyone else), please let me know if this style is off-putting or confusing, and you think it should be changed to a less "clever" style.  I have also started some simple experiments with e.g. racc and ragel, and parser combinators, and other more complex code generation, and even meta-programmed method inlining... but I'd prefer to avoid that added complexity, at least for now. 😉

My preliminary benchmarks were all positive.  No *enormous* speedups, but in most cases a little bit faster.  I'll edit this description with some of the relevant benchmarks later.  In particular, I wanted to avoid any code generation with `eval` unless the benchmarks justify it (but I think they do).

-----

### ✨ Make text in resp-text optional (IMAP4rev2): fe9ded88
_moved to #111_

RFC3501 (IMAP4rev1):

    resp-text       = ["[" resp-text-code "]" SP] text

RFC9051 (IMAP4rev2):

    resp-text       = "[" resp-text-code "]" SP] [text]

And in Appendix E:

    23.  resp-text ABNF non-terminal was updated to allow for empty text.

In the spirit of Appendix E. 23 (and based on some actual server responses I've seen over the years), I've leniently re-interpreted this as also allowing us to drop the trailing `SP` char after `[resp-text-code parsable code data]`, like so:

    resp-text       = ["[" resp-text-code "]" [SP [text]] / [text]

_Actually, the original parser **already** mostly behaved this way, because the original regexps for `T_TEXT` used `*` and not `+`._  But, as I updated the parser in many other places to more closely match the RFCs, I _broke_ this behavior.  This commit originally came after many many other changes.  But, while rebasing, I moved this commit first because it simplified later commits.

Also:
* ♻️ Add `Patterns` module, to organize regexps.
* ♻️ Use `Patterns::CharClassSubtraction` refinement to simplify exceptions.
* ♻️ Add `ParserUtils::Generator#def_char_matchers` to define `SP`, `LBRA`, `RBRA`.
* ♻️ Add `ParserUtils#{match,accept}_re` to replace `TEXT`, `CTEXT` lex states.
* ♻️ Remove unused `lex_state` kwarg from `match`

### ✨ Add UTF-8 support for quoted and text: f30690e2
_moved to #111_

The parser update supports both RFC6855 (`UTF8=ALLOW`, `UTF8=ONLY`) _and_ the extra UTF8 requirements of `IMAP4rev2` (the human-readable `text` in `resp-text`).

Also updated `#enable` documentation and method signature:
* 📖 Document `UTF8=ACCEPT` as "supported"
* ♻️ Use `*rest` args => flatten => map(aliases) => uniq
* ✨ Add `:utf8` as an alias for `UTF8=ACCEPT`

### 🐛⚡♻️ NAMESPACE: fix parsing (not SP-delimited!): 5f080554
_moved to #112_

I misread or misunderstood the spec when I first implemented this...!
I wrongly inserted `SP`-delimiters.  Most servers don't list more than one
namespace, so I guess that very few noticed the bug!

Also:
* ♻️ Rewrote using "new parser style" to more directly imitate the ABNF.
* ⚡ Small but measurable performance improvement.
* ♻️ Add `ParserUtils::Generator#def_token_matchers` for `quoted`, `string`, `nil`, `tagged_ext_label`, etc.
* ♻️ Move `atom`, `astring`, `nstring`, etc to top, so they can be aliased.
* ♻️ Use `NIL?` in nstring, nquoted

### ✨🐛 Update FETCH BODYSTRUCTURE msg-att parser: a4492435
_moved to #113_

✨ Add missing `location` extension data.  This was missing from RFC2060 but part of RFC3501.
It was also missing from `Net::IMAP`... until now! 😄

🐛 Fix many bugs.  Most importantly:
* More strict about where `NIL` is allowed, e.g: `number`, `envelope`, and `body`.  Ignoring these rare server bugs made it difficult to workaround much more common server bugs elsewhere.
* 🗑️ `BodyTypeAttachment` and `BodyTypeExtension` won't be returned any more and the constants have been deprecated.
* Better workaround for multipart parts with... zero parts.

🚧 TODO: Although this will parse *most* strange `BODYSTRUCTURE` `msg-att` found in the wild, a future PR will backtrack on parse errors and try one or more "fool-proof" algorithms that partially parse *nearly* all invalid body structures sent by buggy servers... even in pathological cases, such as when servers send the message-id as a quoted string
containing unescaped quotation marks!

Also:
* ♻️ Add `lookahead` and `peek` methods to `def_char_matchers`, and `peek_str?`, `peek_re`, for matching without consuming and using `MatchData`.
* ♻️ rename `case_insensitive__string` to match new parser style.
* ♻️ add `number64` aliases. (size is unenforced)