### PR TITLE
✨ Add #logout! to combine logout and disconnect 

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -868,7 +868,7 @@ module Net
 
     # Disconnects from the server.
     #
-    # Related: #logout
+    # Related: #logout, #logout!
     def disconnect
       return if disconnected?
       begin
@@ -1067,9 +1067,32 @@ module Net
     # to inform the command to inform the server that the client is done with
     # the connection.
     #
-    # Related: #disconnect
+    # Related: #disconnect, #logout!
     def logout
       send_command("LOGOUT")
+    end
+
+    # Calls #logout then, after receiving the TaggedResponse for the +LOGOUT+,
+    # calls #disconnect.  Returns the TaggedResponse from +LOGOUT+.  Returns
+    # +nil+ when the client is already disconnected, in contrast to #logout
+    # which raises an exception.
+    #
+    # If #logout raises a StandardError, a warning will be printed but the
+    # exception will not be re-raised.
+    #
+    # This is useful in situations where the connection must be dropped, for
+    # example for security or after tests.  If logout errors need to be handled,
+    # use #logout and #disconnect instead.
+    #
+    # Related: #logout, #disconnect
+    def logout!
+      logout unless disconnected?
+    rescue => ex
+      warn "%s during <Net::IMAP %s:%s>logout!: %s" % [
+        ex.class, host, port, ex
+      ]
+    ensure
+      disconnect
     end
 
     # Sends a {STARTTLS command [IMAP4rev1 §6.2.1]}[https://www.rfc-editor.org/rfc/rfc3501#section-6.2.1]

--- a/test/net/imap/fake_server/command_reader.rb
+++ b/test/net/imap/fake_server/command_reader.rb
@@ -30,7 +30,8 @@ class Net::IMAP::FakeServer
 
     # TODO: convert bad command exception to tagged BAD response, when possible
     def parse(buf)
-      /\A([^ ]+) ((?:UID )?\w+)(?: (.+))?\r\n\z/min =~ buf or raise "bad request"
+      /\A([^ ]+) ((?:UID )?\w+)(?: (.+))?\r\n\z/min =~ buf or
+        raise "bad request: %p" [buf]
       case $2.upcase
       when "LOGIN", "SELECT", "ENABLE", "AUTHENTICATE"
         Command.new $1, $2, scan_astrings($3), buf

--- a/test/net/imap/fake_server/test_helper.rb
+++ b/test/net/imap/fake_server/test_helper.rb
@@ -23,8 +23,7 @@ module Net::IMAP::FakeServer::TestHelper
     yield client
   ensure
     if client && !client.disconnected?
-      client.logout rescue pp $!
-      client.disconnect unless client.disconnected?
+      client.logout!
     end
   end
 


### PR DESCRIPTION
A logout command that also disconnects, even if logout raises an exception, and doesn't raise exceptions when already disconnected would be very useful in situations where the connection MUST be gracefully closed, e.g. for security or tests.

Although the change is relatively insignificant, changing #logout to also ignore exceptions and immediately call #disconnect would be backwards incompatible.  So a new method was created.