### PR TITLE
📚 Update SASL docs and add attr_readers

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -1139,13 +1139,13 @@ module Net
     # the documentation for the specific mechanisms you are using:
     #
     # +ANONYMOUS+::
-    #     See AnonymousAuthenticator[Net::IMAP::SASL::AnonymousAuthenticator].
+    #     See AnonymousAuthenticator[rdoc-ref:Net::IMAP::SASL::AnonymousAuthenticator].
     #
     #     Allows the user to gain access to public services or resources without
     #     authenticating or disclosing an identity.
     #
     # +EXTERNAL+::
-    #     See ExternalAuthenticator[Net::IMAP::SASL::ExternalAuthenticator].
+    #     See ExternalAuthenticator[rdoc-ref:Net::IMAP::SASL::ExternalAuthenticator].
     #
     #     Authenticates using already established credentials, such as a TLS
     #     certificate or IPsec.

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -109,7 +109,7 @@ module Net
   # sending them.  Special care should be taken to follow the #capabilities
   # requirements for #starttls, #login, and #authenticate.
   #
-  # See #capable?, #auth_capable, #capabilities, #auth_mechanisms to discover
+  # See #capable?, #auth_capable?, #capabilities, #auth_mechanisms to discover
   # server capabilities.  For relevant capability requirements, see the
   # documentation on each \IMAP command.
   #

--- a/lib/net/imap/sasl.rb
+++ b/lib/net/imap/sasl.rb
@@ -28,13 +28,13 @@ module Net
     # the documentation for the specific mechanisms you are using:
     #
     # +ANONYMOUS+::
-    #     See AnonymousAuthenticator[Net::IMAP::SASL::AnonymousAuthenticator].
+    #     See AnonymousAuthenticator.
     #
     #     Allows the user to gain access to public services or resources without
     #     authenticating or disclosing an identity.
     #
     # +EXTERNAL+::
-    #     See ExternalAuthenticator[Net::IMAP::SASL::ExternalAuthenticator].
+    #     See ExternalAuthenticator.
     #
     #     Authenticates using already established credentials, such as a TLS
     #     certificate or IPsec.

--- a/lib/net/imap/sasl/anonymous_authenticator.rb
+++ b/lib/net/imap/sasl/anonymous_authenticator.rb
@@ -21,7 +21,7 @@ module Net
         # #anonymous_message is an optional message which is sent to the server.
         # It may be sent as a positional argument or as a keyword argument.
         #
-        # Any other keyword parameters are quietly ignored.
+        # Any other keyword arguments are silently ignored.
         def initialize(anon_msg = nil, anonymous_message: nil, **)
           message = (anonymous_message || anon_msg || "").to_str
           @anonymous_message = StringPrep::Trace.stringprep_trace message
@@ -31,14 +31,15 @@ module Net
           end
         end
 
-        # A token sent for the +ANONYMOUS+ mechanism.
+        # An optional token sent for the +ANONYMOUS+ mechanism., up to 255 UTF-8
+        # characters in length.
         #
         # If it contains an "@" sign, the message must be a valid email address
         # (+addr-spec+ from RFC-2822[https://tools.ietf.org/html/rfc2822]).
         # Email syntax is _not_ validated by AnonymousAuthenticator.
         #
         # Otherwise, it can be any UTF8 string which is permitted by the
-        # StringPrep::Trace profile, up to 255 UTF-8 characters in length.
+        # StringPrep::Trace profile.
         attr_reader :anonymous_message
 
         # :call-seq:
@@ -48,7 +49,9 @@ module Net
         def initial_response?; true end
 
         # Returns #anonymous_message.
-        def process(_server_challenge_string) anonymous_message end
+        def process(_server_challenge_string)
+          anonymous_message
+        end
 
       end
     end

--- a/lib/net/imap/sasl/anonymous_authenticator.rb
+++ b/lib/net/imap/sasl/anonymous_authenticator.rb
@@ -9,6 +9,17 @@ module Net
       # Net::IMAP#authenticate.
       class AnonymousAuthenticator
 
+        # An optional token sent for the +ANONYMOUS+ mechanism., up to 255 UTF-8
+        # characters in length.
+        #
+        # If it contains an "@" sign, the message must be a valid email address
+        # (+addr-spec+ from RFC-2822[https://tools.ietf.org/html/rfc2822]).
+        # Email syntax is _not_ validated by AnonymousAuthenticator.
+        #
+        # Otherwise, it can be any UTF8 string which is permitted by the
+        # StringPrep::Trace profile.
+        attr_reader :anonymous_message
+
         # :call-seq:
         #   new(anonymous_message = "", **) -> authenticator
         #   new(anonymous_message:  "", **) -> authenticator
@@ -30,17 +41,6 @@ module Net
                   "anonymous_message is too long.  (%d codepoints)" % [size]
           end
         end
-
-        # An optional token sent for the +ANONYMOUS+ mechanism., up to 255 UTF-8
-        # characters in length.
-        #
-        # If it contains an "@" sign, the message must be a valid email address
-        # (+addr-spec+ from RFC-2822[https://tools.ietf.org/html/rfc2822]).
-        # Email syntax is _not_ validated by AnonymousAuthenticator.
-        #
-        # Otherwise, it can be any UTF8 string which is permitted by the
-        # StringPrep::Trace profile.
-        attr_reader :anonymous_message
 
         # :call-seq:
         #   initial_response? -> true

--- a/lib/net/imap/sasl/cram_md5_authenticator.rb
+++ b/lib/net/imap/sasl/cram_md5_authenticator.rb
@@ -14,13 +14,6 @@
 # of cleartext and recommends TLS version 1.2 or greater be used for all
 # traffic.  With TLS +CRAM-MD5+ is okay, but so is +PLAIN+
 class Net::IMAP::SASL::CramMD5Authenticator
-  def process(challenge)
-    digest = hmac_md5(challenge, @password)
-    return @user + " " + digest
-  end
-
-  private
-
   def initialize(user, password, warn_deprecation: true, **_ignored)
     if warn_deprecation
       warn "WARNING: CRAM-MD5 mechanism is deprecated." # TODO: recommend SCRAM
@@ -29,6 +22,13 @@ class Net::IMAP::SASL::CramMD5Authenticator
     @user = user
     @password = password
   end
+
+  def process(challenge)
+    digest = hmac_md5(challenge, @password)
+    return @user + " " + digest
+  end
+
+  private
 
   def hmac_md5(text, key)
     if key.length > 64

--- a/lib/net/imap/sasl/digest_md5_authenticator.rb
+++ b/lib/net/imap/sasl/digest_md5_authenticator.rb
@@ -9,6 +9,21 @@
 # {RFC6331}[https://tools.ietf.org/html/rfc6331] and should not be relied on for
 # security.  It is included for compatibility with existing servers.
 class Net::IMAP::SASL::DigestMD5Authenticator
+  STAGE_ONE = :stage_one
+  STAGE_TWO = :stage_two
+  private_constant :STAGE_ONE, :STAGE_TWO
+
+  def initialize(user, password, authname = nil, warn_deprecation: true)
+    if warn_deprecation
+      warn "WARNING: DIGEST-MD5 SASL mechanism was deprecated by RFC6331."
+      # TODO: recommend SCRAM instead.
+    end
+    require "digest/md5"
+    require "strscan"
+    @user, @password, @authname = user, password, authname
+    @nc, @stage = {}, STAGE_ONE
+  end
+
   def process(challenge)
     case @stage
     when STAGE_ONE
@@ -74,22 +89,7 @@ class Net::IMAP::SASL::DigestMD5Authenticator
     end
   end
 
-  def initialize(user, password, authname = nil, warn_deprecation: true)
-    if warn_deprecation
-      warn "WARNING: DIGEST-MD5 SASL mechanism was deprecated by RFC6331."
-      # TODO: recommend SCRAM instead.
-    end
-    require "digest/md5"
-    require "strscan"
-    @user, @password, @authname = user, password, authname
-    @nc, @stage = {}, STAGE_ONE
-  end
-
-
   private
-
-  STAGE_ONE = :stage_one
-  STAGE_TWO = :stage_two
 
   def nc(nonce)
     if @nc.has_key? nonce

--- a/lib/net/imap/sasl/digest_md5_authenticator.rb
+++ b/lib/net/imap/sasl/digest_md5_authenticator.rb
@@ -1,29 +1,72 @@
 # frozen_string_literal: true
 
 # Net::IMAP authenticator for the "`DIGEST-MD5`" SASL mechanism type, specified
-# in RFC2831(https://tools.ietf.org/html/rfc2831).  See Net::IMAP#authenticate.
+# in RFC-2831[https://tools.ietf.org/html/rfc2831].  See Net::IMAP#authenticate.
 #
 # == Deprecated
 #
 # "+DIGEST-MD5+" has been deprecated by
-# {RFC6331}[https://tools.ietf.org/html/rfc6331] and should not be relied on for
+# RFC-6331[https://tools.ietf.org/html/rfc6331] and should not be relied on for
 # security.  It is included for compatibility with existing servers.
 class Net::IMAP::SASL::DigestMD5Authenticator
   STAGE_ONE = :stage_one
   STAGE_TWO = :stage_two
   private_constant :STAGE_ONE, :STAGE_TWO
 
-  def initialize(user, password, authname = nil, warn_deprecation: true)
+  # Authentication identity: the identity that matches the #password.
+  #
+  # RFC-2831[https://tools.ietf.org/html/rfc2831] uses the term +username+.
+  # "Authentication identity" is the generic term used by
+  # RFC-4422[https://tools.ietf.org/html/rfc4422].
+  # RFC-4616[https://tools.ietf.org/html/rfc4616] and many later RFCs abbreviate
+  # that to +authcid+.  So +authcid+ is available as an alias for #username.
+  attr_reader :username
+
+  # A password or passphrase that matches the #username.
+  #
+  # The +password+ will be used to create the response digest.
+  attr_reader :password
+
+  # Authorization identity: an identity to act as or on behalf of.  The identity
+  # form is application protocol specific.  If not provided or left blank, the
+  # server derives an authorization identity from the authentication identity.
+  # The server is responsible for verifying the client's credentials and
+  # verifying that the identity it associates with the client's authentication
+  # identity is allowed to act as (or on behalf of) the authorization identity.
+  #
+  # For example, an administrator or superuser might take on another role:
+  #
+  #     imap.authenticate "DIGEST-MD5", "root", ->{passwd}, authzid: "user"
+  #
+  attr_reader :authzid
+
+  # :call-seq:
+  #   new(username,  password,  authzid = nil) -> authenticator
+  #
+  # Creates an Authenticator for the "+DIGEST-MD5+" SASL mechanism.
+  #
+  # Called by Net::IMAP#authenticate and similar methods on other clients.
+  #
+  # ==== Parameters
+  #
+  # * #username — Identity whose #password is used.
+  # * #password — A password or passphrase associated with this #username.
+  # * #authzid ― Alternate identity to act as or on behalf of.  Optional.
+  # * +warn_deprecation+ — Set to +false+ to silence the warning.
+  #
+  # See the documentation for each attribute for more details.
+  def initialize(username, password, authzid = nil, warn_deprecation: true)
     if warn_deprecation
       warn "WARNING: DIGEST-MD5 SASL mechanism was deprecated by RFC6331."
       # TODO: recommend SCRAM instead.
     end
     require "digest/md5"
     require "strscan"
-    @user, @password, @authname = user, password, authname
+    @username, @password, @authzid = username, password, authzid
     @nc, @stage = {}, STAGE_ONE
   end
 
+  # Responds to server challenge in two stages.
   def process(challenge)
     case @stage
     when STAGE_ONE
@@ -46,7 +89,7 @@ class Net::IMAP::SASL::DigestMD5Authenticator
 
       response = {
         :nonce => sparams['nonce'],
-        :username => @user,
+        :username => @username,
         :realm => sparams['realm'],
         :cnonce => Digest::MD5.hexdigest("%.15f:%.15f:%d" % [Time.now.to_f, rand, Process.pid.to_s]),
         :'digest-uri' => 'imap/' + sparams['realm'],
@@ -56,7 +99,7 @@ class Net::IMAP::SASL::DigestMD5Authenticator
         :charset => sparams['charset'],
       }
 
-      response[:authzid] = @authname unless @authname.nil?
+      response[:authzid] = @authzid unless @authzid.nil?
 
       # now, the real thing
       a0 = Digest::MD5.digest( [ response.values_at(:username, :realm), @password ].join(':') )

--- a/lib/net/imap/sasl/external_authenticator.rb
+++ b/lib/net/imap/sasl/external_authenticator.rb
@@ -12,6 +12,12 @@ module Net
       # established external to SASL, for example by TLS certificate or IPsec.
       class ExternalAuthenticator
 
+        # Authorization identity: an identity to act as or on behalf of.
+        #
+        # If not explicitly provided, the server defaults to using the identity
+        # that was authenticated by the external credentials.
+        attr_reader :authzid
+
         # :call-seq:
         #   new(authzid: nil, **) -> authenticator
         #
@@ -29,12 +35,6 @@ module Net
             raise ArgumentError, "contains NULL"
           end
         end
-
-        # Authorization identity: an identity to act as or on behalf of.
-        #
-        # If not explicitly provided, the server defaults to using the identity
-        # that was authenticated by the external credentials.
-        attr_reader :authzid
 
         # :call-seq:
         #   initial_response? -> true

--- a/lib/net/imap/sasl/login_authenticator.rb
+++ b/lib/net/imap/sasl/login_authenticator.rb
@@ -18,20 +18,9 @@
 # {draft-murchison-sasl-login}[https://www.iana.org/go/draft-murchison-sasl-login]
 # for both specification and deprecation.
 class Net::IMAP::SASL::LoginAuthenticator
-  def process(data)
-    case @state
-    when STATE_USER
-      @state = STATE_PASSWORD
-      return @user
-    when STATE_PASSWORD
-      return @password
-    end
-  end
-
-  private
-
   STATE_USER = :USER
   STATE_PASSWORD = :PASSWORD
+  private_constant :STATE_USER, :STATE_PASSWORD
 
   def initialize(user, password, warn_deprecation: true, **_ignored)
     if warn_deprecation
@@ -42,4 +31,13 @@ class Net::IMAP::SASL::LoginAuthenticator
     @state = STATE_USER
   end
 
+  def process(data)
+    case @state
+    when STATE_USER
+      @state = STATE_PASSWORD
+      return @user
+    when STATE_PASSWORD
+      return @password
+    end
+  end
 end

--- a/lib/net/imap/sasl/plain_authenticator.rb
+++ b/lib/net/imap/sasl/plain_authenticator.rb
@@ -10,17 +10,8 @@
 # greater be used for all traffic, and deprecate cleartext access ASAP.  +PLAIN+
 # can be secured by TLS encryption.
 class Net::IMAP::SASL::PlainAuthenticator
-
-  def initial_response?; true end
-
-  def process(data)
-    return "#@authzid\0#@username\0#@password"
-  end
-
-  # :nodoc:
   NULL = -"\0".b
-
-  private
+  private_constant :NULL
 
   # +username+ is the authentication identity, the identity whose +password+ is
   # used.  +username+ is referred to as +authcid+ by
@@ -37,6 +28,12 @@ class Net::IMAP::SASL::PlainAuthenticator
     @username = username
     @password = password
     @authzid  = authzid
+  end
+
+  def initial_response?; true end
+
+  def process(data)
+    return "#@authzid\0#@username\0#@password"
   end
 
 end

--- a/lib/net/imap/sasl/plain_authenticator.rb
+++ b/lib/net/imap/sasl/plain_authenticator.rb
@@ -1,26 +1,55 @@
 # frozen_string_literal: true
 
 # Authenticator for the "+PLAIN+" SASL mechanism, specified in
-# RFC4616[https://tools.ietf.org/html/rfc4616].  See Net::IMAP#authenticate.
+# RFC-4616[https://tools.ietf.org/html/rfc4616].  See Net::IMAP#authenticate.
 #
 # +PLAIN+ authentication sends the password in cleartext.
-# RFC3501[https://tools.ietf.org/html/rfc3501] encourages servers to disable
+# RFC-3501[https://tools.ietf.org/html/rfc3501] encourages servers to disable
 # cleartext authentication until after TLS has been negotiated.
-# RFC8314[https://tools.ietf.org/html/rfc8314] recommends TLS version 1.2 or
+# RFC-8314[https://tools.ietf.org/html/rfc8314] recommends TLS version 1.2 or
 # greater be used for all traffic, and deprecate cleartext access ASAP.  +PLAIN+
 # can be secured by TLS encryption.
 class Net::IMAP::SASL::PlainAuthenticator
+
   NULL = -"\0".b
   private_constant :NULL
 
-  # +username+ is the authentication identity, the identity whose +password+ is
-  # used.  +username+ is referred to as +authcid+ by
-  # RFC4616[https://tools.ietf.org/html/rfc4616].
+  # Authentication identity: the identity that matches the #password.
   #
-  # +authzid+ is the authorization identity (identity to act as).  It can
-  # usually be left blank. When +authzid+ is left blank (nil or empty string)
-  # the server will derive an identity from the credentials and use that as the
-  # authorization identity.
+  # RFC-4616[https://tools.ietf.org/html/rfc4616] and many later RFCs abbreviate
+  # this to +authcid+.
+  attr_reader :username
+
+  # A password or passphrase that matches the #username.
+  attr_reader :password
+
+  # Authorization identity: an identity to act as or on behalf of.  The identity
+  # form is application protocol specific.  If not provided or left blank, the
+  # server derives an authorization identity from the authentication identity.
+  # The server is responsible for verifying the client's credentials and
+  # verifying that the identity it associates with the client's authentication
+  # identity is allowed to act as (or on behalf of) the authorization identity.
+  #
+  # For example, an administrator or superuser might take on another role:
+  #
+  #     imap.authenticate "PLAIN", "root", passwd, authzid: "user"
+  #
+  attr_reader :authzid
+
+  # :call-seq:
+  #   new(username, password, authzid: nil) -> authenticator
+  #
+  # Creates an Authenticator for the "+PLAIN+" SASL mechanism.
+  #
+  # Called by Net::IMAP#authenticate and similar methods on other clients.
+  #
+  # === Parameters
+  #
+  # * #username ― Identity whose +password+ is used.
+  # * #password ― Password or passphrase associated with this username+.
+  # * #authzid ― Alternate identity to act as or on behalf of.  Optional.
+  #
+  # See attribute documentation for more details.
   def initialize(username, password, authzid: nil)
     raise ArgumentError, "username contains NULL" if username&.include?(NULL)
     raise ArgumentError, "password contains NULL" if password&.include?(NULL)
@@ -30,8 +59,13 @@ class Net::IMAP::SASL::PlainAuthenticator
     @authzid  = authzid
   end
 
+  # :call-seq:
+  #   initial_response? -> true
+  #
+  # +PLAIN+ can send an initial client response.
   def initial_response?; true end
 
+  # Responds with the client's credentials.
   def process(data)
     return "#@authzid\0#@username\0#@password"
   end

--- a/lib/net/imap/sasl/xoauth2_authenticator.rb
+++ b/lib/net/imap/sasl/xoauth2_authenticator.rb
@@ -1,22 +1,73 @@
 # frozen_string_literal: true
 
+# Authenticator for the "+XOAUTH2+" SASL mechanism.  This mechanism was
+# originally created for GMail and widely adopted by hosted email providers.
+# +XOAUTH2+ has been documented by
+# Google[https://developers.google.com/gmail/imap/xoauth2-protocol] and
+# Microsoft[https://learn.microsoft.com/en-us/exchange/client-developer/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth].
+#
+# This mechanism requires an OAuth2 +access_token+ which has been authorized
+# with the appropriate OAuth2 scopes to access IMAP.  These scopes are not
+# standardized---consult each email service provider's documentation.
+#
+# Although this mechanism was never standardized and has been obsoleted by
+# "+OAUTHBEARER+", it is still very widely supported.
+#
+# See Net::IMAP::SASL:: OAuthBearerAuthenticator.
 class Net::IMAP::SASL::XOAuth2Authenticator
 
-  def initialize(user, oauth2_token)
-    @user = user
+  # It is unclear from {Google's original XOAUTH2
+  # documentation}[https://developers.google.com/gmail/imap/xoauth2-protocol],
+  # whether "User" refers to the authentication identity (+authcid+) or the
+  # authorization identity (+authzid+).  It appears to behave as +authzid+.
+  #
+  # {Microsoft's documentation for shared
+  # mailboxes}[https://learn.microsoft.com/en-us/exchange/client-developer/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth#sasl-xoauth2-authentication-for-shared-mailboxes-in-office-365]
+  # clearly indicate that the Office 365 server interprets it as the
+  # authorization identity.
+  attr_reader :username
+
+  # An OAuth2 access token which has been authorized with the appropriate OAuth2
+  # scopes to use the service for #username.
+  attr_reader :oauth2_token
+
+  # :call-seq:
+  # :call-seq:
+  #   new(username,  oauth2_token) -> authenticator
+  #
+  # Creates an Authenticator for the "+XOAUTH2+" SASL mechanism, as specified by
+  # Google[https://developers.google.com/gmail/imap/xoauth2-protocol],
+  # Microsoft[https://learn.microsoft.com/en-us/exchange/client-developer/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth]
+  # and Yahoo[https://senders.yahooinc.com/developer/documentation].
+  #
+  # === Properties
+  #
+  # * #username --- the username for the account being accessed.
+  # * #oauth2_token --- An OAuth2.0 access token which is authorized to access
+  #   the service for #username.
+  #
+  # See the documentation for each attribute for more details.
+  def initialize(username, oauth2_token)
+    @username = username
     @oauth2_token = oauth2_token
   end
 
+  # :call-seq:
+  #   initial_response? -> true
+  #
+  # +PLAIN+ can send an initial client response.
   def initial_response?; true end
 
+  # Returns the XOAUTH2 formatted response, which combines the +username+
+  # with the +oauth2_token+.
   def process(_data)
-    build_oauth2_string(@user, @oauth2_token)
+    build_oauth2_string(@username, @oauth2_token)
   end
 
   private
 
-  def build_oauth2_string(user, oauth2_token)
-    format("user=%s\1auth=Bearer %s\1\1", user, oauth2_token)
+  def build_oauth2_string(username, oauth2_token)
+    format("user=%s\1auth=Bearer %s\1\1", username, oauth2_token)
   end
 
 end

--- a/lib/net/imap/sasl/xoauth2_authenticator.rb
+++ b/lib/net/imap/sasl/xoauth2_authenticator.rb
@@ -2,6 +2,11 @@
 
 class Net::IMAP::SASL::XOAuth2Authenticator
 
+  def initialize(user, oauth2_token)
+    @user = user
+    @oauth2_token = oauth2_token
+  end
+
   def initial_response?; true end
 
   def process(_data)
@@ -9,11 +14,6 @@ class Net::IMAP::SASL::XOAuth2Authenticator
   end
 
   private
-
-  def initialize(user, oauth2_token)
-    @user = user
-    @oauth2_token = oauth2_token
-  end
 
   def build_oauth2_string(user, oauth2_token)
     format("user=%s\1auth=Bearer %s\1\1", user, oauth2_token)

--- a/test/net/imap/test_imap_authenticators.rb
+++ b/test/net/imap/test_imap_authenticators.rb
@@ -88,7 +88,7 @@ class IMAPAuthenticatorsTest < Test::Unit::TestCase
     assert_kind_of(Net::IMAP::SASL::XOAuth2Authenticator, xoauth2("user", "tok"))
   end
 
-  def test_xoauth2
+  def test_xoauth2_response
     assert_equal(
       "user=username\1auth=Bearer token\1\1",
       xoauth2("username", "token").process(nil)


### PR DESCRIPTION
Because the documentation for `Net::IMAP#authenticate` and `Net::IMAP::SASL` both point at the individual authenticators to document their own parameters, it's important that all of the authenticators have documentation of their own.  `PLAIN` and `XOAUTH2` in particular both needed more documentation than they had.  This PR fixes that, in addition to a few other documentation-related changes.

Each configuration parameter was given an `attr_reader` (except for CRAM-MD5 and LOGIN, which are deprecated).  In addition to being useful for debugging, the attributes are documented in more detail than the same `#initialize` parameters.  In a few cases, ivars were renamed to normalize the parameter names between different authenticators.

Several internal-use constants were made `private`, which also removes them from the rdoc.

Several authenticator class definitions were re-ordered to place `#initialize` above all other method `def`s (after constants and `attr_reader`s).  By moving them out of the `private` section, rdoc now documents the method parameters for them.