### PR TITLE
✨ Cache server capabilities and add `#capable?(name)`

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -25,10 +25,8 @@ module Net
 
   # Net::IMAP implements Internet Message Access Protocol (\IMAP) client
   # functionality.  The protocol is described in
-  # [IMAP4rev1[https://tools.ietf.org/html/rfc3501]].
-  #--
-  # TODO: and [IMAP4rev2[https://tools.ietf.org/html/rfc9051]].
-  #++
+  # [IMAP4rev1[https://tools.ietf.org/html/rfc3501]] and
+  # [IMAP4rev2[https://tools.ietf.org/html/rfc9051]].
   #
   # == \IMAP Overview
   #
@@ -77,18 +75,9 @@ module Net
   # UIDs have to be reassigned.  An \IMAP client thus cannot
   # rearrange message orders.
   #
-  # === Server capabilities and protocol extensions
+  # === Examples of Usage
   #
-  # Net::IMAP <em>does not modify its behavior</em> according to server
-  # #capability.  Users of the class must check for required capabilities before
-  # issuing commands.  Special care should be taken to follow all #capability
-  # requirements for #starttls, #login, and #authenticate.
-  #
-  # See the #capability method for more information.
-  #
-  # == Examples of Usage
-  #
-  # === List sender and subject of all recent messages in the default mailbox
+  # ==== List sender and subject of all recent messages in the default mailbox
   #
   #   imap = Net::IMAP.new('mail.example.com')
   #   imap.authenticate('LOGIN', 'joe_user', 'joes_password')
@@ -98,7 +87,7 @@ module Net
   #     puts "#{envelope.from[0].name}: \t#{envelope.subject}"
   #   end
   #
-  # === Move all messages from April 2003 from "Mail/sent-mail" to "Mail/sent-apr03"
+  # ==== Move all messages from April 2003 from "Mail/sent-mail" to "Mail/sent-apr03"
   #
   #   imap = Net::IMAP.new('mail.example.com')
   #   imap.authenticate('LOGIN', 'joe_user', 'joes_password')
@@ -111,6 +100,15 @@ module Net
   #     imap.store(message_id, "+FLAGS", [:Deleted])
   #   end
   #   imap.expunge
+  #
+  # == Server capabilities and protocol extensions
+  #
+  # Net::IMAP <em>does not modify its behavior</em> according to server
+  # #capability.  Users of the class must check for required capabilities before
+  # issuing commands.  Special care should be taken to follow all #capability
+  # requirements for #starttls, #login, and #authenticate.
+  #
+  # See the #capability method for more information.
   #
   # == Thread Safety
   #
@@ -173,338 +171,23 @@ module Net
   # == What's here?
   #
   # * {Connection control}[rdoc-ref:Net::IMAP@Connection+control+methods]
-  # * {Core IMAP commands}[rdoc-ref:Net::IMAP@Core+IMAP+commands]
-  #   * {...for any state}[rdoc-ref:Net::IMAP@IMAP+commands+for+any+state]
-  #   * {...for the "not authenticated" state}[rdoc-ref:Net::IMAP@IMAP+commands+for+the+-22Not+Authenticated-22+state]
-  #   * {...for the "authenticated" state}[rdoc-ref:Net::IMAP@IMAP+commands+for+the+-22Authenticated-22+state]
-  #   * {...for the "selected" state}[rdoc-ref:Net::IMAP@IMAP+commands+for+the+-22Selected-22+state]
-  #   * {...for the "logout" state}[rdoc-ref:Net::IMAP@IMAP+commands+for+the+-22Logout-22+state]
-  # * {Supported IMAP extensions}[rdoc-ref:Net::IMAP@Supported+IMAP+extensions]
   # * {Handling server responses}[rdoc-ref:Net::IMAP@Handling+server+responses]
+  # * {Core IMAP commands}[rdoc-ref:Net::IMAP@Core+IMAP+commands]
+  #   * {for any state}[rdoc-ref:Net::IMAP@Any+state]
+  #   * {for the "not authenticated" state}[rdoc-ref:Net::IMAP@Not+Authenticated+state]
+  #   * {for the "authenticated" state}[rdoc-ref:Net::IMAP@Authenticated+state]
+  #   * {for the "selected" state}[rdoc-ref:Net::IMAP@Selected+state]
+  #   * {for the "logout" state}[rdoc-ref:Net::IMAP@Logout+state]
+  # * {IMAP extension support}[rdoc-ref:Net::IMAP@IMAP+extension+support]
   #
   # === Connection control methods
   #
-  # - Net::IMAP.new: A new client connects immediately and waits for a
-  #   successful server greeting before returning the new client object.
+  # - Net::IMAP.new: Creates a new \IMAP client which connects immediately and
+  #   waits for a successful server greeting before the method returns.
   # - #starttls: Asks the server to upgrade a clear-text connection to use TLS.
   # - #logout: Tells the server to end the session. Enters the "_logout_" state.
   # - #disconnect: Disconnects the connection (without sending #logout first).
   # - #disconnected?: True if the connection has been closed.
-  #
-  # === Core \IMAP commands
-  #
-  # The following commands are defined either by
-  # the [IMAP4rev1[https://tools.ietf.org/html/rfc3501]] base specification, or
-  # by one of the following extensions:
-  # [IDLE[https://tools.ietf.org/html/rfc2177]],
-  # [NAMESPACE[https://tools.ietf.org/html/rfc2342]],
-  # [UNSELECT[https://tools.ietf.org/html/rfc3691]],
-  # [ENABLE[https://tools.ietf.org/html/rfc5161]],
-  #--
-  # TODO: [LIST-EXTENDED[https://tools.ietf.org/html/rfc5258]],
-  # TODO: [LIST-STATUS[https://tools.ietf.org/html/rfc5819]],
-  #++
-  # [MOVE[https://tools.ietf.org/html/rfc6851]].
-  # These extensions are widely supported by modern IMAP4rev1 servers and have
-  # all been integrated into [IMAP4rev2[https://tools.ietf.org/html/rfc9051]].
-  # <em>Note: Net::IMAP doesn't fully support IMAP4rev2 yet.</em>
-  #
-  #--
-  # TODO: When IMAP4rev2 is supported, add the following to the each of the
-  # appropriate commands below.
-  #   Note:: CHECK has been removed from IMAP4rev2.
-  #   Note:: LSUB is obsoleted by +LIST-EXTENDED and has been removed from IMAP4rev2.
-  #   <em>Some arguments require the +LIST-EXTENDED+ or +IMAP4rev2+ capability.</em>
-  #   <em>Requires either the +ENABLE+    or +IMAP4rev2+ capability.</em>
-  #   <em>Requires either the +NAMESPACE+ or +IMAP4rev2+ capability.</em>
-  #   <em>Requires either the +IDLE+      or +IMAP4rev2+ capability.</em>
-  #   <em>Requires either the +UNSELECT+  or +IMAP4rev2+ capability.</em>
-  #   <em>Requires either the +UIDPLUS+   or +IMAP4rev2+ capability.</em>
-  #   <em>Requires either the +MOVE+      or +IMAP4rev2+ capability.</em>
-  #++
-  #
-  # ==== \IMAP commands for any state
-  #
-  # - #capability: Returns the server's capabilities as an array of strings.
-  #
-  #   <em>Capabilities may change after</em> #starttls, #authenticate, or #login
-  #   <em>and cached capabilities must be reloaded.</em>
-  # - #noop: Allows the server to send unsolicited untagged #responses.
-  # - #logout: Tells the server to end the session. Enters the "_logout_" state.
-  #
-  # ==== \IMAP commands for the "Not Authenticated" state
-  #
-  # In addition to the universal commands, the following commands are valid in
-  # the "<em>not authenticated</em>" state:
-  #
-  # - #starttls: Upgrades a clear-text connection to use TLS.
-  #
-  #   <em>Requires the +STARTTLS+ capability.</em>
-  # - #authenticate: Identifies the client to the server using a {SASL
-  #   mechanism}[https://www.iana.org/assignments/sasl-mechanisms/sasl-mechanisms.xhtml].
-  #   Enters the "_authenticated_" state.
-  #
-  #   <em>Requires the <tt>AUTH=#{mechanism}</tt> capability for the chosen
-  #   mechanism.</em>
-  # - #login: Identifies the client to the server using a plain text password.
-  #   Using #authenticate is generally preferred.  Enters the "_authenticated_"
-  #   state.
-  #
-  #   <em>The +LOGINDISABLED+ capability</em> <b>must NOT</b> <em>be listed.</em>
-  #
-  # ==== \IMAP commands for the "Authenticated" state
-  #
-  # In addition to the universal commands, the following commands are valid in
-  # the "_authenticated_" state:
-  #
-  # - #enable: Enables backwards incompatible server extensions.
-  #
-  #   <em>Requires the +ENABLE+ capability.</em>
-  # - #select:  Open a mailbox and enter the "_selected_" state.
-  # - #examine: Open a mailbox read-only, and enter the "_selected_" state.
-  # - #create: Creates a new mailbox.
-  # - #delete: Permanently remove a mailbox.
-  # - #rename: Change the name of a mailbox.
-  # - #subscribe: Adds a mailbox to the "subscribed" set.
-  # - #unsubscribe: Removes a mailbox from the "subscribed" set.
-  # - #list: Returns names and attributes of mailboxes matching a given pattern.
-  # - #namespace: Returns mailbox namespaces, with path prefixes and delimiters.
-  #
-  #   <em>Requires the +NAMESPACE+ capability.</em>
-  # - #status: Returns mailbox information, e.g. message count, unseen message
-  #   count, +UIDVALIDITY+ and +UIDNEXT+.
-  # - #append: Appends a message to the end of a mailbox.
-  # - #idle: Allows the server to send updates to the client, without the client
-  #   needing to poll using #noop.
-  #
-  #   <em>Requires the +IDLE+ capability.</em>
-  # - #lsub: Lists mailboxes the user has declared "active" or "subscribed".
-  #--
-  #   <em>Replaced by</em> <tt>LIST-EXTENDED</tt> <em>and removed from</em>
-  #   +IMAP4rev2+.  <em>However, Net::IMAP hasn't implemented</em>
-  #   <tt>LIST-EXTENDED</tt> _yet_.
-  #++
-  #
-  # ==== \IMAP commands for the "Selected" state
-  #
-  # In addition to the universal commands and the "authenticated" commands, the
-  # following commands are valid in the "_selected_" state:
-  #
-  # - #close: Closes the mailbox and returns to the "_authenticated_" state,
-  #   expunging deleted messages, unless the mailbox was opened as read-only.
-  # - #unselect: Closes the mailbox and returns to the "_authenticated_" state,
-  #   without expunging any messages.
-  #
-  #   <em>Requires the +UNSELECT+ capability.</em>
-  # - #expunge: Permanently removes messages which have the Deleted flag set.
-  # - #uid_expunge: Restricts #expunge to only remove the specified UIDs.
-  #
-  #   <em>Requires the +UIDPLUS+ capability.</em>
-  # - #search, #uid_search: Returns sequence numbers or UIDs of messages that
-  #   match the given searching criteria.
-  # - #fetch, #uid_fetch: Returns data associated with a set of messages,
-  #   specified by sequence number or UID.
-  # - #store, #uid_store: Alters a message's flags.
-  # - #copy, #uid_copy: Copies the specified messages to the end of the
-  #   specified destination mailbox.
-  # - #move, #uid_move: Moves the specified messages to the end of the
-  #   specified destination mailbox, expunging them from the current mailbox.
-  #
-  #   <em>Requires the +MOVE+ capability.</em>
-  # - #check: Mostly obsolete.  Can be replaced with #noop or #idle.
-  #--
-  #   <em>Removed from IMAP4rev2.</em>
-  #++
-  #
-  # ==== \IMAP commands for the "Logout" state
-  #
-  # No \IMAP commands are valid in the +logout+ state.  If the socket is still
-  # open, Net::IMAP will close it after receiving server confirmation.
-  # Exceptions will be raised by \IMAP commands that have already started and
-  # are waiting for a response, as well as any that are called after logout.
-  #
-  # === Supported \IMAP extensions
-  #
-  # ==== RFC9051: +IMAP4rev2+
-  #
-  # Although IMAP4rev2[https://tools.ietf.org/html/rfc9051] is <em>not supported
-  # yet</em>, Net::IMAP supports several extensions that have been folded into
-  # it: +ENABLE+, +IDLE+, +MOVE+, +NAMESPACE+, +UIDPLUS+, and +UNSELECT+.
-  #--
-  # TODO: RFC4466, ABNF extensions (automatic support for other extensions)
-  # TODO: +ESEARCH+, ExtendedSearchData
-  # TODO: +SEARCHRES+,
-  # TODO: +SASL-IR+,
-  # TODO: +LIST-EXTENDED+,
-  # TODO: +LIST-STATUS+,
-  # TODO: +LITERAL-+,
-  # TODO: +BINARY+ (only the FETCH side)
-  # TODO: +SPECIAL-USE+
-  # implicitly supported, but we can do better: Response codes: RFC5530, etc
-  # implicitly supported, but we can do better: <tt>STATUS=SIZE</tt>
-  # implicitly supported, but we can do better: <tt>STATUS DELETED</tt>
-  #++
-  # Commands for these extensions are included with the {Core IMAP
-  # commands}[rdoc-ref:Net::IMAP@Core+IMAP+commands], above.  Other supported
-  # extensons are listed below.
-  #
-  # ==== RFC2087: +QUOTA+
-  # - #getquota: returns the resource usage and limits for a quota root
-  # - #getquotaroot: returns the list of quota roots for a mailbox, as well as
-  #   their resource usage and limits.
-  # - #setquota: sets the resource limits for a given quota root.
-  #
-  # ==== RFC2177: +IDLE+
-  # Folded into IMAP4rev2[https://tools.ietf.org/html/rfc9051], so it is also
-  # listed with {Core IMAP commands}[rdoc-ref:Net::IMAP@Core+IMAP+commands].
-  # - #idle: Allows the server to send updates to the client, without the client
-  #   needing to poll using #noop.
-  #
-  # ==== RFC2342: +NAMESPACE+
-  # Folded into IMAP4rev2[https://tools.ietf.org/html/rfc9051], so it is also
-  # listed with {Core IMAP commands}[rdoc-ref:Net::IMAP@Core+IMAP+commands].
-  # - #namespace: Returns mailbox namespaces, with path prefixes and delimiters.
-  #
-  # ==== RFC2971: +ID+
-  # - #id: exchanges client and server implementation information.
-  #
-  #--
-  # ==== RFC3502: +MULTIAPPEND+
-  # TODO...
-  #++
-  #
-  #--
-  # ==== RFC3516: +BINARY+
-  # TODO...
-  #++
-  #
-  # ==== RFC3691: +UNSELECT+
-  # Folded into IMAP4rev2[https://tools.ietf.org/html/rfc9051], so it is also
-  # listed with {Core IMAP commands}[rdoc-ref:Net::IMAP@Core+IMAP+commands].
-  # - #unselect: Closes the mailbox and returns to the "_authenticated_" state,
-  #   without expunging any messages.
-  #
-  # ==== RFC4314: +ACL+
-  # - #getacl: lists the authenticated user's access rights to a mailbox.
-  # - #setacl: sets the access rights for a user on a mailbox
-  #--
-  # TODO: #deleteacl, #listrights, #myrights
-  #++
-  # - *_Note:_* +DELETEACL+, +LISTRIGHTS+, and +MYRIGHTS+ are not supported yet.
-  #
-  # ==== RFC4315: +UIDPLUS+
-  # Folded into IMAP4rev2[https://tools.ietf.org/html/rfc9051], so it is also
-  # listed with {Core IMAP commands}[rdoc-ref:Net::IMAP@Core+IMAP+commands].
-  # - #uid_expunge: Restricts #expunge to only remove the specified UIDs.
-  # - Updates #select, #examine with the +UIDNOTSTICKY+ ResponseCode
-  # - Updates #append with the +APPENDUID+ ResponseCode
-  # - Updates #copy, #move with the +COPYUID+ ResponseCode
-  #
-  #--
-  # ==== RFC4466: Collected Extensions to IMAP4 ABNF
-  # TODO...
-  # Folded into IMAP4rev2[https://tools.ietf.org/html/rfc9051], this RFC updates
-  # the protocol to enable new optional parameters to many commands: #select,
-  # #examine, #create, #rename, #fetch, #uid_fetch, #store, #uid_store, #search,
-  # #uid_search, and #append.  However, specific parameters are not defined.
-  # Extensions to these commands use this syntax whenever possible.  Net::IMAP
-  # may be partially compatible with extensions to these commands, even without
-  # any explicit support.
-  #++
-  #
-  #--
-  # ==== RFC4731 +ESEARCH+
-  # TODO...
-  # Folded into IMAP4rev2[https://tools.ietf.org/html/rfc9051].
-  # - Updates #search, #uid_search to accept result options: +MIN+, +MAX+,
-  #   +ALL+, +COUNT+, and to return ExtendedSearchData.
-  #++
-  #
-  #--
-  # ==== RFC4959: +SASL-IR+
-  # TODO...
-  # Folded into IMAP4rev2[https://tools.ietf.org/html/rfc9051].
-  # - Updates #authenticate to reduce round-trips for supporting mechanisms.
-  #++
-  #
-  #--
-  # ==== RFC4978: COMPRESS=DEFLATE
-  # TODO...
-  #++
-  #
-  # ==== RFC5161: +ENABLE+
-  # Folded into IMAP4rev2[https://tools.ietf.org/html/rfc9051], so it is also
-  # listed with {Core IMAP commands}[rdoc-ref:Net::IMAP@Core+IMAP+commands].
-  # - #enable: Enables backwards incompatible server extensions.
-  #
-  #--
-  # ==== RFC5182 +SEARCHRES+
-  # TODO...
-  # Folded into IMAP4rev2[https://tools.ietf.org/html/rfc9051].
-  # - Updates #search, #uid_search with the +SAVE+ result option.
-  # - Updates #copy, #uid_copy, #fetch, #uid_fetch, #move, #uid_move, #search,
-  #   #uid_search, #store, #uid_store, and #uid_expunge with ability to
-  #   reference the saved result of a previous #search or #uid_search command.
-  #++
-  #
-  # ==== RFC5256: +SORT+
-  # - #sort, #uid_sort: An alternate version of #search or #uid_search which
-  #   sorts the results by specified keys.
-  # ==== RFC5256: +THREAD+
-  # - #thread, #uid_thread: An alternate version of #search or #uid_search,
-  #   which arranges the results into ordered groups or threads according to a
-  #   chosen algorithm.
-  #
-  #--
-  # ==== RFC5258 +LIST-EXTENDED+
-  # TODO...
-  # Folded into IMAP4rev2[https://tools.ietf.org/html/rfc9051], this updates the
-  # protocol with new optional parameters to the #list command, adding a few of
-  # its own.  Net::IMAP may be forward-compatible with future #list extensions,
-  # even without any explicit support.
-  # - Updates #list to accept selection options: +SUBSCRIBED+, +REMOTE+, and
-  #   +RECURSIVEMATCH+, and return options: +SUBSCRIBED+ and +CHILDREN+.
-  #++
-  #
-  #--
-  # ==== RFC5819 +LIST-STATUS+
-  # TODO...
-  # Folded into IMAP4rev2[https://tools.ietf.org/html/rfc9051].
-  # - Updates #list with +STATUS+ return option.
-  #++
-  #
-  # ==== +XLIST+ (non-standard, deprecated)
-  # - #xlist: replaced by +SPECIAL-USE+ attributes in #list responses.
-  #
-  #--
-  # ==== RFC6154 +SPECIAL-USE+
-  # TODO...
-  # Folded into IMAP4rev2[https://tools.ietf.org/html/rfc9051].
-  # - Updates #list with the +SPECIAL-USE+ selection and return options.
-  #++
-  #
-  # ==== RFC6851: +MOVE+
-  # Folded into IMAP4rev2[https://tools.ietf.org/html/rfc9051], so it is also
-  # listed with {Core IMAP commands}[rdoc-ref:Net::IMAP@Core+IMAP+commands].
-  # - #move, #uid_move: Moves the specified messages to the end of the
-  #   specified destination mailbox, expunging them from the current mailbox.
-  #
-  # ==== RFC6855: <tt>UTF8=ACCEPT</tt>, <tt>UTF8=ONLY</tt>
-  #
-  # - See #enable for information about support for UTF-8 string encoding.
-  #
-  #--
-  # ==== RFC7888: <tt>LITERAL+</tt>, +LITERAL-+
-  # TODO...
-  # ==== RFC7162: +QRESYNC+
-  # TODO...
-  # ==== RFC7162: +CONDSTORE+
-  # TODO...
-  # ==== RFC8474: +OBJECTID+
-  # TODO...
-  # ==== RFC9208: +QUOTA+
-  # TODO...
-  #++
   #
   # === Handling server responses
   #
@@ -518,11 +201,196 @@ module Net
   # - #response_handlers: Returns the list of response handlers.
   # - #remove_response_handler: Remove a previously added response handler.
   #
+  # === Core \IMAP commands
+  #
+  # The following commands are defined either by
+  # the [IMAP4rev1[https://tools.ietf.org/html/rfc3501]] base specification, or
+  # by one of the following extensions:
+  # [IDLE[https://tools.ietf.org/html/rfc2177]],
+  # [NAMESPACE[https://tools.ietf.org/html/rfc2342]],
+  # [UNSELECT[https://tools.ietf.org/html/rfc3691]],
+  # [ENABLE[https://tools.ietf.org/html/rfc5161]],
+  # [MOVE[https://tools.ietf.org/html/rfc6851]].
+  # These extensions are widely supported by modern IMAP4rev1 servers and have
+  # all been integrated into [IMAP4rev2[https://tools.ietf.org/html/rfc9051]].
+  # <em>*NOTE:* Net::IMAP doesn't support IMAP4rev2 yet.</em>
+  #
+  # ==== Any state
+  #
+  # - #capability: Returns the server's capabilities as an array of strings.
+  #
+  #   <em>Capabilities may change after</em> #starttls, #authenticate, or #login
+  #   <em>and cached capabilities must be reloaded.</em>
+  # - #noop: Allows the server to send unsolicited untagged #responses.
+  # - #logout: Tells the server to end the session. Enters the "_logout_" state.
+  #
+  # ==== Not Authenticated state
+  #
+  # In addition to the commands for any state, the following commands are valid
+  # in the "<em>not authenticated</em>" state:
+  #
+  # - #starttls: Upgrades a clear-text connection to use TLS.
+  #
+  #   <em>Requires the +STARTTLS+ capability.</em>
+  # - #authenticate: Identifies the client to the server using the given
+  #   {SASL mechanism}[https://www.iana.org/assignments/sasl-mechanisms/sasl-mechanisms.xhtml]
+  #   and credentials.  Enters the "_authenticated_" state.
+  #
+  #   <em>The server should list <tt>"AUTH=#{mechanism}"</tt> capabilities for
+  #   supported mechanisms.</em>
+  # - #login: Identifies the client to the server using a plain text password.
+  #   Using #authenticate is generally preferred.  Enters the "_authenticated_"
+  #   state.
+  #
+  #   <em>The +LOGINDISABLED+ capability</em> <b>must NOT</b> <em>be listed.</em>
+  #
+  # ==== Authenticated state
+  #
+  # In addition to the commands for any state, the following commands are valid
+  # in the "_authenticated_" state:
+  #
+  # - #enable: Enables backwards incompatible server extensions.
+  #   <em>Requires the +ENABLE+ or +IMAP4rev2+ capability.</em>
+  # - #select:  Open a mailbox and enter the "_selected_" state.
+  # - #examine: Open a mailbox read-only, and enter the "_selected_" state.
+  # - #create: Creates a new mailbox.
+  # - #delete: Permanently remove a mailbox.
+  # - #rename: Change the name of a mailbox.
+  # - #subscribe: Adds a mailbox to the "subscribed" set.
+  # - #unsubscribe: Removes a mailbox from the "subscribed" set.
+  # - #list: Returns names and attributes of mailboxes matching a given pattern.
+  # - #namespace: Returns mailbox namespaces, with path prefixes and delimiters.
+  #   <em>Requires the +NAMESPACE+ or +IMAP4rev2+ capability.</em>
+  # - #status: Returns mailbox information, e.g. message count, unseen message
+  #   count, +UIDVALIDITY+ and +UIDNEXT+.
+  # - #append: Appends a message to the end of a mailbox.
+  # - #idle: Allows the server to send updates to the client, without the client
+  #   needing to poll using #noop.
+  #   <em>Requires the +IDLE+ or +IMAP4rev2+ capability.</em>
+  # - *Obsolete* #lsub: <em>Replaced by <tt>LIST-EXTENDED</tt> and removed from
+  #   +IMAP4rev2+.</em>  Lists mailboxes in the "subscribed" set.
+  #
+  #   <em>*Note:* Net::IMAP hasn't implemented <tt>LIST-EXTENDED</tt> yet.</em>
+  #
+  # ==== Selected state
+  #
+  # In addition to the commands for any state and the "_authenticated_"
+  # commands, the following commands are valid in the "_selected_" state:
+  #
+  # - #close: Closes the mailbox and returns to the "_authenticated_" state,
+  #   expunging deleted messages, unless the mailbox was opened as read-only.
+  # - #unselect: Closes the mailbox and returns to the "_authenticated_" state,
+  #   without expunging any messages.
+  #   <em>Requires the +UNSELECT+ or +IMAP4rev2+ capability.</em>
+  # - #expunge: Permanently removes messages which have the Deleted flag set.
+  # - #uid_expunge: Restricts expunge to only remove the specified UIDs.
+  #   <em>Requires the +UIDPLUS+ or +IMAP4rev2+ capability.</em>
+  # - #search, #uid_search: Returns sequence numbers or UIDs of messages that
+  #   match the given searching criteria.
+  # - #fetch, #uid_fetch: Returns data associated with a set of messages,
+  #   specified by sequence number or UID.
+  # - #store, #uid_store: Alters a message's flags.
+  # - #copy, #uid_copy: Copies the specified messages to the end of the
+  #   specified destination mailbox.
+  # - #move, #uid_move: Moves the specified messages to the end of the
+  #   specified destination mailbox, expunging them from the current mailbox.
+  #   <em>Requires the +MOVE+ or +IMAP4rev2+ capability.</em>
+  # - #check: <em>*Obsolete:* removed from +IMAP4rev2+.</em>
+  #   Can be replaced with #noop or #idle.
+  #
+  # ==== Logout state
+  #
+  # No \IMAP commands are valid in the "_logout_" state.  If the socket is still
+  # open, Net::IMAP will close it after receiving server confirmation.
+  # Exceptions will be raised by \IMAP commands that have already started and
+  # are waiting for a response, as well as any that are called after logout.
+  #
+  # === \IMAP extension support
+  #
+  # ==== RFC9051: +IMAP4rev2+
+  #
+  # Although IMAP4rev2[https://tools.ietf.org/html/rfc9051] is not supported
+  # yet, Net::IMAP supports several extensions that have been folded into it:
+  # +ENABLE+, +IDLE+, +MOVE+, +NAMESPACE+, +UIDPLUS+, and +UNSELECT+.  Commands
+  # for these extensions are listed with the
+  # {Core IMAP commands}[rdoc-ref:Net::IMAP@Core+IMAP+commands], above.
+  #
+  # >>>
+  #   <em>The following are folded into +IMAP4rev2+ but are currently
+  #   unsupported or incompletely supported by</em> Net::IMAP<em>: RFC4466
+  #   extensions, +ESEARCH+, +SEARCHRES+, +SASL-IR+, +LIST-EXTENDED+,
+  #   +LIST-STATUS+, +LITERAL-+, +BINARY+ fetch, and +SPECIAL-USE+.  The
+  #   following extensions are implicitly supported, but will be updated with
+  #   more direct support: RFC5530 response codes, <tt>STATUS=SIZE</tt>, and
+  #   <tt>STATUS=DELETED</tt>.</em>
+  #
+  # ==== RFC2087: +QUOTA+
+  # - #getquota: returns the resource usage and limits for a quota root
+  # - #getquotaroot: returns the list of quota roots for a mailbox, as well as
+  #   their resource usage and limits.
+  # - #setquota: sets the resource limits for a given quota root.
+  #
+  # ==== RFC2177: +IDLE+
+  # Folded into IMAP4rev2[https://tools.ietf.org/html/rfc9051] and also included
+  # above with {Core IMAP commands}[rdoc-ref:Net::IMAP@Core+IMAP+commands].
+  # - #idle: Allows the server to send updates to the client, without the client
+  #   needing to poll using #noop.
+  #
+  # ==== RFC2342: +NAMESPACE+
+  # Folded into IMAP4rev2[https://tools.ietf.org/html/rfc9051] and also included
+  # above with {Core IMAP commands}[rdoc-ref:Net::IMAP@Core+IMAP+commands].
+  # - #namespace: Returns mailbox namespaces, with path prefixes and delimiters.
+  #
+  # ==== RFC2971: +ID+
+  # - #id: exchanges client and server implementation information.
+  #
+  # ==== RFC3691: +UNSELECT+
+  # Folded into IMAP4rev2[https://tools.ietf.org/html/rfc9051] and also included
+  # above with {Core IMAP commands}[rdoc-ref:Net::IMAP@Core+IMAP+commands].
+  # - #unselect: Closes the mailbox and returns to the "_authenticated_" state,
+  #   without expunging any messages.
+  #
+  # ==== RFC4314: +ACL+
+  # - #getacl: lists the authenticated user's access rights to a mailbox.
+  # - #setacl: sets the access rights for a user on a mailbox
+  # >>>
+  #   *NOTE:* +DELETEACL+, +LISTRIGHTS+, and +MYRIGHTS+ are not supported yet.
+  #
+  # ==== RFC4315: +UIDPLUS+
+  # Folded into IMAP4rev2[https://tools.ietf.org/html/rfc9051] and also included
+  # above with {Core IMAP commands}[rdoc-ref:Net::IMAP@Core+IMAP+commands].
+  # - #uid_expunge: Restricts #expunge to only remove the specified UIDs.
+  # - Updates #select, #examine with the +UIDNOTSTICKY+ ResponseCode
+  # - Updates #append with the +APPENDUID+ ResponseCode
+  # - Updates #copy, #move with the +COPYUID+ ResponseCode
+  #
+  # ==== RFC5161: +ENABLE+
+  # Folded into IMAP4rev2[https://tools.ietf.org/html/rfc9051] and also included
+  # above with {Core IMAP commands}[rdoc-ref:Net::IMAP@Core+IMAP+commands].
+  # - #enable: Enables backwards incompatible server extensions.
+  #
+  # ==== RFC5256: +SORT+
+  # - #sort, #uid_sort: An alternate version of #search or #uid_search which
+  #   sorts the results by specified keys.
+  # ==== RFC5256: +THREAD+
+  # - #thread, #uid_thread: An alternate version of #search or #uid_search,
+  #   which arranges the results into ordered groups or threads according to a
+  #   chosen algorithm.
+  #
+  # ==== +XLIST+ (non-standard, deprecated)
+  # - #xlist: replaced by +SPECIAL-USE+ attributes in #list responses.
+  #
+  # ==== RFC6851: +MOVE+
+  # Folded into IMAP4rev2[https://tools.ietf.org/html/rfc9051] and also included
+  # above with {Core IMAP commands}[rdoc-ref:Net::IMAP@Core+IMAP+commands].
+  # - #move, #uid_move: Moves the specified messages to the end of the
+  #   specified destination mailbox, expunging them from the current mailbox.
+  #
+  # ==== RFC6855: <tt>UTF8=ACCEPT</tt>, <tt>UTF8=ONLY</tt>
+  #
+  # - See #enable for information about support for UTF-8 string encoding.
   #
   # == References
-  #--
-  # TODO: Consider moving references list to REFERENCES.md or REFERENCES.rdoc.
-  #++
   #
   # [{IMAP4rev1}[https://www.rfc-editor.org/rfc/rfc3501.html]]::
   #   Crispin, M., "INTERNET MESSAGE ACCESS PROTOCOL - \VERSION 4rev1",
@@ -623,27 +491,21 @@ module Net
   #    RFC 1864, DOI 10.17487/RFC1864, October 1995,
   #    <https://www.rfc-editor.org/info/rfc1864>.
   #
-  #--
-  # TODO: Document IMAP keywords.
+  # [RFC3503[https://tools.ietf.org/html/rfc3503]]::
+  #    Melnikov, A., "Message Disposition Notification (MDN)
+  #    profile for Internet Message Access Protocol (IMAP)",
+  #    RFC 3503, DOI 10.17487/RFC3503, March 2003,
+  #    <https://www.rfc-editor.org/info/rfc3503>.
   #
-  # [RFC3503[https://tools.ietf.org/html/rfc3503]]
-  #   Melnikov, A., "Message Disposition Notification (MDN)
-  #   profile for Internet Message Access Protocol (IMAP)",
-  #   RFC 3503, DOI 10.17487/RFC3503, March 2003,
-  #   <https://www.rfc-editor.org/info/rfc3503>.
-  #++
+  # === \IMAP Extensions
   #
-  # === Supported \IMAP Extensions
-  #
-  # [QUOTA[https://tools.ietf.org/html/rfc2087]]::
-  #   Myers, J., "IMAP4 QUOTA extension", RFC 2087, DOI 10.17487/RFC2087,
-  #   January 1997, <https://www.rfc-editor.org/info/rfc2087>.
-  #--
-  # TODO: test compatibility with updated QUOTA extension:
   # [QUOTA[https://tools.ietf.org/html/rfc9208]]::
   #   Melnikov, A., "IMAP QUOTA Extension", RFC 9208, DOI 10.17487/RFC9208,
   #   March 2022, <https://www.rfc-editor.org/info/rfc9208>.
-  #++
+  #
+  #   <em>Note: obsoletes</em>
+  #   RFC-2087[https://tools.ietf.org/html/rfc2087]<em> (January 1997)</em>.
+  #   <em>Net::IMAP does not fully support the RFC9208 updates yet.</em>
   # [IDLE[https://tools.ietf.org/html/rfc2177]]::
   #   Leiba, B., "IMAP4 IDLE command", RFC 2177, DOI 10.17487/RFC2177,
   #   June 1997, <https://www.rfc-editor.org/info/rfc2177>.
@@ -683,26 +545,24 @@ module Net
   #   <https://www.rfc-editor.org/info/rfc6855>.
   #
   # === IANA registries
-  #
   # * {IMAP Capabilities}[http://www.iana.org/assignments/imap4-capabilities]
   # * {IMAP Response Codes}[https://www.iana.org/assignments/imap-response-codes/imap-response-codes.xhtml]
   # * {IMAP Mailbox Name Attributes}[https://www.iana.org/assignments/imap-mailbox-name-attributes/imap-mailbox-name-attributes.xhtml]
   # * {IMAP and JMAP Keywords}[https://www.iana.org/assignments/imap-jmap-keywords/imap-jmap-keywords.xhtml]
   # * {IMAP Threading Algorithms}[https://www.iana.org/assignments/imap-threading-algorithms/imap-threading-algorithms.xhtml]
-  #--
-  # * {IMAP Quota Resource Types}[http://www.iana.org/assignments/imap4-capabilities#imap-capabilities-2]
-  # * [{LIST-EXTENDED options and responses}[https://www.iana.org/assignments/imap-list-extended/imap-list-extended.xhtml]
-  # * {IMAP METADATA Server Entry and Mailbox Entry Registries}[https://www.iana.org/assignments/imap-metadata/imap-metadata.xhtml]
-  # * {IMAP ANNOTATE Extension Entries and Attributes}[https://www.iana.org/assignments/imap-annotate-extension/imap-annotate-extension.xhtml]
-  # * {IMAP URLAUTH Access Identifiers and Prefixes}[https://www.iana.org/assignments/urlauth-access-ids/urlauth-access-ids.xhtml]
-  # * {IMAP URLAUTH Authorization Mechanism Registry}[https://www.iana.org/assignments/urlauth-authorization-mechanism-registry/urlauth-authorization-mechanism-registry.xhtml]
-  #++
   # * {SASL Mechanisms and SASL SCRAM Family Mechanisms}[https://www.iana.org/assignments/sasl-mechanisms/sasl-mechanisms.xhtml]
   # * {Service Name and Transport Protocol Port Number Registry}[https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xml]:
   #   +imap+: tcp/143, +imaps+: tcp/993
   # * {GSSAPI/Kerberos/SASL Service Names}[https://www.iana.org/assignments/gssapi-service-names/gssapi-service-names.xhtml]:
   #   +imap+
   # * {Character sets}[https://www.iana.org/assignments/character-sets/character-sets.xhtml]
+  # ===== For currently unsupported features:
+  # * {IMAP Quota Resource Types}[http://www.iana.org/assignments/imap4-capabilities#imap-capabilities-2]
+  # * {LIST-EXTENDED options and responses}[https://www.iana.org/assignments/imap-list-extended/imap-list-extended.xhtml]
+  # * {IMAP METADATA Server Entry and Mailbox Entry Registries}[https://www.iana.org/assignments/imap-metadata/imap-metadata.xhtml]
+  # * {IMAP ANNOTATE Extension Entries and Attributes}[https://www.iana.org/assignments/imap-annotate-extension/imap-annotate-extension.xhtml]
+  # * {IMAP URLAUTH Access Identifiers and Prefixes}[https://www.iana.org/assignments/urlauth-access-ids/urlauth-access-ids.xhtml]
+  # * {IMAP URLAUTH Authorization Mechanism Registry}[https://www.iana.org/assignments/urlauth-authorization-mechanism-registry/urlauth-authorization-mechanism-registry.xhtml]
   #
   class IMAP < Protocol
     VERSION = "0.3.4"

--- a/lib/net/todo.rdoc
+++ b/lib/net/todo.rdoc
@@ -1,0 +1,70 @@
+Moved from lib/net/imap.rb
+
+==== RFC3502: +MULTIAPPEND+
+TODO...
+
+==== RFC3516: +BINARY+
+TODO...
+
+==== RFC4466: Collected Extensions to IMAP4 ABNF
+TODO...
+Folded into IMAP4rev2[https://tools.ietf.org/html/rfc9051], this RFC updates
+the protocol to enable new optional parameters to many commands: #select,
+#examine, #create, #rename, #fetch, #uid_fetch, #store, #uid_store, #search,
+#uid_search, and #append.  However, specific parameters are not defined.
+Extensions to these commands use this syntax whenever possible.  Net::IMAP
+may be partially compatible with extensions to these commands, even without
+any explicit support.
+
+==== RFC4731 +ESEARCH+
+TODO...
+Folded into IMAP4rev2[https://tools.ietf.org/html/rfc9051].
+- Updates #search, #uid_search to accept result options: +MIN+, +MAX+,
+  +ALL+, +COUNT+, and to return ExtendedSearchData.
+
+==== RFC4959: +SASL-IR+
+TODO...
+Folded into IMAP4rev2[https://tools.ietf.org/html/rfc9051].
+- Updates #authenticate to reduce round-trips for supporting mechanisms.
+
+==== RFC4978: COMPRESS=DEFLATE
+TODO...
+
+==== RFC5182 +SEARCHRES+
+TODO...
+Folded into IMAP4rev2[https://tools.ietf.org/html/rfc9051].
+- Updates #search, #uid_search with the +SAVE+ result option.
+- Updates #copy, #uid_copy, #fetch, #uid_fetch, #move, #uid_move, #search,
+  #uid_search, #store, #uid_store, and #uid_expunge with ability to
+  reference the saved result of a previous #search or #uid_search command.
+
+==== RFC5258 +LIST-EXTENDED+
+TODO...
+Folded into IMAP4rev2[https://tools.ietf.org/html/rfc9051], this updates the
+protocol with new optional parameters to the #list command, adding a few of
+its own.  Net::IMAP may be forward-compatible with future #list extensions,
+even without any explicit support.
+- Updates #list to accept selection options: +SUBSCRIBED+, +REMOTE+, and
+  +RECURSIVEMATCH+, and return options: +SUBSCRIBED+ and +CHILDREN+.
+
+==== RFC5819 +LIST-STATUS+
+TODO...
+Folded into IMAP4rev2[https://tools.ietf.org/html/rfc9051].
+- Updates #list with +STATUS+ return option.
+
+==== RFC6154 +SPECIAL-USE+
+TODO...
+Folded into IMAP4rev2[https://tools.ietf.org/html/rfc9051].
+- Updates #list with the +SPECIAL-USE+ selection and return options.
+
+==== RFC7888: <tt>LITERAL+</tt>, +LITERAL-+
+TODO...
+==== RFC7162: +QRESYNC+
+TODO...
+==== RFC7162: +CONDSTORE+
+TODO...
+==== RFC8474: +OBJECTID+
+TODO...
+==== RFC9208: +QUOTA+
+TODO...
+

--- a/test/net/imap/fake_server.rb
+++ b/test/net/imap/fake_server.rb
@@ -42,6 +42,7 @@ class Net::IMAP::FakeServer
   autoload :ResponseWriter,        "#{dir}/response_writer"
   autoload :Socket,                "#{dir}/socket"
   autoload :Session,               "#{dir}/session"
+  autoload :TestHelper,            "#{dir}/test_helper"
 
   # Returns the server's FakeServer::Configuration
   attr_reader :config

--- a/test/net/imap/fake_server/socket.rb
+++ b/test/net/imap/fake_server/socket.rb
@@ -10,6 +10,8 @@ class Net::IMAP::FakeServer
     def initialize(tcp_socket, config:)
       @config     = config
       @tcp_socket = tcp_socket
+      @tls_socket = nil
+      @closed     = false
       use_tls if config.implicit_tls && tcp_socket
     end
 

--- a/test/net/imap/fake_server/test_helper.rb
+++ b/test/net/imap/fake_server/test_helper.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require_relative "../fake_server"
+
+module Net::IMAP::FakeServer::TestHelper
+
+  def with_fake_server(select: nil, timeout: 5, **opts)
+    Timeout.timeout(timeout) do
+      server = Net::IMAP::FakeServer.new(timeout: timeout, **opts)
+      @threads << Thread.new do server.run end if @threads
+      tls = opts[:implicit_tls]
+      tls = {ca_file: server.config.tls[:ca_file]} if tls == true
+      client = Net::IMAP.new("localhost", port: server.port, ssl: tls)
+      begin
+        if select
+          client.select(select)
+          server.commands.pop
+        end
+        yield server, client
+      ensure
+        client.logout rescue pp $!
+        client.disconnect if !client.disconnected?
+      end
+    ensure
+      server&.shutdown
+    end
+  end
+
+end

--- a/test/net/imap/test_imap_capabilities.rb
+++ b/test/net/imap/test_imap_capabilities.rb
@@ -1,0 +1,296 @@
+# frozen_string_literal: true
+
+require "net/imap"
+require "test/unit"
+require_relative "fake_server"
+
+class IMAPCapabilitiesTest < Test::Unit::TestCase
+
+  include Net::IMAP::FakeServer::TestHelper
+
+  def setup
+    @do_not_reverse_lookup = Socket.do_not_reverse_lookup
+    Socket.do_not_reverse_lookup = true
+    @threads = []
+  end
+
+  def teardown
+    if !@threads.empty?
+      assert_join_threads(@threads)
+    end
+  ensure
+    Socket.do_not_reverse_lookup = @do_not_reverse_lookup
+  end
+
+  test "#capabilities returns cached CAPABILITY data" do
+    with_fake_server do |server, imap|
+      imap.clear_cached_capabilities
+      assert_empty server.commands
+      10.times do
+        assert_equal(%w[IMAP4REV1 NAMESPACE MOVE IDLE UTF8=ACCEPT],
+                     imap.capabilities)
+      end
+      # only one CAPABILITY command was sent
+      assert_equal "CAPABILITY", server.commands.pop.name
+      assert_empty server.commands
+    end
+  end
+
+  test "#capable?(name) checks cached CAPABILITY data for name" do
+    with_fake_server do |server, imap|
+      imap.clear_cached_capabilities
+      assert_empty server.commands
+      10.times do
+        assert imap.capable? "IMAP4rev1"
+        assert imap.capable? :NAMESPACE
+        assert imap.capable? "idle"
+        refute imap.capable? "LOGINDISABLED"
+        refute imap.capable? "auth=plain"
+      end
+      # only one CAPABILITY command was sent
+      assert_equal "CAPABILITY", server.commands.pop.name
+      assert_empty server.commands
+    end
+  end
+
+  test "#auth_capable?(name) checks cached capabilities for AUTH=name" do
+    with_fake_server(
+      preauth: false, cleartext_auth: true,
+      sasl_mechanisms: %i[PLAIN SCRAM-SHA-1 SCRAM-SHA-256 XOAUTH2 OAUTHBEARER],
+    ) do |server, imap|
+      imap.clear_cached_capabilities
+      assert_empty server.commands
+      10.times do
+        assert imap.auth_capable? :PLAIN
+        assert imap.auth_capable? "scram-sha-1"
+        assert imap.auth_capable? "OAuthBearer"
+        assert imap.auth_capable? :XOAuth2
+        refute imap.auth_capable? "EXTERNAL"
+        refute imap.auth_capable? :LOGIN
+        refute imap.auth_capable? "anonymous"
+      end
+      # only one CAPABILITY command was sent
+      assert_equal "CAPABILITY", server.commands.pop.name
+      assert_empty server.commands
+    end
+  end
+
+  test "#auth_mechanisms reports cached capabilities with AUTH={name}" do
+    with_fake_server(
+      preauth: false, cleartext_auth: true,
+      sasl_mechanisms: %i[PLAIN SCRAM-SHA-1 SCRAM-SHA-256 XOAUTH2 OAUTHBEARER],
+    ) do |server, imap|
+      imap.clear_cached_capabilities
+      assert_empty server.commands
+      10.times do
+        assert_equal(%w[PLAIN SCRAM-SHA-1 SCRAM-SHA-256 XOAUTH2 OAUTHBEARER],
+                     imap.auth_mechanisms)
+      end
+      # only one CAPABILITY command was sent
+      assert_equal "CAPABILITY", server.commands.pop.name
+      assert_empty server.commands
+    end
+  end
+
+  test "#clear_cached_capabilities clears cached capabilities" do
+    with_fake_server do |server, imap|
+      assert imap.capable?(:IMAP4rev1)
+      assert imap.capabilities_cached?
+      assert_empty server.commands
+      imap.clear_cached_capabilities
+      refute imap.capabilities_cached?
+      assert imap.capable?(:IMAP4rev1)
+      assert_equal "CAPABILITY", server.commands.pop.name
+      assert imap.capabilities_cached?
+    end
+  end
+
+  test "#capability caches its result" do
+    with_fake_server(greeting_capabilities: false) do |server, imap|
+      imap.capability
+      assert imap.capabilities_cached?
+      assert_equal "CAPABILITY", server.commands.pop.name
+      assert_empty server.commands
+    end
+  end
+
+  test "#capabilities caches greeting capabilities (cleartext)" do
+    with_fake_server(
+      preauth: false, cleartext_login: false, cleartext_auth: false,
+    ) do |server, imap|
+      assert imap.capabilities_cached?
+      assert_equal %w[IMAP4REV1 STARTTLS LOGINDISABLED], imap.capabilities
+      assert_empty imap.auth_mechanisms
+      refute imap.auth_capable? "plain"
+      refute imap.capable? "plain"
+      assert_empty server.commands
+    end
+  end
+
+  test "#capabilities caches greeting capabilities (PREAUTH)" do
+    with_fake_server(preauth: true) do |server, imap|
+      assert imap.capabilities_cached?
+      assert_equal %w[IMAP4REV1 NAMESPACE MOVE IDLE UTF8=ACCEPT],
+                   imap.capabilities
+      assert_empty server.commands
+    end
+  end
+
+  if defined?(OpenSSL::SSL::SSLError)
+    test "#capabilities caches greeting capabilities (implicit TLS)" do
+      with_fake_server(preauth: false, implicit_tls: true) do |server, imap|
+        assert imap.capabilities_cached?
+        assert_equal %w[IMAP4REV1 AUTH=PLAIN], imap.capabilities
+        assert_equal %w[PLAIN], imap.auth_mechanisms
+        assert imap.capable? :IMAP4rev1
+        assert imap.auth_capable? "plain"
+        assert_empty server.commands
+      end
+    end
+
+    test "#capabilities cache is cleared after #starttls" do
+      with_fake_server(preauth: false, cleartext_auth: false) do |server, imap|
+        assert imap.capabilities_cached?
+        assert imap.capable? :IMAP4rev1
+        refute imap.auth_capable? "plain"
+
+        imap.starttls(ca_file: server.config.tls[:ca_file])
+        assert_equal "STARTTLS", server.commands.pop.name
+        refute imap.capabilities_cached?
+
+        assert imap.capable? :IMAP4rev1
+        assert imap.auth_capable? "plain"
+        assert_equal "CAPABILITY", server.commands.pop.name
+        assert imap.capabilities_cached?
+        assert_empty server.commands
+      end
+    end
+  end
+
+  test "#capabilities cache is cleared after #login" do
+    with_fake_server(preauth: false, cleartext_login: true) do |server, imap|
+      assert imap.capable? :IMAP4rev1
+      assert imap.capabilities_cached?
+
+      imap.login("test_user", "test-password")
+      assert_equal "LOGIN", server.commands.pop.name
+      refute imap.capabilities_cached?
+
+      assert imap.capable? :IMAP4rev1
+      assert_equal "CAPABILITY", server.commands.pop.name
+      assert imap.capabilities_cached?
+      assert_empty server.commands
+    end
+  end
+
+  test "#capabilities cache is cleared after #authenticate" do
+    with_fake_server(preauth: false, cleartext_auth: true) do |server, imap|
+      assert imap.capable?("AUTH=PLAIN")
+      assert imap.auth_capable?("PLAIN")
+
+      imap.authenticate("PLAIN", "test_user", "test-password")
+      assert_equal "AUTHENTICATE", server.commands.pop.name
+      refute imap.capabilities_cached?
+
+      assert imap.capable? :IMAP4rev1
+      refute imap.auth_capable?("PLAIN")
+      assert_empty imap.auth_mechanisms
+      assert_equal "CAPABILITY", server.commands.pop.name
+      assert_empty server.commands
+    end
+  end
+
+  # TODO: should we warn about this?
+  test "#capabilities cache IGNORES tagged OK response to STARTTLS" do
+    with_fake_server(preauth: false) do |server, imap|
+      server.on "STARTTLS" do |cmd|
+        cmd.done_ok code: "[CAPABILITY IMAP4rev1 AUTH=PLAIN fnord]"
+        server.state.use_tls
+      end
+
+      imap.starttls(ca_file: server.config.tls[:ca_file])
+      assert_equal "STARTTLS", server.commands.pop.name
+      refute imap.capabilities_cached?
+
+      refute imap.capable? "fnord"
+      assert_equal "CAPABILITY", server.commands.pop.name
+    end
+  end
+
+  test "#capabilities caches tagged OK response to LOGIN" do
+    with_fake_server(preauth: false, cleartext_login: true) do |server, imap|
+      server.on "LOGIN" do |cmd|
+        server.state.authenticate server.config.user
+        cmd.done_ok code: "[CAPABILITY IMAP4rev1 IMAP4rev2 MOVE NAMESPACE" \
+                           " ENABLE IDLE UIDPLUS UNSELECT UTF8=ACCEPT]"
+      end
+
+      imap.login("test_user", "test-password")
+      assert_equal "LOGIN", server.commands.pop.name
+      assert imap.capabilities_cached?
+
+      assert imap.capable? :IMAP4rev1
+      assert imap.capable? :IMAP4rev2
+      assert imap.capable? "UIDPLUS"
+      assert_empty server.commands
+    end
+  end
+
+  test "#capabilities caches tagged OK response to AUTHENTICATE" do
+    with_fake_server(preauth: false, cleartext_login: true) do |server, imap|
+      server.on "AUTHENTICATE" do |cmd|
+        cmd.request_continuation ""
+        server.state.authenticate server.config.user
+        cmd.done_ok code: "[CAPABILITY IMAP4rev1 IMAP4rev2 MOVE NAMESPACE" \
+                           " ENABLE IDLE UIDPLUS UNSELECT UTF8=ACCEPT]"
+      end
+
+      imap.authenticate("PLAIN", "test_user", "test-password")
+      assert_equal "AUTHENTICATE", server.commands.pop.name
+      assert imap.capabilities_cached?
+
+      assert imap.capable? :IMAP4rev1
+      assert imap.capable? :IMAP4rev2
+      assert imap.capable? "UIDPLUS"
+      assert_empty server.commands
+    end
+  end
+
+  test "#capabilities cache is NOT cleared after #login fails" do
+    with_fake_server(preauth: false, cleartext_auth: true) do |server, imap|
+      original_capabilities = imap.capabilities
+      begin
+        imap.login("wrong_user", "wrong-password")
+      rescue Net::IMAP::NoResponseError
+      end
+      assert_equal "LOGIN", server.commands.pop.name
+      assert_equal original_capabilities, imap.capabilities
+      assert_empty server.commands
+    end
+  end
+
+  test "#capabilities cache is NOT cleared after #authenticate fails" do
+    with_fake_server(preauth: false, cleartext_auth: true) do |server, imap|
+      original_capabilities = imap.capabilities
+      begin
+        imap.authenticate("PLAIN", "wrong_user", "wrong-password")
+      rescue Net::IMAP::NoResponseError
+      end
+      assert_equal "AUTHENTICATE", server.commands.pop.name
+      assert_equal original_capabilities, imap.capabilities
+      assert_empty server.commands
+    end
+  end
+
+  # NOTE: other recorded responses are cleared after #select
+  test "#capabilities cache is retained after selecting a mailbox" do
+    with_fake_server do |server, imap|
+      original_capabilities = imap.capabilities
+      imap.select "inbox"
+      assert_equal "SELECT", server.commands.pop.name
+      assert_equal original_capabilities, imap.capabilities
+      assert_empty server.commands
+    end
+  end
+
+end


### PR DESCRIPTION
Updated methods:
* `#initialize` - save capabilities in `OK` or `PREAUTH` greeting
* `#capability` - always update saved capabilities
* `#starttls` - always clear capabilities after tagged OK response
* `#authenticate` - clear capabilities or update from tagged OK response
* `#login` - clear capabilities or update from tagged OK response

New methods:
* `#capable?(name)` - the primary API for discovering capabilities
* `#auth_capable?(name)` - returns whether a SASL mechanism is supported
* `#auth_mechanisms` - returns the server's supported SASL mechanisms
* `#capabilities` - calls `capability` when needed
* `#capabilities_cached?` - whether capabilities are cached
* `#clear_cached_capabilities` - clears the cache

Fixes https://github.com/ruby/net-imap/issues/31
Related issues:
* Fixes #31
* Depends on #157 