### PR TITLE
🐛 Add missing lookahead_case_insensitive_string!

### DIFF
--- a/lib/net/imap/response_parser/parser_utils.rb
+++ b/lib/net/imap/response_parser/parser_utils.rb
@@ -81,6 +81,16 @@ module Net
             class_eval <<~RUBY, __FILE__, __LINE__ + 1
               # frozen_string_literal: true
 
+              # lookahead version of match, returning the value
+              def lookahead_#{name}!
+                token = #{LOOKAHEAD}
+                if #{matcher}
+                  #{value}
+                else
+                  #{raise_parse_error}
+                end
+              end
+
               def #{name}?
                 token = #{LOOKAHEAD}
                 if #{matcher}
@@ -99,6 +109,7 @@ module Net
                 end
               end
             RUBY
+
           end
 
         end


### PR DESCRIPTION
This adds `lookahead_{token}!` to `def_token_matchers`, as a lookahead version of match, returning the value without consuming the token.

`lookahead_case_insensitive_string!` is a fallback for the regexp in `body_type_1part`.  This fallback should be invoked only very rarely.

Its definition was lost when rebasing.