### PR TITLE
🐛 Fix empty SASL-IR to send "="

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -1236,7 +1236,8 @@ module Net
       cmdargs = ["AUTHENTICATE", mechanism]
       if sasl_ir && capable?("SASL-IR") && auth_capable?(mechanism) &&
           SASL.initial_response?(authenticator)
-        cmdargs << [authenticator.process(nil)].pack("m0")
+        response = authenticator.process(nil)
+        cmdargs << (response.empty? ? "=" : [response].pack("m0"))
       end
       result = send_command(*cmdargs) do |resp|
         if resp.instance_of?(ContinuationRequest)

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -847,6 +847,24 @@ EOF
     end
   end
 
+  test("#authenticate sends '=' as the initial reponse " \
+       "when the initial response is an empty string") do
+    with_fake_server(
+      preauth: false, cleartext_auth: true,
+      sasl_ir: true, sasl_mechanisms: %i[EXTERNAL],
+    ) do |server, imap|
+      server.on "AUTHENTICATE" do |cmd|
+        server.state.authenticate(server.config.user)
+        cmd.done_ok
+      end
+      imap.authenticate("EXTERNAL")
+      cmd = server.commands.pop
+      assert_equal "AUTHENTICATE", cmd.name
+      assert_equal %w[EXTERNAL =], cmd.args
+      assert_empty server.commands rescue pp server.commands.pop
+    end
+  end
+
   test("#authenticate never sends an initial response " \
        "when the server doesn't explicitly support the mechanism") do
     with_fake_server(


### PR DESCRIPTION
As per RFC-4959 and RFC-9051:
> To send a zero-length initial response, the client MUST send a single
> pad character ("=").  This indicates that the response is present, but
> is a zero- length string.