### PR TITLE
🔒 SASL: Clarify usage of username vs authcid vs authzid

### DIFF
--- a/lib/net/imap/sasl/anonymous_authenticator.rb
+++ b/lib/net/imap/sasl/anonymous_authenticator.rb
@@ -29,8 +29,9 @@ module Net
         # this, see Net::IMAP#authenticate or your client's authentication
         # method.
         #
-        # #anonymous_message is an optional message which is sent to the server.
-        # It may be sent as a positional argument or as a keyword argument.
+        # ==== Parameters
+        #
+        # * _optional_ #anonymous_message — a message to send to the server.
         #
         # Any other keyword arguments are silently ignored.
         def initialize(anon_msg = nil, anonymous_message: nil, **)

--- a/lib/net/imap/sasl/cram_md5_authenticator.rb
+++ b/lib/net/imap/sasl/cram_md5_authenticator.rb
@@ -14,13 +14,17 @@
 # of cleartext and recommends TLS version 1.2 or greater be used for all
 # traffic.  With TLS +CRAM-MD5+ is okay, but so is +PLAIN+
 class Net::IMAP::SASL::CramMD5Authenticator
-  def initialize(user, password, warn_deprecation: true, **_ignored)
+  def initialize(user = nil, pass = nil,
+                 authcid: nil, username: nil,
+                 password: nil,
+                 warn_deprecation: true,
+                 **)
     if warn_deprecation
       warn "WARNING: CRAM-MD5 mechanism is deprecated." # TODO: recommend SCRAM
     end
     require "digest/md5"
-    @user = user
-    @password = password
+    @user = authcid || username || user
+    @password = password || pass
     @done = false
   end
 

--- a/lib/net/imap/sasl/digest_md5_authenticator.rb
+++ b/lib/net/imap/sasl/digest_md5_authenticator.rb
@@ -20,8 +20,9 @@ class Net::IMAP::SASL::DigestMD5Authenticator
   # "Authentication identity" is the generic term used by
   # RFC-4422[https://tools.ietf.org/html/rfc4422].
   # RFC-4616[https://tools.ietf.org/html/rfc4616] and many later RFCs abbreviate
-  # that to +authcid+.  So +authcid+ is available as an alias for #username.
+  # this to +authcid+.
   attr_reader :username
+  alias authcid username
 
   # A password or passphrase that matches the #username.
   #
@@ -44,6 +45,7 @@ class Net::IMAP::SASL::DigestMD5Authenticator
   # :call-seq:
   #   new(username,  password,  authzid = nil, **options) -> authenticator
   #   new(username:, password:, authzid:  nil, **options) -> authenticator
+  #   new(authcid:,  password:, authzid:  nil, **options) -> authenticator
   #
   # Creates an Authenticator for the "+DIGEST-MD5+" SASL mechanism.
   #
@@ -51,9 +53,11 @@ class Net::IMAP::SASL::DigestMD5Authenticator
   #
   # ==== Parameters
   #
-  # * #username — Identity whose #password is used.
-  # * #password — A password or passphrase associated with this #username.
+  # * #authcid  ― Authentication identity that is associated with #password.
   #
+  #   #username ― An alias for +authcid+.
+  #
+  # * #password ― A password or passphrase associated with this #authcid.
   #
   # * _optional_ #authzid  ― Authorization identity to act as or on behalf of.
   #
@@ -65,8 +69,10 @@ class Net::IMAP::SASL::DigestMD5Authenticator
   # Any other keyword arguments are silently ignored.
   def initialize(user = nil, pass = nil, authz = nil,
                  username: nil, password: nil, authzid: nil,
+                 authcid: nil,
                  warn_deprecation: true, **)
-    username ||= user or raise ArgumentError, "missing username"
+    username = authcid || username || user or
+      raise ArgumentError, "missing username (authcid)"
     password ||= pass or raise ArgumentError, "missing password"
     authzid  ||= authz
     if warn_deprecation

--- a/lib/net/imap/sasl/digest_md5_authenticator.rb
+++ b/lib/net/imap/sasl/digest_md5_authenticator.rb
@@ -53,10 +53,16 @@ class Net::IMAP::SASL::DigestMD5Authenticator
   #
   # * #username — Identity whose #password is used.
   # * #password — A password or passphrase associated with this #username.
-  # * #authzid ― Alternate identity to act as or on behalf of.  Optional.
-  # * +warn_deprecation+ — Set to +false+ to silence the warning.
   #
-  # See the documentation for each attribute for more details.
+  #
+  # * _optional_ #authzid  ― Authorization identity to act as or on behalf of.
+  #
+  #   When +authzid+ is not set, the server should derive the authorization
+  #   identity from the authentication identity.
+  #
+  # * _optional_ +warn_deprecation+ — Set to +false+ to silence the warning.
+  #
+  # Any other keyword arguments are silently ignored.
   def initialize(user = nil, pass = nil, authz = nil,
                  username: nil, password: nil, authzid: nil,
                  warn_deprecation: true, **)

--- a/lib/net/imap/sasl/external_authenticator.rb
+++ b/lib/net/imap/sasl/external_authenticator.rb
@@ -12,10 +12,18 @@ module Net
       # established external to SASL, for example by TLS certificate or IPsec.
       class ExternalAuthenticator
 
-        # Authorization identity: an identity to act as or on behalf of.
+        # Authorization identity: an identity to act as or on behalf of.  The
+        # identity form is application protocol specific.  If not provided or
+        # left blank, the server derives an authorization identity from the
+        # authentication identity.  The server is responsible for verifying the
+        # client's credentials and verifying that the identity it associates
+        # with the client's authentication identity is allowed to act as (or on
+        # behalf of) the authorization identity.
         #
-        # If not explicitly provided, the server defaults to using the identity
-        # that was authenticated by the external credentials.
+        # For example, an administrator or superuser might take on another role:
+        #
+        #     imap.authenticate "PLAIN", "root", passwd, authzid: "user"
+        #
         attr_reader :authzid
 
         # :call-seq:
@@ -26,7 +34,9 @@ module Net
         # this, see Net::IMAP#authenticate or your client's authentication
         # method.
         #
-        # #authzid is an optional identity to act as or on behalf of.
+        # ==== Parameters
+        #
+        # * _optional_ #authzid  ― Authorization identity to act as or on behalf of.
         #
         # Any other keyword parameters are quietly ignored.
         def initialize(authzid: nil, **)

--- a/lib/net/imap/sasl/external_authenticator.rb
+++ b/lib/net/imap/sasl/external_authenticator.rb
@@ -25,9 +25,12 @@ module Net
         #     imap.authenticate "PLAIN", "root", passwd, authzid: "user"
         #
         attr_reader :authzid
+        alias username authzid
 
         # :call-seq:
         #   new(authzid: nil, **) -> authenticator
+        #   new(username: nil, **) -> authenticator
+        #   new(username = nil, **) -> authenticator
         #
         # Creates an Authenticator for the "+EXTERNAL+" SASL mechanism, as
         # specified in RFC-4422[https://tools.ietf.org/html/rfc4422].  To use
@@ -38,8 +41,16 @@ module Net
         #
         # * _optional_ #authzid  ― Authorization identity to act as or on behalf of.
         #
+        #   _optional_ #username ― An alias for #authzid.
+        #
+        #   Note that, unlike some other authenticators, +username+ sets the
+        #   _authorization_ identity and not the _authentication_ identity.  The
+        #   authentication identity is established for the client by the
+        #   external credentials.
+        #
         # Any other keyword parameters are quietly ignored.
-        def initialize(authzid: nil, **)
+        def initialize(user = nil, authzid: nil, username: nil, **)
+          authzid ||= username || user
           @authzid = authzid&.to_str&.encode "UTF-8"
           if @authzid&.match?(/\u0000/u) # also validates UTF8 encoding
             raise ArgumentError, "contains NULL"

--- a/lib/net/imap/sasl/login_authenticator.rb
+++ b/lib/net/imap/sasl/login_authenticator.rb
@@ -23,12 +23,16 @@ class Net::IMAP::SASL::LoginAuthenticator
   STATE_DONE = :DONE
   private_constant :STATE_USER, :STATE_PASSWORD, :STATE_DONE
 
-  def initialize(user, password, warn_deprecation: true, **_ignored)
+  def initialize(user = nil, pass = nil,
+                 authcid: nil, username: nil,
+                 password: nil,
+                 warn_deprecation: true,
+                 **)
     if warn_deprecation
       warn "WARNING: LOGIN SASL mechanism is deprecated. Use PLAIN instead."
     end
-    @user = user
-    @password = password
+    @user = authcid || username || user
+    @password = password || pass
     @state = STATE_USER
   end
 

--- a/lib/net/imap/sasl/oauthbearer_authenticator.rb
+++ b/lib/net/imap/sasl/oauthbearer_authenticator.rb
@@ -141,8 +141,9 @@ module Net
         attr_reader :oauth2_token
 
         # :call-seq:
-        #   new(oauth2_token,  **options) -> authenticator
-        #   new(oauth2_token:, **options) -> authenticator
+        #   new(oauth2_token,          **options) -> authenticator
+        #   new(authzid, oauth2_token, **options) -> authenticator
+        #   new(oauth2_token:,         **options) -> authenticator
         #
         # Creates an Authenticator for the "+OAUTHBEARER+" SASL mechanism.
         #
@@ -172,8 +173,9 @@ module Net
         # noting that <b><em>application protocols are allowed to
         # require</em></b> #authzid (<em>or other parameters, such as</em> #host
         # _or_ #port) <b><em>as are specific server implementations</em></b>.
-        def initialize(oauth2_token_arg = nil, oauth2_token: nil, **args, &blk)
-          super(**args, &blk) # handles authzid, host, port, etc
+        def initialize(arg1 = nil, arg2 = nil, oauth2_token: nil, **args, &blk)
+          username, oauth2_token_arg = arg2.nil? ? [nil, arg1] : [arg1, arg2]
+          super(username: username, **args, &blk)
           oauth2_token && oauth2_token_arg and
             raise ArgumentError, "conflicting values for oauth2_token"
           @oauth2_token = oauth2_token || oauth2_token_arg or

--- a/lib/net/imap/sasl/oauthbearer_authenticator.rb
+++ b/lib/net/imap/sasl/oauthbearer_authenticator.rb
@@ -27,6 +27,7 @@ module Net
         #     imap.authenticate "PLAIN", "root", passwd, authzid: "user"
         #
         attr_reader :authzid
+        alias username authzid
 
         # Hostname to which the client connected.  (optional)
         attr_reader :host
@@ -45,6 +46,7 @@ module Net
 
         # The query string.  (optional)
         attr_reader :qs
+        alias query qs
 
         # Stores the most recent server "challenge".  When authentication fails,
         # this may hold information about the failure reason, as JSON.
@@ -61,6 +63,14 @@ module Net
         # #host or #port) <b>as are specific server implementations</b>.
         #
         # * _optional_ #authzid  ― Authorization identity to act as or on behalf of.
+        #
+        #   _optional_ #username — An alias for #authzid.
+        #
+        #   Note that, unlike some other authenticators, +username+ sets the
+        #   _authorization_ identity and not the _authentication_ identity.  The
+        #   authentication identity is established for the client by the OAuth
+        #   token.
+        #
         # * _optional_ #host — Hostname to which the client connected.
         # * _optional_ #port — Service port to which the client connected.
         # * _optional_ #mthd — HTTP method
@@ -68,16 +78,19 @@ module Net
         # * _optional_ #post — HTTP post data
         # * _optional_ #qs   — HTTP query string
         #
+        #   _optional_ #query — An alias for #qs
+        #
         # Any other keyword parameters are quietly ignored.
         def initialize(authzid: nil, host: nil, port: nil,
+                       username: nil, query: nil,
                        mthd: nil, path: nil, post: nil, qs: nil, **)
-          @authzid = authzid
+          @authzid = authzid || username
           @host    = host
           @port    = port
           @mthd    = mthd
           @path    = path
           @post    = post
-          @qs      = qs
+          @qs      = qs || query
           @done    = false
         end
 
@@ -144,6 +157,14 @@ module Net
         # The most common ones are:
         #
         # * _optional_ #authzid  ― Authorization identity to act as or on behalf of.
+        #
+        #   _optional_ #username — An alias for #authzid.
+        #
+        #   Note that, unlike some other authenticators, +username+ sets the
+        #   _authorization_ identity and not the _authentication_ identity.  The
+        #   authentication identity is established for the client by
+        #   #oauth2_token.
+        #
         # * _optional_ #host — Hostname to which the client connected.
         # * _optional_ #port — Service port to which the client connected.
         #

--- a/lib/net/imap/sasl/oauthbearer_authenticator.rb
+++ b/lib/net/imap/sasl/oauthbearer_authenticator.rb
@@ -176,8 +176,6 @@ module Net
         def initialize(arg1 = nil, arg2 = nil, oauth2_token: nil, **args, &blk)
           username, oauth2_token_arg = arg2.nil? ? [nil, arg1] : [arg1, arg2]
           super(username: username, **args, &blk)
-          oauth2_token && oauth2_token_arg and
-            raise ArgumentError, "conflicting values for oauth2_token"
           @oauth2_token = oauth2_token || oauth2_token_arg or
             raise ArgumentError, "missing oauth2_token"
         end

--- a/lib/net/imap/sasl/oauthbearer_authenticator.rb
+++ b/lib/net/imap/sasl/oauthbearer_authenticator.rb
@@ -14,18 +14,24 @@ module Net
       class OAuthAuthenticator
         include GS2Header
 
-        # Authorization identity: an identity to act as or on behalf of.
+        # Authorization identity: an identity to act as or on behalf of.  The
+        # identity form is application protocol specific.  If not provided or
+        # left blank, the server derives an authorization identity from the
+        # authentication identity.  The server is responsible for verifying the
+        # client's credentials and verifying that the identity it associates
+        # with the client's authentication identity is allowed to act as (or on
+        # behalf of) the authorization identity.
         #
-        # If no explicit authorization identity is provided, it is usually
-        # derived from the authentication identity.  For the OAuth-based
-        # mechanisms, the authentication identity is the identity established by
-        # the OAuth credential.
+        # For example, an administrator or superuser might take on another role:
+        #
+        #     imap.authenticate "PLAIN", "root", passwd, authzid: "user"
+        #
         attr_reader :authzid
 
-        # Hostname to which the client connected.
+        # Hostname to which the client connected.  (optional)
         attr_reader :host
 
-        # Service port to which the client connected.
+        # Service port to which the client connected.  (optional)
         attr_reader :port
 
         # HTTP method.  (optional)
@@ -47,20 +53,22 @@ module Net
         # Creates an RFC7628[https://tools.ietf.org/html/rfc7628] OAuth
         # authenticator.
         #
-        # === Options
+        # ==== Parameters
         #
-        # See child classes for required configuration parameter(s).  The
-        # following parameters are all optional, but protocols or servers may
-        # add requirements for #authzid, #host, #port, or any other parameter.
+        # See child classes for required parameter(s).  The following parameters
+        # are all optional, but it is worth noting that <b>application protocols
+        # are allowed to require</b> #authzid (or other parameters, such as
+        # #host or #port) <b>as are specific server implementations</b>.
         #
-        # * #authzid ― Identity to act as or on behalf of.
-        # * #host — Hostname to which the client connected.
-        # * #port — Service port to which the client connected.
-        # * #mthd — HTTP method
-        # * #path — HTTP path data
-        # * #post — HTTP post data
-        # * #qs   — HTTP query string
+        # * _optional_ #authzid  ― Authorization identity to act as or on behalf of.
+        # * _optional_ #host — Hostname to which the client connected.
+        # * _optional_ #port — Service port to which the client connected.
+        # * _optional_ #mthd — HTTP method
+        # * _optional_ #path — HTTP path data
+        # * _optional_ #post — HTTP post data
+        # * _optional_ #qs   — HTTP query string
         #
+        # Any other keyword parameters are quietly ignored.
         def initialize(authzid: nil, host: nil, port: nil,
                        mthd: nil, path: nil, post: nil, qs: nil, **)
           @authzid = authzid
@@ -116,7 +124,7 @@ module Net
       # the bearer token.
       class OAuthBearerAuthenticator < OAuthAuthenticator
 
-        # An OAuth2 bearer token, generally the access token.
+        # An OAuth 2.0 bearer token.  See {RFC-6750}[https://www.rfc-editor.org/rfc/rfc6750]
         attr_reader :oauth2_token
 
         # :call-seq:
@@ -127,19 +135,22 @@ module Net
         #
         # Called by Net::IMAP#authenticate and similar methods on other clients.
         #
-        # === Options
+        # ==== Parameters
         #
-        # Only +oauth2_token+ is required by the mechanism, however protocols
-        # and servers may add requirements for #authzid, #host, #port, or any
-        # other parameter.
+        # * #oauth2_token — An OAuth2 bearer token
         #
-        # * #oauth2_token — An OAuth2 bearer token or access token. *Required.*
-        #   May be provided as either regular or keyword argument.
-        # * #authzid ― Identity to act as or on behalf of.
-        # * #host — Hostname to which the client connected.
-        # * #port — Service port to which the client connected.
-        # * See OAuthAuthenticator documentation for less common parameters.
+        # All other keyword parameters are passed to
+        # {super}[rdoc-ref:OAuthAuthenticator::new] (see OAuthAuthenticator).
+        # The most common ones are:
         #
+        # * _optional_ #authzid  ― Authorization identity to act as or on behalf of.
+        # * _optional_ #host — Hostname to which the client connected.
+        # * _optional_ #port — Service port to which the client connected.
+        #
+        # Although only oauth2_token is required by this mechanism, it is worth
+        # noting that <b><em>application protocols are allowed to
+        # require</em></b> #authzid (<em>or other parameters, such as</em> #host
+        # _or_ #port) <b><em>as are specific server implementations</em></b>.
         def initialize(oauth2_token_arg = nil, oauth2_token: nil, **args, &blk)
           super(**args, &blk) # handles authzid, host, port, etc
           oauth2_token && oauth2_token_arg and

--- a/lib/net/imap/sasl/plain_authenticator.rb
+++ b/lib/net/imap/sasl/plain_authenticator.rb
@@ -66,10 +66,6 @@ class Net::IMAP::SASL::PlainAuthenticator
   def initialize(user = nil, pass = nil,
                  authcid: nil,
                  username: nil, password: nil, authzid: nil, **)
-    [authcid, username, user].compact.count <= 1 or
-      raise ArgumentError, "conflicting values for username (authcid)"
-    [password, pass].compact.count <= 1 or
-      raise ArgumentError, "conflicting values for password"
     username ||= authcid || user or
       raise ArgumentError, "missing username (authcid)"
     password ||= pass or raise ArgumentError, "missing password"

--- a/lib/net/imap/sasl/plain_authenticator.rb
+++ b/lib/net/imap/sasl/plain_authenticator.rb
@@ -22,6 +22,7 @@ class Net::IMAP::SASL::PlainAuthenticator
   # RFC-4616[https://tools.ietf.org/html/rfc4616] and many later RFCs abbreviate
   # this to +authcid+.
   attr_reader :username
+  alias authcid username
 
   # A password or passphrase that matches the #username.
   attr_reader :password
@@ -42,6 +43,7 @@ class Net::IMAP::SASL::PlainAuthenticator
   # :call-seq:
   #   new(username,  password,  authzid: nil, **) -> authenticator
   #   new(username:, password:, authzid: nil, **) -> authenticator
+  #   new(authcid:,  password:, authzid: nil, **) -> authenticator
   #
   # Creates an Authenticator for the "+PLAIN+" SASL mechanism.
   #
@@ -49,8 +51,11 @@ class Net::IMAP::SASL::PlainAuthenticator
   #
   # ==== Parameters
   #
-  # * #username ― Identity whose +password+ is used.
-  # * #password ― Password or passphrase associated with this username+.
+  # * #authcid ― Authentication identity that is associated with #password.
+  #
+  #   #username ― An alias for #authcid.
+  #
+  # * #password ― A password or passphrase associated with the #authcid.
   #
   # * _optional_ #authzid  ― Authorization identity to act as or on behalf of.
   #
@@ -59,12 +64,14 @@ class Net::IMAP::SASL::PlainAuthenticator
   #
   # Any other keyword parameters are quietly ignored.
   def initialize(user = nil, pass = nil,
+                 authcid: nil,
                  username: nil, password: nil, authzid: nil, **)
-    [username, user].compact.count == 1 or
-      raise ArgumentError, "conflicting values for username"
-    [password, pass].compact.count == 1 or
+    [authcid, username, user].compact.count <= 1 or
+      raise ArgumentError, "conflicting values for username (authcid)"
+    [password, pass].compact.count <= 1 or
       raise ArgumentError, "conflicting values for password"
-    username ||= user or raise ArgumentError, "missing username"
+    username ||= authcid || user or
+      raise ArgumentError, "missing username (authcid)"
     password ||= pass or raise ArgumentError, "missing password"
     raise ArgumentError, "username contains NULL" if username.include?(NULL)
     raise ArgumentError, "password contains NULL" if password.include?(NULL)

--- a/lib/net/imap/sasl/plain_authenticator.rb
+++ b/lib/net/imap/sasl/plain_authenticator.rb
@@ -47,13 +47,17 @@ class Net::IMAP::SASL::PlainAuthenticator
   #
   # Called by Net::IMAP#authenticate and similar methods on other clients.
   #
-  # === Parameters
+  # ==== Parameters
   #
   # * #username ― Identity whose +password+ is used.
   # * #password ― Password or passphrase associated with this username+.
-  # * #authzid ― Alternate identity to act as or on behalf of.  Optional.
   #
-  # See attribute documentation for more details.
+  # * _optional_ #authzid  ― Authorization identity to act as or on behalf of.
+  #
+  #   When +authzid+ is not set, the server should derive the authorization
+  #   identity from the authentication identity.
+  #
+  # Any other keyword parameters are quietly ignored.
   def initialize(user = nil, pass = nil,
                  username: nil, password: nil, authzid: nil, **)
     [username, user].compact.count == 1 or

--- a/lib/net/imap/sasl/scram_authenticator.rb
+++ b/lib/net/imap/sasl/scram_authenticator.rb
@@ -86,12 +86,8 @@ module Net
                        **options)
           @username = username || username_arg || authcid or
             raise ArgumentError, "missing username (authcid)"
-          [username, username_arg, authcid].compact.count == 1 or
-            raise ArgumentError, "conflicting values for username (authcid)"
           @password = password || password_arg or
             raise ArgumentError, "missing password"
-          [password, password_arg].compact.count == 1 or
-            raise ArgumentError, "conflicting values for password"
           @authzid = authzid
 
           @min_iterations = Integer min_iterations

--- a/lib/net/imap/sasl/scram_authenticator.rb
+++ b/lib/net/imap/sasl/scram_authenticator.rb
@@ -70,10 +70,10 @@ module Net
         #
         # * #username ― Identity whose #password is used.  Aliased as #authcid.
         # * #password ― Password or passphrase associated with this #username.
-        # * #authzid ― Alternate identity to act as or on behalf of.  Optional.
-        # * #min_iterations - Overrides the default value (4096).  Optional.
+        # * _optional_ #authzid ― Alternate identity to act as or on behalf of.
+        # * _optional_ #min_iterations - Overrides the default value (4096).
         #
-        # See the documentation on the corresponding attributes for more.
+        # Any other keyword parameters are quietly ignored.
         def initialize(username_arg = nil, password_arg = nil,
                        username: nil, password: nil, authcid: nil, authzid: nil,
                        min_iterations: 4096, # see both RFC5802 and RFC7677
@@ -96,6 +96,12 @@ module Net
         end
 
         # Authentication identity: the identity that matches the #password.
+        #
+        # RFC-2831[https://tools.ietf.org/html/rfc2831] uses the term +username+.
+        # "Authentication identity" is the generic term used by
+        # RFC-4422[https://tools.ietf.org/html/rfc4422].
+        # RFC-4616[https://tools.ietf.org/html/rfc4616] and many later RFCs abbreviate
+        # this to +authcid+.
         attr_reader :username
         alias authcid username
 

--- a/lib/net/imap/sasl/scram_authenticator.rb
+++ b/lib/net/imap/sasl/scram_authenticator.rb
@@ -60,6 +60,7 @@ module Net
         # :call-seq:
         #   new(username,  password,  **options) -> auth_ctx
         #   new(username:, password:, **options) -> auth_ctx
+        #   new(authcid:,  password:, **options) -> auth_ctx
         #
         # Creates an authenticator for one of the "+SCRAM-*+" SASL mechanisms.
         # Each subclass defines #digest to match a specific mechanism.
@@ -68,14 +69,18 @@ module Net
         #
         # === Parameters
         #
-        # * #username ― Identity whose #password is used.  Aliased as #authcid.
+        # * #authcid  ― Identity whose #password is used.
+        #
+        #   #username - An alias for #authcid.
         # * #password ― Password or passphrase associated with this #username.
         # * _optional_ #authzid ― Alternate identity to act as or on behalf of.
         # * _optional_ #min_iterations - Overrides the default value (4096).
         #
         # Any other keyword parameters are quietly ignored.
         def initialize(username_arg = nil, password_arg = nil,
-                       username: nil, password: nil, authcid: nil, authzid: nil,
+                       authcid: nil, username: nil,
+                       authzid: nil,
+                       password: nil,
                        min_iterations: 4096, # see both RFC5802 and RFC7677
                        cnonce: nil, # must only be set in tests
                        **options)
@@ -92,6 +97,7 @@ module Net
           @min_iterations = Integer min_iterations
           @min_iterations.positive? or
             raise ArgumentError, "min_iterations must be positive"
+
           @cnonce = cnonce || SecureRandom.base64(32)
         end
 

--- a/lib/net/imap/sasl/xoauth2_authenticator.rb
+++ b/lib/net/imap/sasl/xoauth2_authenticator.rb
@@ -34,6 +34,11 @@ class Net::IMAP::SASL::XOAuth2Authenticator
   # relying only the identity and scope authorized by the token.
   attr_reader :username
 
+  # Note that, unlike most other authenticators, #username is an alias for the
+  # authorization identity and not the authentication identity.  The
+  # authenticated identity is established for the client by the #oauth2_token.
+  alias authzid username
+
   # An OAuth2 access token which has been authorized with the appropriate OAuth2
   # scopes to use the service for #username.
   attr_reader :oauth2_token
@@ -41,6 +46,7 @@ class Net::IMAP::SASL::XOAuth2Authenticator
   # :call-seq:
   #   new(username,  oauth2_token,  **) -> authenticator
   #   new(username:, oauth2_token:, **) -> authenticator
+  #   new(authzid:,  oauth2_token:, **) -> authenticator
   #
   # Creates an Authenticator for the "+XOAUTH2+" SASL mechanism, as specified by
   # Google[https://developers.google.com/gmail/imap/xoauth2-protocol],
@@ -50,13 +56,21 @@ class Net::IMAP::SASL::XOAuth2Authenticator
   # === Properties
   #
   # * #username --- the username for the account being accessed.
+  #
+  #   #authzid  --- an alias for #username.
+  #
+  #   Note that, unlike some other authenticators, +username+ sets the
+  #   _authorization_ identity and not the _authentication_ identity.  The
+  #   authenticated identity is established for the client with the OAuth token.
+  #
   # * #oauth2_token --- An OAuth2.0 access token which is authorized to access
   #   the service for #username.
   #
   # Any other keyword parameters are quietly ignored.
-  def initialize(user = nil, token = nil, username: nil, oauth2_token: nil, **)
-    @username = username || user or
-      raise ArgumentError, "missing username"
+  def initialize(user = nil, token = nil, username: nil, oauth2_token: nil,
+                 authzid: nil, **)
+    @username = authzid || username || user or
+      raise ArgumentError, "missing username (authzid)"
     @oauth2_token = oauth2_token || token or
       raise ArgumentError, "missing oauth2_token"
     [username, user].compact.count == 1 or

--- a/lib/net/imap/sasl/xoauth2_authenticator.rb
+++ b/lib/net/imap/sasl/xoauth2_authenticator.rb
@@ -73,10 +73,6 @@ class Net::IMAP::SASL::XOAuth2Authenticator
       raise ArgumentError, "missing username (authzid)"
     @oauth2_token = oauth2_token || token or
       raise ArgumentError, "missing oauth2_token"
-    [username, user].compact.count == 1 or
-      raise ArgumentError, "conflicting values for username"
-    [oauth2_token, token].compact.count == 1 or
-      raise ArgumentError, "conflicting values for oauth2_token"
     @done = false
   end
 


### PR DESCRIPTION
Different SASL mechanisms use the term "username" differently.  In general the pattern seems to be the following:

* Some mechanisms avoid using the term `username` at all, and instead use the terms Authentication Identity (`authcid`) and Authorization Identity (`authzid`).
* Some mechanisms do not distinguish clearly between `authcid` and `authzid`.  `username` may be semantically equivalent to `authcid`, `authzid`, or both.
* When the mechanism supports an explicit `authcid`) and an Authorization Identity `authzid`, `username` commonly refers to the `authcid`.
* When the authentication identity is derived from the credentials, `username` commonly refers to the `authzid`

Every mechanism's keyword arguments, positional arguments, and documentation has been updated to match this terminology.  Aliases have been added from `username` to `authcid` or `authzid`—or in the other direction, from `authcid` or `authzd` to `username`

Instead of raising an exception, conflicting arguments are treated like silently ignored.  This allows more specific argument (like `authcid` or a keyword argument) to be used like an override to more generic terms (like `username` or a positional argument).  This could simplify using a single hash of keyword arguments with multiple SASL mechanisms, which could facilitate dynamically negotiating the mechanism, or automatically retrying multiple acceptable mechanisms.

`OAuthBearerAuthenticator` was updated to allow two arguments, in order to match the common `auth(username, secret)` parameter style.  In my opinion, this makes the API a little bit more confusing.  But the mechanism only requires one argument, so it's natural to allow a single argument version.  And this two argument version matches with how many clients and applications seem to _assume_ the SASL mechanisms _always_ work.