### PR TITLE
🧵 Synchronize @responses update in thread_internal

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -2526,8 +2526,10 @@ module Net
         normalize_searching_criteria(search_keys)
       end
       normalize_searching_criteria(search_keys)
-      send_command(cmd, algorithm, charset, *search_keys)
-      return @responses.delete("THREAD")[-1]
+      synchronize do
+        send_command(cmd, algorithm, charset, *search_keys)
+        @responses.delete("THREAD")[-1]
+      end
     end
 
     def normalize_searching_criteria(keys)


### PR DESCRIPTION
This was the only unsynchronized access of `@responses` that I saw, so long as the private `record_responses` method is only called inside the mutex, or before the initializer returns and the receiver thread has started.