### PR TITLE
🗑️ Deprecate backward compatible parameters to `new` and `starttls`

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -1075,7 +1075,12 @@ module Net
     # Sends a {STARTTLS command [IMAP4rev1 §6.2.1]}[https://www.rfc-editor.org/rfc/rfc3501#section-6.2.1]
     # to start a TLS session.
     #
-    # Any +options+ are forwarded to OpenSSL::SSL::SSLContext#set_params.
+    # Any +options+ are forwarded directly to
+    # {OpenSSL::SSL::SSLContext#set_params}[https://docs.ruby-lang.org/en/master/OpenSSL/SSL/SSLContext.html#method-i-set_params];
+    # the keys are names of attribute assignment methods on
+    # SSLContext[https://docs.ruby-lang.org/en/master/OpenSSL/SSL/SSLContext.html].
+    #
+    # See DeprecatedClientOptions#starttls for deprecated arguments.
     #
     # This method returns after TLS negotiation and hostname verification are
     # both successful.  Any error indicates that the connection has not been
@@ -1097,14 +1102,8 @@ module Net
     # Server capabilities may change after #starttls, #login, and #authenticate.
     # Cached #capabilities will be cleared when this method completes.
     #
-    def starttls(options = {}, verify = true)
-      begin
-        # for backward compatibility
-        certs = options.to_str
-        options = create_ssl_params(certs, verify)
-      rescue NoMethodError
-      end
-      @ssl_ctx_params, @ssl_ctx = build_ssl_ctx(options || {})
+    def starttls(**options)
+      @ssl_ctx_params, @ssl_ctx = build_ssl_ctx(options)
       send_command("STARTTLS") do |resp|
         if resp.kind_of?(TaggedResponse) && resp.name == "OK"
           clear_cached_capabilities

--- a/lib/net/imap/deprecated_client_options.rb
+++ b/lib/net/imap/deprecated_client_options.rb
@@ -91,6 +91,33 @@ module Net
         end
       end
 
+      # :call-seq:
+      #   starttls(**options) # standard
+      #   starttls(options = {}) # obsolete
+      #   starttls(certs = nil, verify = true) # deprecated
+      #
+      # Translates Net::IMAP#starttls arguments for backward compatibility.
+      #
+      # Support for +certs+ and +verify+ will be dropped in a future release.
+      #
+      # See ::new for interpretation of +certs+ and +verify+.
+      def starttls(*deprecated, **options)
+        if deprecated.empty?
+          super(**options)
+        elsif options.any?
+          # starttls(*__invalid__, **options)
+          raise ArgumentError, "Do not combine deprecated and keyword options"
+        elsif deprecated.first.respond_to?(:to_hash) && deprecated.length > 1
+          # starttls(*__invalid__, **options)
+          raise ArgumentError, "Do not use deprecated verify param with options hash"
+        elsif deprecated.first.respond_to?(:to_hash)
+          super(**Hash.try_convert(deprecated.first))
+        else
+          warn "DEPRECATED: Call Net::IMAP#starttls with keyword options", uplevel: 1
+          super(**create_ssl_params(*deprecated))
+        end
+      end
+
       private
 
       def create_ssl_params(certs = nil, verify = true)

--- a/lib/net/imap/deprecated_client_options.rb
+++ b/lib/net/imap/deprecated_client_options.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+module Net
+  class IMAP < Protocol
+
+    # This module handles deprecated arguments to various Net::IMAP methods.
+    module DeprecatedClientOptions
+
+      # :call-seq:
+      #   Net::IMAP.new(host, **options) # standard keyword options
+      #   Net::IMAP.new(host, options)   # obsolete hash options
+      #   Net::IMAP.new(host, port)      # obsolete port argument
+      #   Net::IMAP.new(host, port, usessl, certs = nil, verify = true) # deprecated SSL arguments
+      #
+      # Translates Net::IMAP.new arguments for backward compatibility.
+      #
+      # ==== Obsolete arguments
+      #
+      # Using obsolete arguments does not a warning.  Obsolete arguments will be
+      # deprecated by a future release.
+      #
+      # If a second positional argument is given and it is a hash (or is
+      # convertable via +#to_hash+), it is converted to keyword arguments.
+      #
+      #     # Obsolete:
+      #     Net::IMAP.new("imap.example.com", options_hash)
+      #     # Use instead:
+      #     Net::IMAP.new("imap.example.com", **options_hash)
+      #
+      # If a second positional argument is given and it is not a hash, it is
+      # converted to the +port+ keyword argument.
+      #     # Obsolete:
+      #     Net::IMAP.new("imap.example.com", 114433)
+      #     # Use instead:
+      #     Net::IMAP.new("imap.example.com", port: 114433)
+      #
+      # ==== Deprecated arguments
+      #
+      # Using deprecated arguments prints a warning.  Convert to keyword
+      # arguments to avoid the warning.  Deprecated arguments will be removed in
+      # a future release.
+      #
+      # If +usessl+ is false, +certs+, and +verify+ are ignored.  When it true,
+      # all three arguments are converted to the +ssl+ keyword argument.
+      # Without +certs+ or +verify+, it is converted to <tt>ssl: true</tt>.
+      #     # DEPRECATED:
+      #     Net::IMAP.new("imap.example.com", nil, true) # => prints a warning
+      #     # Use instead:
+      #     Net::IMAP.new("imap.example.com", ssl: true)
+      #
+      # When +certs+ is a path to a directory, it is converted to <tt>ca_path:
+      # certs</tt>.
+      #     # DEPRECATED:
+      #     Net::IMAP.new("imap.example.com", nil, true, "/path/to/certs") # => prints a warning
+      #     # Use instead:
+      #     Net::IMAP.new("imap.example.com", ssl: {ca_path: "/path/to/certs"})
+      #
+      # When +certs+ is a path to a file, it is converted to <tt>ca_file:
+      # certs</tt>.
+      #     # DEPRECATED:
+      #     Net::IMAP.new("imap.example.com", nil, true, "/path/to/cert.pem") # => prints a warning
+      #     # Use instead:
+      #     Net::IMAP.new("imap.example.com", ssl: {ca_file: "/path/to/cert.pem"})
+      #
+      # When +verify+ is +false+, it is converted to <tt>verify_mode:
+      # OpenSSL::SSL::VERIFY_NONE</tt>.
+      #     # DEPRECATED:
+      #     Net::IMAP.new("imap.example.com", nil, true, nil, false) # => prints a warning
+      #     # Use instead:
+      #     Net::IMAP.new("imap.example.com", ssl: {verify_mode: OpenSSL::SSL::VERIFY_NONE})
+      #
+      def initialize(host, port_or_options = nil, *deprecated, **options)
+        if port_or_options.nil? && deprecated.empty?
+          super host, **options
+        elsif options.any?
+          # Net::IMAP.new(host, *__invalid__, **options)
+          raise ArgumentError, "Do not combine deprecated and keyword arguments"
+        elsif port_or_options.respond_to?(:to_hash) and deprecated.any?
+          # Net::IMAP.new(host, options, *__invalid__)
+          raise ArgumentError, "Do not use deprecated SSL params with options hash"
+        elsif port_or_options.respond_to?(:to_hash)
+          super host, **Hash.try_convert(port_or_options)
+        elsif deprecated.empty?
+          super host, port: port_or_options
+        elsif deprecated.shift
+          warn "DEPRECATED: Call Net::IMAP.new with keyword options", uplevel: 1
+          super host, port: port_or_options, ssl: create_ssl_params(*deprecated)
+        else
+          warn "DEPRECATED: Call Net::IMAP.new with keyword options", uplevel: 1
+          super host, port: port_or_options, ssl: false
+        end
+      end
+
+      private
+
+      def create_ssl_params(certs = nil, verify = true)
+        params = {}
+        if certs
+          if File.file?(certs)
+            params[:ca_file] = certs
+          elsif File.directory?(certs)
+            params[:ca_path] = certs
+          end
+        end
+        params[:verify_mode] =
+          verify ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
+        params
+      end
+
+    end
+  end
+end

--- a/test/net/imap/fake_server/test_helper.rb
+++ b/test/net/imap/fake_server/test_helper.rb
@@ -4,10 +4,14 @@ require_relative "../fake_server"
 
 module Net::IMAP::FakeServer::TestHelper
 
-  def run_fake_server_in_thread(timeout: 5, **opts)
+  def run_fake_server_in_thread(ignore_io_error: false, timeout: 5, **opts)
     Timeout.timeout(timeout) do
       server = Net::IMAP::FakeServer.new(timeout: timeout, **opts)
-      @threads << Thread.new do server.run end if @threads
+      @threads << Thread.new do
+        server.run
+      rescue IOError
+        raise unless ignore_io_error
+      end
       yield server
     ensure
       server&.shutdown

--- a/test/net/imap/test_deprecated_client_options.rb
+++ b/test/net/imap/test_deprecated_client_options.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "net/imap"
+require "test/unit"
+require_relative "fake_server"
+
+class DeprecatedClientOptionsTest < Test::Unit::TestCase
+  include Net::IMAP::FakeServer::TestHelper
+
+  def setup
+    @do_not_reverse_lookup = Socket.do_not_reverse_lookup
+    Socket.do_not_reverse_lookup = true
+    @threads = []
+  end
+
+  def teardown
+    assert_join_threads(@threads) unless @threads.empty?
+  ensure
+    Socket.do_not_reverse_lookup = @do_not_reverse_lookup
+  end
+
+  class InitializeTests < DeprecatedClientOptionsTest
+
+    test "Convert obsolete options hash to keywords" do
+      run_fake_server_in_thread do |server|
+        with_client(server.host, {port: server.port, ssl: false}) do |client|
+          assert_equal server.host, client.host
+          assert_equal server.port, client.port
+          assert_equal false, client.ssl_ctx_params
+        end
+      end
+    end
+
+    test "Convert obsolete port argument to :port keyword" do
+      run_fake_server_in_thread do |server|
+        with_client(server.host, server.port) do |client|
+          assert_equal server.host, client.host
+          assert_equal server.port, client.port
+          assert_equal false, client.ssl_ctx_params
+        end
+      end
+    end
+
+    test "Convert deprecated usessl (= false) with warning" do
+      run_fake_server_in_thread do |server|
+        assert_deprecated_warning(/Call Net::IMAP\.new with keyword/i) do
+          with_client(server.host, server.port, false, :who, :cares) do |client|
+            assert_equal server.host, client.host
+            assert_equal server.port, client.port
+            assert_equal false, client.ssl_ctx_params
+          end
+        end
+      end
+    end
+
+    test "Convert deprecated usessl (= true) and certs, with warning" do
+      run_fake_server_in_thread(implicit_tls: true) do |server|
+        certs = server.config.tls[:ca_file]
+        assert_deprecated_warning(/Call Net::IMAP\.new with keyword/i) do
+          with_client("localhost", server.port, true, certs) do |client|
+            assert_equal "localhost", client.host
+            assert_equal server.port, client.port
+            assert_equal(
+              {ca_file: certs, verify_mode: OpenSSL::SSL::VERIFY_PEER},
+              client.ssl_ctx_params
+            )
+          end
+        end
+      end
+    end
+
+    test "Convert deprecated usessl (= true) and verify (= false), with warning" do
+      run_fake_server_in_thread(implicit_tls: true) do |server|
+        assert_deprecated_warning(/Call Net::IMAP\.new with keyword/i) do
+          with_client("localhost", server.port, true, nil, false) do |client|
+            assert_equal "localhost", client.host
+            assert_equal server.port, client.port
+            assert_equal(
+              {verify_mode: OpenSSL::SSL::VERIFY_NONE},
+              client.ssl_ctx_params
+            )
+            assert_equal OpenSSL::SSL::VERIFY_NONE, client.ssl_ctx.verify_mode
+          end
+        end
+      end
+    end
+
+    test "combined options hash and keyword args raises ArgumentError" do
+      ex = nil
+      run_fake_server_in_thread(
+        ignore_io_error: true, implicit_tls: true
+      ) do |server|
+        imap = Net::IMAP.new("localhost", {port: 993}, ssl: true)
+      rescue => ex
+        nil
+      ensure
+        imap&.disconnect
+      end
+      assert_equal ArgumentError, ex.class
+    end
+
+    test "combined options hash and ssl args raises ArgumentError" do
+      ex = nil
+      run_fake_server_in_thread(
+        ignore_io_error: true, implicit_tls: true
+      ) do |server|
+        imap = Net::IMAP.new("localhost", {port: 993}, true)
+      rescue => ex
+        nil
+      ensure
+        imap&.disconnect
+      end
+      assert_equal ArgumentError, ex.class
+    end
+
+  end
+
+end


### PR DESCRIPTION
Since 2007, `.new` and `#starttls` have taken an options hash (bad00272) and the original parameters have been undocumented (e631911e).  The original `usessl`, `certs`, and `verify` parameters will now print a deprecation warning whenever they are used.  In a future release (no sooner than a year after 0.4.0 is released), they will be removed from both methods.

The `options` hash has been converted to keyword parameters.  An. sending `port` as the second argument to `#initialize` is also obsolete.  Neither of them will print a deprecation warning, but they _will_ be marked as deprecated in a future release.

To simplify the implementations of both `#initialize` and `#starttls`, the backwards compatible parameters have all been extracted to a `DeprecatedClientOptions` module, which is (currently) prepended to `Net::IMAP`.  

_Note: #174 accidentally included rdoc references to `DeprecatedClientOptions`, which is added by this PR._