### PR TITLE
✨ Parse UTF-8 encoded strings, for UTF8=ACCEPT and IMAP4rev2

### DIFF
--- a/benchmarks/generate_parser_benchmarks
+++ b/benchmarks/generate_parser_benchmarks
@@ -28,7 +28,8 @@ init = <<RUBY
   require "net/imap"
 
   def load_response(file, name)
-    YAML.unsafe_load_file(file).dig(:tests, name, :response) \\
+    YAML.unsafe_load_file(file).dig(:tests, name, :response)
+      .force_encoding "ASCII-8BIT" \\
       or abort "ERRORO: missing %p fixture data in %p" % [name, file]
   end
 

--- a/benchmarks/parser.yml
+++ b/benchmarks/parser.yml
@@ -4,7 +4,8 @@ prelude: |2
     require "net/imap"
 
     def load_response(file, name)
-      YAML.unsafe_load_file(file).dig(:tests, name, :response) \
+      YAML.unsafe_load_file(file).dig(:tests, name, :response)
+        .force_encoding "ASCII-8BIT" \
         or abort "ERRORO: missing %p fixture data in %p" % [name, file]
     end
 
@@ -559,6 +560,16 @@ benchmark:
   prelude: |2
       response = load_response("../test/net/imap/fixtures/response_parser/thread_responses.yml",
                                "thread_rfc5256_example5")
+  script: parser.parse(response)
+- name: utf8_in_list_mailbox
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/utf8_responses.yml",
+                               "test_utf8_in_list_mailbox")
+  script: parser.parse(response)
+- name: utf8_in_resp_text
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/utf8_responses.yml",
+                               "test_utf8_in_resp_text")
   script: parser.parse(response)
 - name: xlist_inbox
   prelude: |2

--- a/lib/net/imap/response_parser/parser_utils.rb
+++ b/lib/net/imap/response_parser/parser_utils.rb
@@ -8,26 +8,58 @@ module Net
       # (internal API, subject to change)
       module ParserUtils # :nodoc:
 
+        module Generator
+
+          LOOKAHEAD = "(@token ||= next_token)"
+          SHIFT_TOKEN = "(@token = nil)"
+
+          # we can skip lexer for single character matches, as a shortcut
+          def def_char_matchers(name, char, token)
+            match_name = name.match(/\A[A-Z]/) ? "#{name}!" : name
+            char = char.dump
+            class_eval <<~RUBY, __FILE__, __LINE__ + 1
+              # frozen_string_literal: true
+
+              # like accept(token_symbols); returns token or nil
+              def #{name}?
+                if @token&.symbol == #{token}
+                  #{SHIFT_TOKEN}
+                  #{char}
+                elsif !@token && @str[@pos] == #{char}
+                  @pos += 1
+                  #{char}
+                end
+              end
+
+              # like match(token_symbols); returns token or raises parse_error
+              def #{match_name}
+                if @token&.symbol == #{token}
+                  #{SHIFT_TOKEN}
+                  #{char}
+                elsif !@token && @str[@pos] == #{char}
+                  @pos += 1
+                  #{char}
+                else
+                  parse_error("unexpected %s (expected %p)",
+                              @token&.symbol || @str[@pos].inspect, #{char})
+                end
+              end
+            RUBY
+          end
+
+        end
+
         private
 
-        def match(*args, lex_state: @lex_state)
-          if @token && lex_state != @lex_state
-            parse_error("invalid lex_state change to %s with unconsumed token",
-                        lex_state)
+        def match(*args)
+          token = lookahead
+          unless args.include?(token.symbol)
+            parse_error('unexpected token %s (expected %s)',
+                        token.symbol.id2name,
+                        args.collect {|i| i.id2name}.join(" or "))
           end
-          begin
-            @lex_state, original_lex_state = lex_state, @lex_state
-            token = lookahead
-            unless args.include?(token.symbol)
-              parse_error('unexpected token %s (expected %s)',
-                          token.symbol.id2name,
-                          args.collect {|i| i.id2name}.join(" or "))
-            end
-            shift_token
-            return token
-          ensure
-            @lex_state = original_lex_state
-          end
+          shift_token
+          token
         end
 
         # like match, but does not raise error on failure.
@@ -42,6 +74,14 @@ module Net
           end
         end
 
+        # To be used conditionally:
+        #   assert_no_lookahead if Net::IMAP.debug
+        def assert_no_lookahead
+          @token.nil? or
+            parse_error("assertion failed: expected @token.nil?, actual %s: %p",
+                        @token.symbol, @token.value)
+        end
+
         # like accept, without consuming the token
         def lookahead?(*symbols)
           @token if symbols.include?((@token ||= next_token)&.symbol)
@@ -49,6 +89,22 @@ module Net
 
         def lookahead
           @token ||= next_token
+        end
+
+        def accept_re(re)
+          assert_no_lookahead if Net::IMAP.debug
+          re.match(@str, @pos) and @pos = $~.end(0)
+          $~
+        end
+
+        def match_re(re, name)
+          assert_no_lookahead if Net::IMAP.debug
+          if re.match(@str, @pos)
+            @pos = $~.end(0)
+            $~
+          else
+            parse_error("invalid #{name}")
+          end
         end
 
         def shift_token

--- a/test/net/imap/fixtures/response_parser/utf8_responses.yml
+++ b/test/net/imap/fixtures/response_parser/utf8_responses.yml
@@ -1,0 +1,23 @@
+
+---
+:tests:
+
+  test_utf8_in_list_mailbox:
+    :response: "* LIST () \"/\" \"☃️&☺️\"\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: LIST
+      data: !ruby/struct:Net::IMAP::MailboxList
+        attr: []
+        delim: "/"
+        name: "☃️&☺️"
+      raw_data: !binary |-
+        KiBMSVNUICgpICIvIiAi4piD77iPJuKYuu+4jyINCg==
+
+  test_utf8_in_resp_text:
+    :response: "* OK 𝖀𝖓𝖎𝖈𝖔𝖉𝖊 «α-ω» ほげ ふが ʇɐɥʍ\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: OK
+      data: !ruby/struct:Net::IMAP::ResponseText
+        text: "𝖀𝖓𝖎𝖈𝖔𝖉𝖊 «α-ω» ほげ ふが ʇɐɥʍ"
+      raw_data: !binary |-
+        KiBPSyDwnZaA8J2Wk/Cdlo7wnZaI8J2WlPCdlonwnZaKIMKrzrEtz4nCuyDjgbvjgZIg44G144 GMIMqHyZDJpcqNDQo=

--- a/test/net/imap/net_imap_test_helpers.rb
+++ b/test/net/imap/net_imap_test_helpers.rb
@@ -40,7 +40,7 @@ module NetIMAPTestHelpers
         case type
 
         when :parser_assert_equal
-          response = test.fetch(:response)
+          response = test.fetch(:response).force_encoding "ASCII-8BIT"
           expected = test.fetch(:expected)
 
           define_method name do

--- a/test/net/imap/test_imap_response_parser.rb
+++ b/test/net/imap/test_imap_response_parser.rb
@@ -31,6 +31,9 @@ class IMAPResponseParserTest < Test::Unit::TestCase
   # Core IMAP, by RFC9051 section (w/obsolete in relative RFC3501 section):
   generate_tests_from fixture_file: "rfc3501_examples.yml"
 
+  # §4.3: Strings (also §5.1, §9, and RFC6855):
+  generate_tests_from fixture_file: "utf8_responses.yml"
+
   # §7.1: Generic Status Responses (OK, NO, BAD, PREAUTH, BYE, codes, text)
   generate_tests_from fixture_file: "resp_code_examples.yml"
   generate_tests_from fixture_file: "resp_cond_examples.yml"


### PR DESCRIPTION
Split off from #104, this PR updates how `text` and `quoted` are handled (without the other bugfixes and updates in that PR).

* Fixes #110
* Fixes #38
* Fixes #109