### PR TITLE
♻️ Allow keyword args on all SASL authenticators

### DIFF
--- a/lib/net/imap/sasl/digest_md5_authenticator.rb
+++ b/lib/net/imap/sasl/digest_md5_authenticator.rb
@@ -41,7 +41,8 @@ class Net::IMAP::SASL::DigestMD5Authenticator
   attr_reader :authzid
 
   # :call-seq:
-  #   new(username,  password,  authzid = nil) -> authenticator
+  #   new(username,  password,  authzid = nil, **options) -> authenticator
+  #   new(username:, password:, authzid:  nil, **options) -> authenticator
   #
   # Creates an Authenticator for the "+DIGEST-MD5+" SASL mechanism.
   #
@@ -55,7 +56,12 @@ class Net::IMAP::SASL::DigestMD5Authenticator
   # * +warn_deprecation+ — Set to +false+ to silence the warning.
   #
   # See the documentation for each attribute for more details.
-  def initialize(username, password, authzid = nil, warn_deprecation: true)
+  def initialize(user = nil, pass = nil, authz = nil,
+                 username: nil, password: nil, authzid: nil,
+                 warn_deprecation: true, **)
+    username ||= user or raise ArgumentError, "missing username"
+    password ||= pass or raise ArgumentError, "missing password"
+    authzid  ||= authz
     if warn_deprecation
       warn "WARNING: DIGEST-MD5 SASL mechanism was deprecated by RFC6331."
       # TODO: recommend SCRAM instead.

--- a/lib/net/imap/sasl/external_authenticator.rb
+++ b/lib/net/imap/sasl/external_authenticator.rb
@@ -29,7 +29,7 @@ module Net
         # #authzid is an optional identity to act as or on behalf of.
         #
         # Any other keyword parameters are quietly ignored.
-        def initialize(authzid: nil)
+        def initialize(authzid: nil, **)
           @authzid = authzid&.to_str&.encode "UTF-8"
           if @authzid&.match?(/\u0000/u) # also validates UTF8 encoding
             raise ArgumentError, "contains NULL"

--- a/lib/net/imap/sasl/plain_authenticator.rb
+++ b/lib/net/imap/sasl/plain_authenticator.rb
@@ -37,7 +37,8 @@ class Net::IMAP::SASL::PlainAuthenticator
   attr_reader :authzid
 
   # :call-seq:
-  #   new(username, password, authzid: nil) -> authenticator
+  #   new(username,  password,  authzid: nil, **) -> authenticator
+  #   new(username:, password:, authzid: nil, **) -> authenticator
   #
   # Creates an Authenticator for the "+PLAIN+" SASL mechanism.
   #
@@ -50,10 +51,13 @@ class Net::IMAP::SASL::PlainAuthenticator
   # * #authzid ― Alternate identity to act as or on behalf of.  Optional.
   #
   # See attribute documentation for more details.
-  def initialize(username, password, authzid: nil)
-    raise ArgumentError, "username contains NULL" if username&.include?(NULL)
-    raise ArgumentError, "password contains NULL" if password&.include?(NULL)
-    raise ArgumentError, "authzid  contains NULL" if authzid&.include?(NULL)
+  def initialize(user = nil, pass = nil,
+                 username: nil, password: nil, authzid: nil, **)
+    username ||= user or raise ArgumentError, "missing username"
+    password ||= pass or raise ArgumentError, "missing password"
+    raise ArgumentError, "username contains NULL" if username.include?(NULL)
+    raise ArgumentError, "password contains NULL" if password.include?(NULL)
+    raise ArgumentError, "authzid contains NULL"  if authzid&.include?(NULL)
     @username = username
     @password = password
     @authzid  = authzid

--- a/lib/net/imap/sasl/xoauth2_authenticator.rb
+++ b/lib/net/imap/sasl/xoauth2_authenticator.rb
@@ -32,8 +32,8 @@ class Net::IMAP::SASL::XOAuth2Authenticator
   attr_reader :oauth2_token
 
   # :call-seq:
-  # :call-seq:
-  #   new(username,  oauth2_token) -> authenticator
+  #   new(username,  oauth2_token,  **) -> authenticator
+  #   new(username:, oauth2_token:, **) -> authenticator
   #
   # Creates an Authenticator for the "+XOAUTH2+" SASL mechanism, as specified by
   # Google[https://developers.google.com/gmail/imap/xoauth2-protocol],
@@ -47,9 +47,15 @@ class Net::IMAP::SASL::XOAuth2Authenticator
   #   the service for #username.
   #
   # See the documentation for each attribute for more details.
-  def initialize(username, oauth2_token)
-    @username = username
-    @oauth2_token = oauth2_token
+  def initialize(user = nil, token = nil, username: nil, oauth2_token: nil, **)
+    @username = username || user or
+      raise ArgumentError, "missing username"
+    @oauth2_token = oauth2_token || token or
+      raise ArgumentError, "missing oauth2_token"
+    [username, user].compact.count == 1 or
+      raise ArgumentError, "conflicting values for username"
+    [oauth2_token, token].compact.count == 1 or
+      raise ArgumentError, "conflicting values for oauth2_token"
   end
 
   # :call-seq:

--- a/test/net/imap/test_imap_authenticators.rb
+++ b/test/net/imap/test_imap_authenticators.rb
@@ -95,6 +95,17 @@ class IMAPAuthenticatorsTest < Test::Unit::TestCase
     )
   end
 
+  def test_xoauth2_kwargs
+    assert_equal(
+      "user=arg\1auth=Bearer kwarg\1\1",
+      xoauth2("arg", oauth2_token: "kwarg").process(nil)
+    )
+    assert_equal(
+      "user=user\1auth=Bearer kwarg\1\1",
+      xoauth2(username: "user", oauth2_token: "kwarg").process(nil)
+    )
+  end
+
   def test_xoauth2_supports_initial_response
     assert xoauth2("foo", "bar").initial_response?
     assert Net::IMAP::SASL.initial_response?(xoauth2("foo", "bar"))


### PR DESCRIPTION
All SASL authenticators have been updated to take keyword arguments.  Parameters with the same semantics (or very similar) have been given the same name across all authenticators, and unknown keywords are ignored.  This can allow the same "credentials hash" to be used with multiple authenticators.

`ArgumentError` will be raised for missing required arguments and for conflicting positional vs keyword arguments.