### PR TITLE
✨ Add `secret` alias (for `password`, `oauth2_token`, etc) to relevant SASL mechanisms

### DIFF
--- a/lib/net/imap/sasl/cram_md5_authenticator.rb
+++ b/lib/net/imap/sasl/cram_md5_authenticator.rb
@@ -16,7 +16,7 @@
 class Net::IMAP::SASL::CramMD5Authenticator
   def initialize(user = nil, pass = nil,
                  authcid: nil, username: nil,
-                 password: nil,
+                 password: nil, secret: nil,
                  warn_deprecation: true,
                  **)
     if warn_deprecation
@@ -24,7 +24,7 @@ class Net::IMAP::SASL::CramMD5Authenticator
     end
     require "digest/md5"
     @user = authcid || username || user
-    @password = password || pass
+    @password = password || secret || pass
     @done = false
   end
 

--- a/lib/net/imap/sasl/digest_md5_authenticator.rb
+++ b/lib/net/imap/sasl/digest_md5_authenticator.rb
@@ -69,11 +69,11 @@ class Net::IMAP::SASL::DigestMD5Authenticator
   # Any other keyword arguments are silently ignored.
   def initialize(user = nil, pass = nil, authz = nil,
                  username: nil, password: nil, authzid: nil,
-                 authcid: nil,
+                 authcid: nil, secret: nil,
                  warn_deprecation: true, **)
     username = authcid || username || user or
       raise ArgumentError, "missing username (authcid)"
-    password ||= pass or raise ArgumentError, "missing password"
+    password ||= secret || pass or raise ArgumentError, "missing password"
     authzid  ||= authz
     if warn_deprecation
       warn "WARNING: DIGEST-MD5 SASL mechanism was deprecated by RFC6331."

--- a/lib/net/imap/sasl/login_authenticator.rb
+++ b/lib/net/imap/sasl/login_authenticator.rb
@@ -25,14 +25,14 @@ class Net::IMAP::SASL::LoginAuthenticator
 
   def initialize(user = nil, pass = nil,
                  authcid: nil, username: nil,
-                 password: nil,
+                 password: nil, secret: nil,
                  warn_deprecation: true,
                  **)
     if warn_deprecation
       warn "WARNING: LOGIN SASL mechanism is deprecated. Use PLAIN instead."
     end
     @user = authcid || username || user
-    @password = password || pass
+    @password = password || secret || pass
     @state = STATE_USER
   end
 

--- a/lib/net/imap/sasl/oauthbearer_authenticator.rb
+++ b/lib/net/imap/sasl/oauthbearer_authenticator.rb
@@ -139,6 +139,7 @@ module Net
 
         # An OAuth 2.0 bearer token.  See {RFC-6750}[https://www.rfc-editor.org/rfc/rfc6750]
         attr_reader :oauth2_token
+        alias secret oauth2_token
 
         # :call-seq:
         #   new(oauth2_token,          **options) -> authenticator
@@ -173,10 +174,12 @@ module Net
         # noting that <b><em>application protocols are allowed to
         # require</em></b> #authzid (<em>or other parameters, such as</em> #host
         # _or_ #port) <b><em>as are specific server implementations</em></b>.
-        def initialize(arg1 = nil, arg2 = nil, oauth2_token: nil, **args, &blk)
+        def initialize(arg1 = nil, arg2 = nil,
+                       oauth2_token: nil, secret: nil,
+                       **args, &blk)
           username, oauth2_token_arg = arg2.nil? ? [nil, arg1] : [arg1, arg2]
           super(username: username, **args, &blk)
-          @oauth2_token = oauth2_token || oauth2_token_arg or
+          @oauth2_token = oauth2_token || secret || oauth2_token_arg or
             raise ArgumentError, "missing oauth2_token"
         end
 

--- a/lib/net/imap/sasl/plain_authenticator.rb
+++ b/lib/net/imap/sasl/plain_authenticator.rb
@@ -26,6 +26,7 @@ class Net::IMAP::SASL::PlainAuthenticator
 
   # A password or passphrase that matches the #username.
   attr_reader :password
+  alias secret password
 
   # Authorization identity: an identity to act as or on behalf of.  The identity
   # form is application protocol specific.  If not provided or left blank, the
@@ -64,11 +65,11 @@ class Net::IMAP::SASL::PlainAuthenticator
   #
   # Any other keyword parameters are quietly ignored.
   def initialize(user = nil, pass = nil,
-                 authcid: nil,
+                 authcid: nil, secret: nil,
                  username: nil, password: nil, authzid: nil, **)
     username ||= authcid || user or
       raise ArgumentError, "missing username (authcid)"
-    password ||= pass or raise ArgumentError, "missing password"
+    password ||= secret || pass or raise ArgumentError, "missing password"
     raise ArgumentError, "username contains NULL" if username.include?(NULL)
     raise ArgumentError, "password contains NULL" if password.include?(NULL)
     raise ArgumentError, "authzid contains NULL"  if authzid&.include?(NULL)

--- a/lib/net/imap/sasl/scram_authenticator.rb
+++ b/lib/net/imap/sasl/scram_authenticator.rb
@@ -80,13 +80,13 @@ module Net
         def initialize(username_arg = nil, password_arg = nil,
                        authcid: nil, username: nil,
                        authzid: nil,
-                       password: nil,
+                       password: nil, secret: nil,
                        min_iterations: 4096, # see both RFC5802 and RFC7677
                        cnonce: nil, # must only be set in tests
                        **options)
           @username = username || username_arg || authcid or
             raise ArgumentError, "missing username (authcid)"
-          @password = password || password_arg or
+          @password = password || secret || password_arg or
             raise ArgumentError, "missing password"
           @authzid = authzid
 
@@ -109,6 +109,7 @@ module Net
 
         # A password or passphrase that matches the #username.
         attr_reader :password
+        alias secret password
 
         # Authorization identity: an identity to act as or on behalf of.  The
         # identity form is application protocol specific.  If not provided or

--- a/lib/net/imap/sasl/xoauth2_authenticator.rb
+++ b/lib/net/imap/sasl/xoauth2_authenticator.rb
@@ -42,6 +42,7 @@ class Net::IMAP::SASL::XOAuth2Authenticator
   # An OAuth2 access token which has been authorized with the appropriate OAuth2
   # scopes to use the service for #username.
   attr_reader :oauth2_token
+  alias secret oauth2_token
 
   # :call-seq:
   #   new(username,  oauth2_token,  **) -> authenticator
@@ -68,10 +69,10 @@ class Net::IMAP::SASL::XOAuth2Authenticator
   #
   # Any other keyword parameters are quietly ignored.
   def initialize(user = nil, token = nil, username: nil, oauth2_token: nil,
-                 authzid: nil, **)
+                 authzid: nil, secret: nil, **)
     @username = authzid || username || user or
       raise ArgumentError, "missing username (authzid)"
-    @oauth2_token = oauth2_token || token or
+    @oauth2_token = oauth2_token || secret || token or
       raise ArgumentError, "missing oauth2_token"
     @done = false
   end


### PR DESCRIPTION
`secret` is similar to `username`: a convenient alias with ambiguous semantics.  Adding it is reasonable, but I probably wouldn't add it only for `Net::IMAP`.  However, relevant to #23, `Net::SMTP` uses it and probably others would find it useful too.