### PR TITLE
♻️ Use Net::IMAP::FakeServer::TestHelper

### DIFF
--- a/test/net/imap/fake_server/test_helper.rb
+++ b/test/net/imap/fake_server/test_helper.rb
@@ -15,6 +15,7 @@ module Net::IMAP::FakeServer::TestHelper
         if select
           client.select(select)
           server.commands.pop
+          assert server.state.selected?
         end
         yield server, client
       ensure


### PR DESCRIPTION
The module was originally extracted from this code, and this was accidentally left behind when `Net::IMAP::FakeServer::TestHelper` was originally committed.