### PR TITLE
♻️ Update `response` and `continue-req` to new parser style

### DIFF
--- a/lib/net/imap/response_data.rb
+++ b/lib/net/imap/response_data.rb
@@ -108,6 +108,9 @@ module Net
     # UntaggedResponse#data when the response type is a "condition" ("OK", "NO",
     # "BAD", "PREAUTH", or "BYE").
     class ResponseText < Struct.new(:code, :text)
+      # Used to avoid an allocation when ResponseText is empty
+      EMPTY = new(nil, "").freeze
+
       ##
       # method: code
       # :call-seq: code -> ResponseCode or nil

--- a/lib/net/imap/response_parser/parser_utils.rb
+++ b/lib/net/imap/response_parser/parser_utils.rb
@@ -170,6 +170,16 @@ module Net
           @token ||= next_token
         end
 
+        # like match, without consuming the token
+        def lookahead!(*args)
+          if args.include?((@token ||= next_token)&.symbol)
+            @token
+          else
+            parse_error('unexpected token %s (expected %s)',
+                        @token&.symbol, args.join(" or "))
+          end
+        end
+
         def peek_str?(str)
           assert_no_lookahead if Net::IMAP.debug
           @str[@pos, str.length] == str


### PR DESCRIPTION
This is primarily about making it easier to compare the parser source code to the RFC grammar, and secondarily about making it easier to debug parse errors.  This is subjective, of course. Perhaps more importantly, many of my other parser updates will have conflicts if this isn't added first. 😉