### PR TITLE
⚡ Simpler, faster `msg-att` parser (for fetch responses)

### DIFF
--- a/lib/net/imap/response_parser.rb
+++ b/lib/net/imap/response_parser.rb
@@ -655,41 +655,31 @@ module Net
       #   msg-att-static   =/ "BINARY" section-binary ["<" number ">"] SP
       #                       (nstring / literal8)
       def msg_att(n)
-        match(T_LPAR)
+        lpar
         attr = {}
         while true
-          token = lookahead
-          case token.symbol
-          when T_RPAR
-            shift_token
-            break
-          when T_SPACE
-            shift_token
-            next
-          end
-          case token.value
-          when /\A(?:ENVELOPE)\z/ni
-            name, val = envelope_data
-          when /\A(?:FLAGS)\z/ni
-            name, val = flags_data
-          when /\A(?:INTERNALDATE)\z/ni
-            name, val = internaldate_data
-          when /\A(?:RFC822(?:\.HEADER|\.TEXT)?)\z/ni
-            name, val = rfc822_text
-          when /\A(?:RFC822\.SIZE)\z/ni
-            name, val = rfc822_size
-          when /\A(?:BODY(?:STRUCTURE)?)\z/ni
-            name, val = body_data
-          when /\A(?:UID)\z/ni
-            name, val = uid_data
-          when /\A(?:MODSEQ)\z/ni
-            name, val = modseq_data
-          else
-            parse_error("unknown attribute `%s' for {%d}", token.value, n)
-          end
+          name = lookahead!(T_ATOM).value.upcase
+          name, val =
+            case name
+            when "UID"                  then uid_data
+            when "FLAGS"                then flags_data
+            when "BODY"                 then body_data
+            when "BODYSTRUCTURE"        then body_data
+            when "ENVELOPE"             then envelope_data
+            when "INTERNALDATE"         then internaldate_data
+            when "RFC822.SIZE"          then rfc822_size
+            when "RFC822"               then rfc822_text
+            when "RFC822.HEADER"        then rfc822_text        # not in rev2
+            when "RFC822.TEXT"          then rfc822_text        # not in rev2
+            when "MODSEQ"               then modseq_data        # CONDSTORE
+            else parse_error("unknown attribute `%s' for {%d}", name, n)
+            end
           attr[name] = val
+          break unless SP?
+          break if lookahead_rpar?
         end
-        return attr
+        rpar
+        attr
       end
 
       def envelope_data


### PR DESCRIPTION
* Similar to #201, but for `msg-att`.
* Converted the case statement to (mostly) use upcase'd strings, not regexps.
* The case stmt clauses were sorted.  This _might_ help with speed (need better `msg-att` frequency statistics to back up that claim) but it should _definitely_ help to help avoid conflicts.
  * first the most commonly seen ones (`UID` and `FLAGS`),
  * then the ones in both 3051 and 9051 (sorted alphabetically),
  * then the ones in 3051 that were removed from 9051,
  * then `MODSEQ` (currently, the only supported attribute that's in neither 3501 or 9051).
* Rewrite the parser for `section`, `section-spec`, `header-list`, `header-fld-name`.
* Read the entire `msg-att` label for `BODY[...]<...>` _prior_ to the case stmt.  This greatly simplifies the code for reading attribute values, allowing much of it to be deleted.

I have written support for several more fetch `msg-att`, that builds on the changes in this PR:
* #207 (`BINARY` and `BINARY.SIZE`) -- also needed for `IMAP4rev2`
* #206 (for the `OBJECTID` extension)
* `X-GM-MSGID`, `X-GM-THRID`, `X-GM-LABELS` (nonstandard GMail extensions)
* `ANNOTATION`
* `PREVIEW`
* `SAVEDATE`