### PR TITLE
🥅 Validate response tagged in the parser

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -2519,7 +2519,8 @@ module Net
       when /\A(?:BAD)\z/ni
         raise BadResponseError, resp
       else
-        raise UnknownResponseError, resp
+        disconnect
+        raise InvalidResponseError, "invalid tagged resp: %p" % [resp.raw.chomp]
       end
     end
 

--- a/lib/net/imap/errors.rb
+++ b/lib/net/imap/errors.rb
@@ -47,7 +47,27 @@ module Net
     class ByeResponseError < ResponseError
     end
 
+    # Error raised when the server sends an invalid response.
+    #
+    # This is different from UnknownResponseError: the response has been
+    # rejected.  Although it may be parsable, the server is forbidden from
+    # sending it in the current context.  The client should automatically
+    # disconnect, abruptly (without logout).
+    #
+    # Note that InvalidResponseError does not inherit from ResponseError: it
+    # can be raised before the response is fully parsed.  A related
+    # ResponseParseError or ResponseError may be the #cause.
+    class InvalidResponseError < Error
+    end
+
     # Error raised upon an unknown response from the server.
+    #
+    # This is different from InvalidResponseError: the response may be a
+    # valid extension response and the server may be allowed to send it in
+    # this context, but Net::IMAP either does not know how to parse it or
+    # how to handle it.  This could result from enabling unknown or
+    # unhandled extensions.  The connection may still be usable,
+    # but—depending on context—it may be prudent to disconnect.
     class UnknownResponseError < ResponseError
     end
 

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -147,9 +147,10 @@ class IMAPTest < Test::Unit::TestCase
       imap = nil
       starttls_stripping_test do |port|
         imap = Net::IMAP.new("localhost", :port => port)
-        assert_raise(Net::IMAP::UnknownResponseError) do
+        assert_raise(Net::IMAP::InvalidResponseError) do
           imap.starttls(:ca_file => CA_FILE)
         end
+        assert imap.disconnected?
         imap
       end
       assert_equal false, imap.tls_verified?


### PR DESCRIPTION
Two parts (in two commits):

### [Add new `InvalidResponseError` exception class](https://github.com/ruby/net-imap/commit/609acd9fa60d276d1251d18d9093b898dfd2cd95)

The documentation for `InvalidResponseError` is:
> Error raised when the server sends an invalid response.
>
> This is different from UnknownResponseError: the response has been
> rejected.  Although it may be parsable, the server is forbidden from
> sending it in the current context.  The client should automatically
> disconnect, abruptly (without logout).
>
> Note that InvalidResponseError does not inherit from ResponseError: it
> can be raised before the response is fully parsed.  A related
> ResponseParseError or ResponseError may be the #cause.

The rdoc for `UnknownResponseError` is updated to:
> Error raised upon an unknown response from the server.
>
> This is different from InvalidResponseError: the response may be a
> valid extension response and the server may be allowed to send it in
> this context, but Net::IMAP either does not know how to parse it or
> how to handle it.  This could result from enabling unknown or
> unhandled extensions.  The connection may still be usable,
> but—depending on context—it may be prudent to disconnect.

All code that previously raised `UnknownResponseError` now raises
`InvalidResponseError`.  However, the class is kept both for backward
compatibility and because it might be reused in the future for similar
scenarios: e.g: when a tag doesn't match any outstanding response tags.

### [Validate `response-tagged` in the parser](https://github.com/ruby/net-imap/commit/6c3056c9e869aa01a5ed5f36ae9ea3215ee8c3d5)

The `response-tagged` parser now enforces `resp-cond-state`, raising
`InvalidResponseError` for any invalid status conditions.  It is also
refactored to the new parser style.  An explicit method for `tag` is
added, which is parsed similarly to `astring_chars` and `atom`.

```abnf
   response-tagged = tag SP resp-cond-state CRLF

   resp-cond-state = ("OK" / "NO" / "BAD") SP resp-text
                       ; Status condition

   tag             = 1*<any ASTRING-CHAR except "+">
```

Currently, any exception raised by the parser will abruptly drop the
connection.  In the future, if the response handler thread is made more
robust against recoverable errors, `InvalidResponseError` should be
considered non-recoverable.  A test covering this was added already.