### PR TITLE
🐛 Fix typo in uncommon BODYSTRUCTURE parsing code

### DIFF
--- a/lib/net/imap/response_parser.rb
+++ b/lib/net/imap/response_parser.rb
@@ -643,7 +643,7 @@ module Net
         choice = m&.named_captures&.compact&.keys&.first
         # In practice, the following line should never be used. But the ABNF
         # *does* allow literals, and this will handle them.
-        choice ||= lookahead_case_insensitive_string!
+        choice ||= lookahead_case_insensitive__string!
         case choice
         when "BASIC"   then body_type_basic # => BodyTypeBasic
         when "MESSAGE" then body_type_msg   # => BodyTypeMessage | BodyTypeBasic


### PR DESCRIPTION
I believe this code is only executed when there is something strange in the server's response.  If I remember correctly, I've usually only encountered this from server bugs... but it's an easy work around.