### PR TITLE
🐛 Fix NAMESPACE parsing (and other ♻️ refactoring)

### DIFF
--- a/test/net/imap/fixtures/response_parser/namespace_responses.yml
+++ b/test/net/imap/fixtures/response_parser/namespace_responses.yml
@@ -49,9 +49,7 @@
       raw_data: *rfc2342_ex5_3
 
   NAMESPACE_rfc2342_example_5.4:
-    # WARNING: this example is wrong and will be fixed soon...
-    :response: &rfc2342_ex5_4 "* NAMESPACE ((\"\" \"/\")) ((\"~\" \"/\")) ((\"#shared/\" \"/\") (\"#public/\"
-      \"/\") (\"#ftp/\" \"/\") (\"#news.\" \".\"))\r\n"
+    :response: &rfc2342_ex5_4 "* NAMESPACE ((\"\" \"/\")) ((\"~\" \"/\")) ((\"#shared/\" \"/\")(\"#public/\" \"/\")(\"#ftp/\" \"/\")(\"#news.\" \".\"))\r\n"
     :expected: !ruby/struct:Net::IMAP::UntaggedResponse
       name: NAMESPACE
       data: !ruby/struct:Net::IMAP::Namespaces
@@ -100,7 +98,7 @@
       raw_data: *rfc2342_ex5_5
 
   NAMESPACE_rfc2342_example_5.6:
-    :response: &rfc2342_ex5_6 "* NAMESPACE ((\"\" \"/\") (\"#mh/\" \"/\" \"X-PARAM\" (\"FLAG1\" \"FLAG2\")))
+    :response: &rfc2342_ex5_6 "* NAMESPACE ((\"\" \"/\")(\"#mh/\" \"/\" \"X-PARAM\" (\"FLAG1\" \"FLAG2\")))
       NIL NIL\r\n"
     :expected: !ruby/struct:Net::IMAP::UntaggedResponse
       name: NAMESPACE


### PR DESCRIPTION
n.b, this was split off from #104, which was too big for a single PR.

I misread or misunderstood the spec when I first implemented this... I wrongly inserted SP-delimiters.  Most servers don't list more than one namespace, so probably very few noticed the bug!

Also:
* ♻️ Rewrote using "new parser style" to more directly imitate the ABNF.
* ⚡️ Small but measurable performance improvement.
* ♻️ Add ParserUtils::Generator#def_token_matchers for quoted, string, nil, tagged_ext_label, etc.
* ♻️ Move atom, astring, nstring, etc to top, so they can be aliased.
* ♻️ Use NIL in nstring, nquoted