### PR TITLE
🚚 Move and rename SASL authenticators

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -1015,7 +1015,7 @@ module Net
     # +PLAIN+::     See PlainAuthenticator.
     #               Login using clear-text username and password.
     #
-    # +XOAUTH2+::   See XOauth2Authenticator.
+    # +XOAUTH2+::   See XOAuth2Authenticator.
     #               Login using a username and OAuth2 access token.
     #               Non-standard and obsoleted by +OAUTHBEARER+, but widely
     #               supported.

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -1074,10 +1074,7 @@ module Net
     # completes.  If the TaggedResponse to #authenticate includes updated
     # capabilities, they will be cached.
     def authenticate(mechanism, *creds, sasl_ir: true, **props, &callback)
-      authenticator = self.class.authenticator(mechanism,
-                                               *creds,
-                                               **props,
-                                               &callback)
+      authenticator = SASL.authenticator(mechanism, *creds, **props, &callback)
       cmdargs = ["AUTHENTICATE", mechanism]
       if sasl_ir && capable?("SASL-IR") && auth_capable?(mechanism) &&
           SASL.initial_response?(authenticator)

--- a/lib/net/imap/authenticators.rb
+++ b/lib/net/imap/authenticators.rb
@@ -12,7 +12,7 @@ module Net::IMAP::Authenticators
   # The authenticator session must respond to +#process+, receiving the server's
   # challenge and returning the client's response.
   #
-  # See PlainAuthenticator, XOauth2Authenticator, and DigestMD5Authenticator for
+  # See PlainAuthenticator, XOAuth2Authenticator, and DigestMD5Authenticator for
   # examples.
   def add_authenticator(auth_type, authenticator)
     authenticators[auth_type] = authenticator
@@ -54,11 +54,20 @@ module Net::IMAP::Authenticators
 
 end
 
-Net::IMAP.extend Net::IMAP::Authenticators
+class Net::IMAP
+  extend Authenticators
+  add_authenticator "PLAIN",      SASL::PlainAuthenticator
+  add_authenticator "XOAUTH2",    SASL::XOAuth2Authenticator
 
-require_relative "authenticators/plain"
+  add_authenticator "CRAM-MD5",   SASL::CramMD5Authenticator   # deprecated
+  add_authenticator "LOGIN",      SASL::LoginAuthenticator     # deprecated
+  add_authenticator "DIGEST-MD5", SASL::DigestMD5Authenticator # deprecated
+end
 
-require_relative "authenticators/login"
-require_relative "authenticators/cram_md5"
-require_relative "authenticators/digest_md5"
-require_relative "authenticators/xoauth2"
+class Net::IMAP
+  PlainAuthenticator = SASL::PlainAuthenticator # :nodoc:
+  deprecate_constant :PlainAuthenticator
+
+  XOauth2Authenticator = SASL::XOAuth2Authenticator # :nodoc:
+  deprecate_constant :XOauth2Authenticator
+end

--- a/lib/net/imap/authenticators.rb
+++ b/lib/net/imap/authenticators.rb
@@ -1,67 +1,31 @@
 # frozen_string_literal: true
 
-# Registry for SASL authenticators used by Net::IMAP.
+# Backward compatible delegators from Net::IMAP to Net::IMAP::SASL.
 module Net::IMAP::Authenticators
 
-  # Adds an authenticator for Net::IMAP#authenticate to use.  +mechanism+ is the
-  # {SASL mechanism}[https://www.iana.org/assignments/sasl-mechanisms/sasl-mechanisms.xhtml]
-  # implemented by +authenticator+ (for instance, <tt>"PLAIN"</tt>).
-  #
-  # The +authenticator+ must respond to +#new+ (or #call), receiving the
-  # authenticator configuration and return a configured authentication session.
-  # The authenticator session must respond to +#process+, receiving the server's
-  # challenge and returning the client's response.
-  #
-  # See PlainAuthenticator, XOAuth2Authenticator, and DigestMD5Authenticator for
-  # examples.
-  def add_authenticator(auth_type, authenticator)
-    authenticators[auth_type] = authenticator
+  # Deprecated.  Use Net::IMAP::SASL.add_authenticator instead.
+  def add_authenticator(...)
+    warn(
+      "%s.%s is deprecated.  Use %s.%s instead." % [
+        Net::IMAP, __method__, Net::IMAP::SASL, __method__
+      ],
+      uplevel: 1
+    )
+    Net::IMAP::SASL.add_authenticator(...)
   end
 
-  # :call-seq:
-  #   authenticator(mechanism, ...)                            -> authenticator
-  #   authenticator(mech, *creds, **props) {|prop, auth| val } -> authenticator
-  #   authenticator(mechanism, authnid, creds, authzid=nil)    -> authenticator
-  #   authenticator(mechanism, **properties)                   -> authenticator
-  #   authenticator(mechanism) {|propname, authctx| value }    -> authenticator
-  #
-  # Builds a new authentication session context for +mechanism+.
-  #
-  # [Note]
-  #   This method is intended for internal use by connection protocol code only.
-  #   Protocol client users should see refer to their client's documentation,
-  #   e.g. Net::IMAP#authenticate for Net::IMAP.
-  #
-  # The call signatures documented for this method are recommendations for
-  # authenticator implementors.  All arguments (other than +mechanism+) are
-  # forwarded to the registered authenticator's +#new+ (or +#call+) method, and
-  # each authenticator must document its own arguments.
-  #
-  # The returned object represents a single authentication exchange and <em>must
-  # not</em> be reused for multiple authentication attempts.
-  def authenticator(mechanism, ...)
-    auth = authenticators.fetch(mechanism.upcase) do
-      raise ArgumentError, 'unknown auth type - "%s"' % mechanism
-    end
-    auth.respond_to?(:new) ? auth.new(...) : auth.call(...)
+  # Deprecated.  Use Net::IMAP::SASL.authenticator instead.
+  def authenticator(...)
+    warn(
+      "%s.%s is deprecated.  Use %s.%s instead." % [
+        Net::IMAP, __method__, Net::IMAP::SASL, __method__
+      ],
+      uplevel: 1
+    )
+    Net::IMAP::SASL.authenticator(...)
   end
 
-  private
-
-  def authenticators
-    @authenticators ||= {}
-  end
-
-end
-
-class Net::IMAP
-  extend Authenticators
-  add_authenticator "PLAIN",      SASL::PlainAuthenticator
-  add_authenticator "XOAUTH2",    SASL::XOAuth2Authenticator
-
-  add_authenticator "CRAM-MD5",   SASL::CramMD5Authenticator   # deprecated
-  add_authenticator "LOGIN",      SASL::LoginAuthenticator     # deprecated
-  add_authenticator "DIGEST-MD5", SASL::DigestMD5Authenticator # deprecated
+  Net::IMAP.extend self
 end
 
 class Net::IMAP

--- a/lib/net/imap/sasl.rb
+++ b/lib/net/imap/sasl.rb
@@ -33,12 +33,25 @@ module Net
       autoload :BidiStringError,     sasl_stringprep_rb
 
       sasl_dir = File.expand_path("sasl", __dir__)
+      autoload :Authenticators,           "#{sasl_dir}/authenticators"
+
       autoload :PlainAuthenticator,       "#{sasl_dir}/plain_authenticator"
       autoload :XOAuth2Authenticator,     "#{sasl_dir}/xoauth2_authenticator"
 
       autoload :CramMD5Authenticator,     "#{sasl_dir}/cram_md5_authenticator"
       autoload :DigestMD5Authenticator,   "#{sasl_dir}/digest_md5_authenticator"
       autoload :LoginAuthenticator,       "#{sasl_dir}/login_authenticator"
+
+      # Returns the default global SASL::Authenticators instance.
+      def self.authenticators
+        @authenticators ||= Authenticators.new(use_defaults: true)
+      end
+
+      # Delegates to ::authenticators.  See Authenticators#authenticator.
+      def self.authenticator(...)     authenticators.authenticator(...) end
+
+      # Delegates to ::authenticators.  See Authenticators#add_authenticator.
+      def self.add_authenticator(...) authenticators.add_authenticator(...) end
 
       module_function
 

--- a/lib/net/imap/sasl.rb
+++ b/lib/net/imap/sasl.rb
@@ -32,6 +32,14 @@ module Net
       autoload :ProhibitedCodepoint, sasl_stringprep_rb
       autoload :BidiStringError,     sasl_stringprep_rb
 
+      sasl_dir = File.expand_path("sasl", __dir__)
+      autoload :PlainAuthenticator,       "#{sasl_dir}/plain_authenticator"
+      autoload :XOAuth2Authenticator,     "#{sasl_dir}/xoauth2_authenticator"
+
+      autoload :CramMD5Authenticator,     "#{sasl_dir}/cram_md5_authenticator"
+      autoload :DigestMD5Authenticator,   "#{sasl_dir}/digest_md5_authenticator"
+      autoload :LoginAuthenticator,       "#{sasl_dir}/login_authenticator"
+
       module_function
 
       # See Net::IMAP::StringPrep::SASLprep#saslprep.

--- a/lib/net/imap/sasl/authenticators.rb
+++ b/lib/net/imap/sasl/authenticators.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+module Net::IMAP::SASL
+
+  # Registry for SASL authenticators
+  #
+  # Registered authenticators must respond to +#new+ or +#call+ (e.g. a class or
+  # a proc), receiving any credentials and options and returning an
+  # authenticator instance. The returned object represents a single
+  # authentication exchange and <em>must not</em> be reused for multiple
+  # authentication attempts.
+  #
+  # An authenticator instance object must respond to +#process+, receiving the
+  # server's challenge and returning the client's response.  Optionally, it may
+  # also respond to +#initial_response?+ and +#done?+.  When
+  # +#initial_response?+ returns +true+, +#process+ may be called the first
+  # time with +nil+.  When +#done?+ returns +false+, the exchange is incomplete
+  # and an exception should be raised if the exchange terminates prematurely.
+  #
+  # See the source for PlainAuthenticator, XOAuth2Authenticator, and
+  # ScramSHA1Authenticator for examples.
+  class Authenticators
+
+    # Create a new Authenticators registry.
+    #
+    # This class is usually not instantiated directly.  Use SASL.authenticators
+    # to reuse the default global registry.
+    #
+    # By default, the registry will be empty--without any registrations.  When
+    # +add_defaults+ is +true+, authenticators for all standard mechanisms will
+    # be registered.
+    #
+    def initialize(use_defaults: false)
+      @authenticators = {}
+      if use_defaults
+        add_authenticator "PLAIN",      PlainAuthenticator
+        add_authenticator "XOAUTH2",    XOAuth2Authenticator
+        add_authenticator "LOGIN",      LoginAuthenticator     # deprecated
+        add_authenticator "CRAM-MD5",   CramMD5Authenticator   # deprecated
+        add_authenticator "DIGEST-MD5", DigestMD5Authenticator # deprecated
+      end
+    end
+
+    # Returns the names of all registered SASL mechanisms.
+    def names; @authenticators.keys end
+
+    # :call-seq:
+    #   add_authenticator(mechanism)
+    #   add_authenticator(mechanism, authenticator_class)
+    #   add_authenticator(mechanism, authenticator_proc)
+    #
+    # Registers an authenticator for #authenticator to use.  +mechanism+ is the
+    # name of the
+    # {SASL mechanism}[https://www.iana.org/assignments/sasl-mechanisms/sasl-mechanisms.xhtml]
+    # implemented by +authenticator_class+ (for instance, <tt>"PLAIN"</tt>).
+    #
+    # If +mechanism+ refers to an existing authenticator, a warning will be
+    # printed and the old authenticator will be replaced.
+    #
+    # When only a single argument is given, the authenticator class will be
+    # lazily loaded from <tt>Net::IMAP::SASL::#{name}Authenticator</tt> (case is
+    # preserved and non-alphanumeric characters are removed..
+    def add_authenticator(auth_type, authenticator)
+      @authenticators[auth_type] = authenticator
+    end
+
+    # :call-seq:
+    #   authenticator(mechanism, ...) -> auth_session
+    #
+    # Builds an authenticator instance using the authenticator registered to
+    # +mechanism+.  The returned object represents a single authentication
+    # exchange and <em>must not</em> be reused for multiple authentication
+    # attempts.
+    #
+    # All arguments (except +mechanism+) are forwarded to the registered
+    # authenticator's +#new+ or +#call+ method.  Each authenticator must
+    # document its own arguments.
+    #
+    # [Note]
+    #   This method is intended for internal use by connection protocol code
+    #   only.  Protocol client users should see refer to their client's
+    #   documentation, e.g. Net::IMAP#authenticate.
+    def authenticator(mechanism, ...)
+      auth = @authenticators.fetch(mechanism.upcase) do
+        raise ArgumentError, 'unknown auth type - "%s"' % mechanism
+      end
+      auth.respond_to?(:new) ? auth.new(...) : auth.call(...)
+    end
+
+  end
+
+end

--- a/lib/net/imap/sasl/cram_md5_authenticator.rb
+++ b/lib/net/imap/sasl/cram_md5_authenticator.rb
@@ -13,7 +13,7 @@
 # Additionally, RFC8314[https://tools.ietf.org/html/rfc8314] discourage the use
 # of cleartext and recommends TLS version 1.2 or greater be used for all
 # traffic.  With TLS +CRAM-MD5+ is okay, but so is +PLAIN+
-class Net::IMAP::CramMD5Authenticator
+class Net::IMAP::SASL::CramMD5Authenticator
   def process(challenge)
     digest = hmac_md5(challenge, @password)
     return @user + " " + digest
@@ -47,5 +47,4 @@ class Net::IMAP::CramMD5Authenticator
     return Digest::MD5.hexdigest(k_opad + digest)
   end
 
-  Net::IMAP.add_authenticator "CRAM-MD5", self
 end

--- a/lib/net/imap/sasl/digest_md5_authenticator.rb
+++ b/lib/net/imap/sasl/digest_md5_authenticator.rb
@@ -8,7 +8,7 @@
 # "+DIGEST-MD5+" has been deprecated by
 # {RFC6331}[https://tools.ietf.org/html/rfc6331] and should not be relied on for
 # security.  It is included for compatibility with existing servers.
-class Net::IMAP::DigestMD5Authenticator
+class Net::IMAP::SASL::DigestMD5Authenticator
   def process(challenge)
     case @stage
     when STAGE_ONE
@@ -111,5 +111,4 @@ class Net::IMAP::DigestMD5Authenticator
     end
   end
 
-  Net::IMAP.add_authenticator "DIGEST-MD5", self
 end

--- a/lib/net/imap/sasl/login_authenticator.rb
+++ b/lib/net/imap/sasl/login_authenticator.rb
@@ -17,7 +17,7 @@
 # compatibility with existing servers.  See
 # {draft-murchison-sasl-login}[https://www.iana.org/go/draft-murchison-sasl-login]
 # for both specification and deprecation.
-class Net::IMAP::LoginAuthenticator
+class Net::IMAP::SASL::LoginAuthenticator
   def process(data)
     case @state
     when STATE_USER
@@ -42,5 +42,4 @@ class Net::IMAP::LoginAuthenticator
     @state = STATE_USER
   end
 
-  Net::IMAP.add_authenticator "LOGIN", self
 end

--- a/lib/net/imap/sasl/plain_authenticator.rb
+++ b/lib/net/imap/sasl/plain_authenticator.rb
@@ -9,7 +9,7 @@
 # RFC8314[https://tools.ietf.org/html/rfc8314] recommends TLS version 1.2 or
 # greater be used for all traffic, and deprecate cleartext access ASAP.  +PLAIN+
 # can be secured by TLS encryption.
-class Net::IMAP::PlainAuthenticator
+class Net::IMAP::SASL::PlainAuthenticator
 
   def initial_response?; true end
 
@@ -39,5 +39,4 @@ class Net::IMAP::PlainAuthenticator
     @authzid  = authzid
   end
 
-  Net::IMAP.add_authenticator "PLAIN", self
 end

--- a/lib/net/imap/sasl/xoauth2_authenticator.rb
+++ b/lib/net/imap/sasl/xoauth2_authenticator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Net::IMAP::XOauth2Authenticator
+class Net::IMAP::SASL::XOAuth2Authenticator
 
   def initial_response?; true end
 
@@ -19,5 +19,4 @@ class Net::IMAP::XOauth2Authenticator
     format("user=%s\1auth=Bearer %s\1\1", user, oauth2_token)
   end
 
-  Net::IMAP.add_authenticator 'XOAUTH2', self
 end

--- a/test/net/imap/test_imap_authenticators.rb
+++ b/test/net/imap/test_imap_authenticators.rb
@@ -5,11 +5,17 @@ require "test/unit"
 
 class IMAPAuthenticatorsTest < Test::Unit::TestCase
 
+  def test_net_imap_authenticator_deprecated
+    assert_warn(/Net::IMAP\.authenticator .+deprecated./) do
+      Net::IMAP.authenticator("PLAIN", "user", "pass")
+    end
+  end
+
   # ----------------------
   # PLAIN
   # ----------------------
 
-  def plain(...) Net::IMAP.authenticator("PLAIN", ...) end
+  def plain(...) Net::IMAP::SASL.authenticator("PLAIN", ...) end
 
   def test_plain_authenticator_matches_mechanism
     assert_kind_of(Net::IMAP::SASL::PlainAuthenticator, plain("user", "pass"))
@@ -36,7 +42,7 @@ class IMAPAuthenticatorsTest < Test::Unit::TestCase
   # XOAUTH2
   # ----------------------
 
-  def xoauth2(...) Net::IMAP.authenticator("XOAUTH2", ...) end
+  def xoauth2(...) Net::IMAP::SASL.authenticator("XOAUTH2", ...) end
 
   def test_xoauth2_authenticator_matches_mechanism
     assert_kind_of(Net::IMAP::SASL::XOAuth2Authenticator, xoauth2("user", "tok"))
@@ -59,7 +65,7 @@ class IMAPAuthenticatorsTest < Test::Unit::TestCase
   # ----------------------
 
   def login(*args, warn_deprecation: false, **kwargs, &block)
-    Net::IMAP.authenticator(
+    Net::IMAP::SASL.authenticator(
       "LOGIN", *args, warn_deprecation: warn_deprecation, **kwargs, &block
     )
   end
@@ -74,7 +80,7 @@ class IMAPAuthenticatorsTest < Test::Unit::TestCase
 
   def test_login_authenticator_deprecated
     assert_warn(/LOGIN.+deprecated.+PLAIN/) do
-      Net::IMAP.authenticator("LOGIN", "user", "pass")
+      Net::IMAP::SASL.authenticator("LOGIN", "user", "pass")
     end
   end
 
@@ -89,7 +95,7 @@ class IMAPAuthenticatorsTest < Test::Unit::TestCase
   # ----------------------
 
   def cram_md5(*args, warn_deprecation: false, **kwargs, &block)
-    Net::IMAP.authenticator(
+    Net::IMAP::SASL.authenticator(
       "CRAM-MD5", *args, warn_deprecation: warn_deprecation, **kwargs, &block
     )
   end
@@ -104,7 +110,7 @@ class IMAPAuthenticatorsTest < Test::Unit::TestCase
 
   def test_cram_md5_authenticator_deprecated
     assert_warn(/CRAM-MD5.+deprecated./) do
-      Net::IMAP.authenticator("CRAM-MD5", "user", "pass")
+      Net::IMAP::SASL.authenticator("CRAM-MD5", "user", "pass")
     end
   end
 
@@ -119,7 +125,7 @@ class IMAPAuthenticatorsTest < Test::Unit::TestCase
   # ----------------------
 
   def digest_md5(*args, warn_deprecation: false, **kwargs, &block)
-    Net::IMAP.authenticator(
+    Net::IMAP::SASL.authenticator(
       "DIGEST-MD5", *args, warn_deprecation: warn_deprecation, **kwargs, &block
     )
   end
@@ -131,7 +137,7 @@ class IMAPAuthenticatorsTest < Test::Unit::TestCase
 
   def test_digest_md5_authenticator_deprecated
     assert_warn(/DIGEST-MD5.+deprecated.+RFC6331/) do
-      Net::IMAP.authenticator("DIGEST-MD5", "user", "pass")
+      Net::IMAP::SASL.authenticator("DIGEST-MD5", "user", "pass")
     end
   end
 

--- a/test/net/imap/test_imap_authenticators.rb
+++ b/test/net/imap/test_imap_authenticators.rb
@@ -12,7 +12,7 @@ class IMAPAuthenticatorsTest < Test::Unit::TestCase
   def plain(...) Net::IMAP.authenticator("PLAIN", ...) end
 
   def test_plain_authenticator_matches_mechanism
-    assert_kind_of(Net::IMAP::PlainAuthenticator, plain("user", "pass"))
+    assert_kind_of(Net::IMAP::SASL::PlainAuthenticator, plain("user", "pass"))
   end
 
   def test_plain_supports_initial_response
@@ -39,7 +39,7 @@ class IMAPAuthenticatorsTest < Test::Unit::TestCase
   def xoauth2(...) Net::IMAP.authenticator("XOAUTH2", ...) end
 
   def test_xoauth2_authenticator_matches_mechanism
-    assert_kind_of(Net::IMAP::XOauth2Authenticator, xoauth2("user", "pass"))
+    assert_kind_of(Net::IMAP::SASL::XOAuth2Authenticator, xoauth2("user", "tok"))
   end
 
   def test_xoauth2
@@ -65,7 +65,7 @@ class IMAPAuthenticatorsTest < Test::Unit::TestCase
   end
 
   def test_login_authenticator_matches_mechanism
-    assert_kind_of(Net::IMAP::LoginAuthenticator, login("n", "p"))
+    assert_kind_of(Net::IMAP::SASL::LoginAuthenticator, login("n", "p"))
   end
 
   def test_login_does_not_support_initial_response
@@ -95,7 +95,7 @@ class IMAPAuthenticatorsTest < Test::Unit::TestCase
   end
 
   def test_cram_md5_authenticator_matches_mechanism
-    assert_kind_of(Net::IMAP::CramMD5Authenticator, cram_md5("n", "p"))
+    assert_kind_of(Net::IMAP::SASL::CramMD5Authenticator, cram_md5("n", "p"))
   end
 
   def test_cram_md5_does_not_support_initial_response
@@ -125,7 +125,8 @@ class IMAPAuthenticatorsTest < Test::Unit::TestCase
   end
 
   def test_digest_md5_authenticator_matches_mechanism
-    assert_kind_of(Net::IMAP::DigestMD5Authenticator, digest_md5("n", "p", "z"))
+    assert_kind_of(Net::IMAP::SASL::DigestMD5Authenticator,
+                   digest_md5("n", "p", "z"))
   end
 
   def test_digest_md5_authenticator_deprecated

--- a/test/net/imap/test_regexps.rb
+++ b/test/net/imap/test_regexps.rb
@@ -25,7 +25,11 @@ class IMAPRegexpsTest < Test::Unit::TestCase
     RegexpCollector.new(
       Net::IMAP,
       exclude_map: {
-        Net::IMAP => %i[BodyTypeAttachment BodyTypeExtension], # deprecated
+        Net::IMAP => %i[
+          BodyTypeAttachment BodyTypeExtension
+          PlainAuthenticator
+          XOauth2Authenticator
+        ], # deprecated
       },
     ).to_h
   )


### PR DESCRIPTION
* `Net::IMAP#authenticate` still behaves identically to before
* `Net::IMAP::PlainAuthenticator` and `Net::IMAP::Xoauth2Authenticator` have been moved to `Net::IMAP::SASL::PlainAuthenticator` and `Net::IMAP::SASL::XOAuth2Authenticator`.  The original constants still work but are deprecated.
* `Net::IMAP::DigestMD5Authenticator`, `Net::IMAP::LoginAuthenticator`, and `Net::IMAP::CramMD5Authenticator` were also moved to `Net::IMAP::SASL`.  The original constants have simply been removed.
* `Net::IMAP::Authenticators` has also been moved to `Net::IMAP::SASL` and has been converted to a class (with a default global instance).  The original mixin module still exists and delegates to `Net::IMAP::SASL`, but it is deprecated.