### PR TITLE
🐛 Fix authenticate using Symbol mechanism name

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -1248,6 +1248,7 @@ module Net
     # completes.  If the TaggedResponse to #authenticate includes updated
     # capabilities, they will be cached.
     def authenticate(mechanism, *creds, sasl_ir: true, **props, &callback)
+      mechanism = mechanism.to_s.tr("_", "-").upcase
       authenticator = SASL.authenticator(mechanism, *creds, **props, &callback)
       cmdargs = ["AUTHENTICATE", mechanism]
       if sasl_ir && capable?("SASL-IR") && auth_capable?(mechanism) &&

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -934,7 +934,7 @@ EOF
         server.state.authenticate(server.config.user)
         cmd.done_ok
       end
-      imap.authenticate("DIGEST-MD5", "test_user", "test-password",
+      imap.authenticate(:digest_md5, "test_user", "test-password",
                         warn_deprecation: false)
       cmd, cont1, cont2 = 3.times.map { server.commands.pop }
       assert_equal %w[AUTHENTICATE DIGEST-MD5], [cmd.name, *cmd.args]


### PR DESCRIPTION
Based on `net-smtp`, I had added the ability to use symbols to lookup authenticator.  But it had two issues: 1) dealing with dashes vs underscores, and 2) sending the command name using flag syntax.  This fixes both issues.