### PR TITLE
🔒 Verify SASL authentication has completed

### DIFF
--- a/lib/net/imap/sasl/anonymous_authenticator.rb
+++ b/lib/net/imap/sasl/anonymous_authenticator.rb
@@ -40,6 +40,7 @@ module Net
             raise ArgumentError,
                   "anonymous_message is too long.  (%d codepoints)" % [size]
           end
+          @done = false
         end
 
         # :call-seq:
@@ -51,7 +52,15 @@ module Net
         # Returns #anonymous_message.
         def process(_server_challenge_string)
           anonymous_message
+        ensure
+          @done = true
         end
+
+        # Returns true when the initial client response was sent.
+        #
+        # The authentication should not succeed unless this returns true, but it
+        # does *not* indicate success.
+        def done?; @done end
 
       end
     end

--- a/lib/net/imap/sasl/cram_md5_authenticator.rb
+++ b/lib/net/imap/sasl/cram_md5_authenticator.rb
@@ -21,12 +21,17 @@ class Net::IMAP::SASL::CramMD5Authenticator
     require "digest/md5"
     @user = user
     @password = password
+    @done = false
   end
 
   def process(challenge)
     digest = hmac_md5(challenge, @password)
     return @user + " " + digest
+  ensure
+    @done = true
   end
+
+  def done?; @done end
 
   private
 

--- a/lib/net/imap/sasl/digest_md5_authenticator.rb
+++ b/lib/net/imap/sasl/digest_md5_authenticator.rb
@@ -11,7 +11,8 @@
 class Net::IMAP::SASL::DigestMD5Authenticator
   STAGE_ONE = :stage_one
   STAGE_TWO = :stage_two
-  private_constant :STAGE_ONE, :STAGE_TWO
+  STAGE_DONE = :stage_done
+  private_constant :STAGE_ONE, :STAGE_TWO, :STAGE_DONE
 
   # Authentication identity: the identity that matches the #password.
   #
@@ -126,7 +127,7 @@ class Net::IMAP::SASL::DigestMD5Authenticator
 
       return response.keys.map {|key| qdval(key.to_s, response[key]) }.join(',')
     when STAGE_TWO
-      @stage = nil
+      @stage = STAGE_DONE
       # if at the second stage, return an empty string
       if challenge =~ /rspauth=/
         return ''
@@ -137,6 +138,8 @@ class Net::IMAP::SASL::DigestMD5Authenticator
       raise ResponseParseError, challenge
     end
   end
+
+  def done?; @stage == STAGE_DONE end
 
   private
 

--- a/lib/net/imap/sasl/external_authenticator.rb
+++ b/lib/net/imap/sasl/external_authenticator.rb
@@ -34,6 +34,7 @@ module Net
           if @authzid&.match?(/\u0000/u) # also validates UTF8 encoding
             raise ArgumentError, "contains NULL"
           end
+          @done = false
         end
 
         # :call-seq:
@@ -45,7 +46,15 @@ module Net
         # Returns #authzid, or an empty string if there is no authzid.
         def process(_)
           authzid || ""
+        ensure
+          @done = true
         end
+
+        # Returns true when the initial client response was sent.
+        #
+        # The authentication should not succeed unless this returns true, but it
+        # does *not* indicate success.
+        def done?; @done end
 
       end
     end

--- a/lib/net/imap/sasl/login_authenticator.rb
+++ b/lib/net/imap/sasl/login_authenticator.rb
@@ -20,7 +20,8 @@
 class Net::IMAP::SASL::LoginAuthenticator
   STATE_USER = :USER
   STATE_PASSWORD = :PASSWORD
-  private_constant :STATE_USER, :STATE_PASSWORD
+  STATE_DONE = :DONE
+  private_constant :STATE_USER, :STATE_PASSWORD, :STATE_DONE
 
   def initialize(user, password, warn_deprecation: true, **_ignored)
     if warn_deprecation
@@ -37,7 +38,12 @@ class Net::IMAP::SASL::LoginAuthenticator
       @state = STATE_PASSWORD
       return @user
     when STATE_PASSWORD
+      @state = STATE_DONE
       return @password
+    when STATE_DONE
+      raise ResponseParseError, data
     end
   end
+
+  def done?; @state == STATE_DONE end
 end

--- a/lib/net/imap/sasl/plain_authenticator.rb
+++ b/lib/net/imap/sasl/plain_authenticator.rb
@@ -61,6 +61,7 @@ class Net::IMAP::SASL::PlainAuthenticator
     @username = username
     @password = password
     @authzid  = authzid
+    @done = false
   end
 
   # :call-seq:
@@ -72,6 +73,14 @@ class Net::IMAP::SASL::PlainAuthenticator
   # Responds with the client's credentials.
   def process(data)
     return "#@authzid\0#@username\0#@password"
+  ensure
+    @done = true
   end
+
+  # Returns true when the initial client response was sent.
+  #
+  # The authentication should not succeed unless this returns true, but it
+  # does *not* indicate success.
+  def done?; @done end
 
 end

--- a/lib/net/imap/sasl/xoauth2_authenticator.rb
+++ b/lib/net/imap/sasl/xoauth2_authenticator.rb
@@ -56,6 +56,7 @@ class Net::IMAP::SASL::XOAuth2Authenticator
       raise ArgumentError, "conflicting values for username"
     [oauth2_token, token].compact.count == 1 or
       raise ArgumentError, "conflicting values for oauth2_token"
+    @done = false
   end
 
   # :call-seq:
@@ -68,7 +69,15 @@ class Net::IMAP::SASL::XOAuth2Authenticator
   # with the +oauth2_token+.
   def process(_data)
     build_oauth2_string(@username, @oauth2_token)
+  ensure
+    @done = true
   end
+
+  # Returns true when the initial client response was sent.
+  #
+  # The authentication should not succeed unless this returns true, but it
+  # does *not* indicate success.
+  def done?; @done end
 
   private
 

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -911,15 +911,48 @@ EOF
           ].pack("m0")
         )
         state.commands << {continuation: response_b64}
+        response_b64 = cmd.request_continuation(["rspauth="].pack("m0"))
+        state.commands << {continuation: response_b64}
         server.state.authenticate(server.config.user)
         cmd.done_ok
       end
       imap.authenticate("DIGEST-MD5", "test_user", "test-password",
                         warn_deprecation: false)
-      cmd, cont = 2.times.map { server.commands.pop }
+      cmd, cont1, cont2 = 3.times.map { server.commands.pop }
       assert_equal %w[AUTHENTICATE DIGEST-MD5], [cmd.name, *cmd.args]
-      assert_match(%r{\A[a-z0-9+/]+=*\z}i, cont[:continuation].strip)
+      assert_match(%r{\A[a-z0-9+/]+=*\z}i, cont1[:continuation].strip)
+      assert_empty cont2[:continuation].strip
       assert_empty server.commands
+    end
+  end
+
+  test("#authenticate disconnects and raises SASL::AuthenticationFailed " \
+       "when the server succeeds prematurely") do
+    with_fake_server(
+      preauth: false, cleartext_auth: true,
+      sasl_ir: true, sasl_mechanisms: %i[DIGEST-MD5]
+    ) do |server, imap|
+      server.on "AUTHENTICATE" do |cmd|
+        response_b64 = cmd.request_continuation(
+          [
+            %w[
+              realm="somerealm"
+              nonce="OA6MG9tEQGm2hh"
+              qop="auth"
+              charset=utf-8
+              algorithm=md5-sess
+            ].join(",")
+          ].pack("m0")
+        )
+        state.commands << {continuation: response_b64}
+        server.state.authenticate(server.config.user)
+        cmd.done_ok
+      end
+      assert_raise(Net::IMAP::SASL::AuthenticationFailed) do
+        imap.authenticate("DIGEST-MD5", "test_user", "test-password",
+                          warn_deprecation: false)
+      end
+      assert imap.disconnected?
     end
   end
 


### PR DESCRIPTION
The client is responsible for raising an error if the command completes successfully but "done?" returns false.

This is needed in order to correctly implement `SCRAM-*`:
* #54
* #172

Without this PR, if the server returns OK before sending its final message, then we can't satisfy the following requirement from the RFC:

> The client then authenticates the server by computing the
> ServerSignature and comparing it to the value sent by the server. If
> the two are different, the client MUST consider the authentication
> exchange to be unsuccessful, and it might have to drop the
> connection.

Note that this PR adds `Net::IMAP::SASL::Error` (inheriting from `StandardError`, not from `Net::IMAP::Error`) and three subclasses: `AuthenticationFailed`, `AuthenticationError`, and `AuthenticationCancelled`.

Note that even `EXTERNAL` and `ANONYMOUS` send data (the authorization identity or the anonymous message/email), so even they are not done until `process` has been called at least once.