### PR TITLE
Set utf-8 encoding when looking for VERSION in the file.

### DIFF
--- a/net-imap.gemspec
+++ b/net-imap.gemspec
@@ -2,7 +2,7 @@
 
 name = File.basename(__FILE__, ".gemspec")
 version = ["lib", Array.new(name.count("-"), "..").join("/")].find do |dir|
-  break File.foreach(File.join(__dir__, dir, "#{name.tr('-', '/')}.rb")) do |line|
+  break File.foreach(File.join(__dir__, dir, "#{name.tr('-', '/')}.rb"), :encoding=> 'utf-8') do |line|
     /^\s*VERSION\s*=\s*"(.*)"/ =~ line and break $1
   end rescue nil
 end


### PR DESCRIPTION
Signed-off-by: Debasish Biswas <debasishbsws.dev@gmail.com>

By default, Ruby reads files with the system's default encoding, which is not utf-8 for every system and it does not handle special characters like '§' correctly and fails to get the VERSION from the lib/net/imap.rb file as it contains special characters
https://github.com/ruby/net-imap/blob/6dda58178b47d402edb0486e48d10c7558bc9b60/lib/net/imap.rb#L149-L151