### PR TITLE
⚡ Simpler, faster `resp-text-code` parser (for response codes)

### DIFF
--- a/lib/net/imap/response_parser.rb
+++ b/lib/net/imap/response_parser.rb
@@ -1498,28 +1498,25 @@ module Net
         name = resp_text_code__name
         case name
         when "ALERT", "PARSE", "READ-ONLY", "READ-WRITE", "TRYCREATE", "NOMODSEQ"
-          ResponseCode.new(name, nil)
+          data = nil
         when "BADCHARSET"
-          ResponseCode.new(name, charset_list)
+          data = charset_list
         when "CAPABILITY"
-          ResponseCode.new(name, capability__list)
+          data = capability__list
         when "PERMANENTFLAGS"
           SP!
-          ResponseCode.new(name, flag_list)
+          data = flag_list
         when "UIDVALIDITY", "UIDNEXT", "UNSEEN"
           SP!
-          ResponseCode.new(name, number)
+          data = number
         when "APPENDUID"
-          ResponseCode.new(name, resp_code_apnd__data)
+          data = resp_code_apnd__data
         when "COPYUID"
-          ResponseCode.new(name, resp_code_copy__data)
+          data = resp_code_copy__data
         else
-          if SP?
-            ResponseCode.new(name, text_chars_except_rbra)
-          else
-            ResponseCode.new(name, nil)
-          end
+          data = SP? && text_chars_except_rbra
         end
+        ResponseCode.new(name, data)
       end
 
       alias resp_text_code__name case_insensitive__atom

--- a/lib/net/imap/response_parser.rb
+++ b/lib/net/imap/response_parser.rb
@@ -1498,29 +1498,28 @@ module Net
         name = resp_text_code__name
         case name
         when "ALERT", "PARSE", "READ-ONLY", "READ-WRITE", "TRYCREATE", "NOMODSEQ"
-          result = ResponseCode.new(name, nil)
+          ResponseCode.new(name, nil)
         when "BADCHARSET"
-          result = ResponseCode.new(name, charset_list)
+          ResponseCode.new(name, charset_list)
         when "CAPABILITY"
-          result = ResponseCode.new(name, capability__list)
+          ResponseCode.new(name, capability__list)
         when "PERMANENTFLAGS"
           SP!
-          result = ResponseCode.new(name, flag_list)
+          ResponseCode.new(name, flag_list)
         when "UIDVALIDITY", "UIDNEXT", "UNSEEN"
           SP!
-          result = ResponseCode.new(name, number)
+          ResponseCode.new(name, number)
         when "APPENDUID"
-          result = ResponseCode.new(name, resp_code_apnd__data)
+          ResponseCode.new(name, resp_code_apnd__data)
         when "COPYUID"
-          result = ResponseCode.new(name, resp_code_copy__data)
+          ResponseCode.new(name, resp_code_copy__data)
         else
           if SP?
-            result = ResponseCode.new(name, text_chars_except_rbra)
+            ResponseCode.new(name, text_chars_except_rbra)
           else
-            result = ResponseCode.new(name, nil)
+            ResponseCode.new(name, nil)
           end
         end
-        return result
       end
 
       alias resp_text_code__name case_insensitive__atom

--- a/lib/net/imap/response_parser.rb
+++ b/lib/net/imap/response_parser.rb
@@ -1487,6 +1487,35 @@ module Net
       #   capability-data  = "CAPABILITY" *(SP capability) SP "IMAP4rev1"
       #                      *(SP capability)
       #
+      # RFC5530:
+      #   resp-text-code  =/ "UNAVAILABLE" / "AUTHENTICATIONFAILED" /
+      #                     "AUTHORIZATIONFAILED" / "EXPIRED" /
+      #                     "PRIVACYREQUIRED" / "CONTACTADMIN" / "NOPERM" /
+      #                     "INUSE" / "EXPUNGEISSUED" / "CORRUPTION" /
+      #                     "SERVERBUG" / "CLIENTBUG" / "CANNOT" /
+      #                     "LIMIT" / "OVERQUOTA" / "ALREADYEXISTS" /
+      #                     "NONEXISTENT"
+      # RFC9051:
+      #   resp-text-code   = "ALERT" /
+      #                      "BADCHARSET" [SP "(" charset *(SP charset) ")" ] /
+      #                      capability-data / "PARSE" /
+      #                      "PERMANENTFLAGS" SP "(" [flag-perm *(SP flag-perm)] ")" /
+      #                      "READ-ONLY" / "READ-WRITE" / "TRYCREATE" /
+      #                      "UIDNEXT" SP nz-number / "UIDVALIDITY" SP nz-number /
+      #                      resp-code-apnd / resp-code-copy / "UIDNOTSTICKY" /
+      #                      "UNAVAILABLE" / "AUTHENTICATIONFAILED" /
+      #                      "AUTHORIZATIONFAILED" / "EXPIRED" /
+      #                      "PRIVACYREQUIRED" / "CONTACTADMIN" / "NOPERM" /
+      #                      "INUSE" / "EXPUNGEISSUED" / "CORRUPTION" /
+      #                      "SERVERBUG" / "CLIENTBUG" / "CANNOT" /
+      #                      "LIMIT" / "OVERQUOTA" / "ALREADYEXISTS" /
+      #                      "NONEXISTENT" / "NOTSAVED" / "HASCHILDREN" /
+      #                      "CLOSED" /
+      #                      "UNKNOWN-CTE" /
+      #                      atom [SP 1*<any TEXT-CHAR except "]">]
+      #   capability-data  = "CAPABILITY" *(SP capability) SP "IMAP4rev2"
+      #                      *(SP capability)
+      #
       # RFC4315 (UIDPLUS), RFC9051 (IMAP4rev2):
       #   resp-code-apnd   = "APPENDUID" SP nz-number SP append-uid
       #   resp-code-copy   = "COPYUID" SP nz-number SP uid-set SP uid-set
@@ -1508,7 +1537,12 @@ module Net
           when "APPENDUID"          then SP!; resp_code_apnd__data # rev2, UIDPLUS
           when "COPYUID"            then SP!; resp_code_copy__data # rev2, UIDPLUS
           when "BADCHARSET"         then SP? ? charset__list : []
-          when "ALERT", "PARSE", "READ-ONLY", "READ-WRITE", "TRYCREATE"
+          when "ALERT", "PARSE", "READ-ONLY", "READ-WRITE", "TRYCREATE",
+            "UNAVAILABLE", "AUTHENTICATIONFAILED", "AUTHORIZATIONFAILED",
+            "EXPIRED", "PRIVACYREQUIRED", "CONTACTADMIN", "NOPERM", "INUSE",
+            "EXPUNGEISSUED", "CORRUPTION", "SERVERBUG", "CLIENTBUG", "CANNOT",
+            "LIMIT", "OVERQUOTA", "ALREADYEXISTS", "NONEXISTENT", "CLOSED",
+            "NOTSAVED", "UIDNOTSTICKY", "UNKNOWN-CTE", "HASCHILDREN"
           when "NOMODSEQ"           # CONDSTORE
           else
             SP? and text_chars_except_rbra

--- a/lib/net/imap/response_parser.rb
+++ b/lib/net/imap/response_parser.rb
@@ -1473,44 +1473,48 @@ module Net
         end
       end
 
-      # See https://www.rfc-editor.org/errata/rfc3501
+      # RFC3501 (See https://www.rfc-editor.org/errata/rfc3501):
+      #   resp-text-code   = "ALERT" /
+      #                      "BADCHARSET" [SP "(" charset *(SP charset) ")" ] /
+      #                      capability-data / "PARSE" /
+      #                      "PERMANENTFLAGS" SP "(" [flag-perm *(SP flag-perm)] ")" /
+      #                      "READ-ONLY" / "READ-WRITE" / "TRYCREATE" /
+      #                      "UIDNEXT" SP nz-number / "UIDVALIDITY" SP nz-number /
+      #                      "UNSEEN" SP nz-number /
+      #                      atom [SP 1*<any TEXT-CHAR except "]">]
+      #   capability-data  = "CAPABILITY" *(SP capability) SP "IMAP4rev1"
+      #                      *(SP capability)
       #
-      # resp-text-code  = "ALERT" /
-      #                   "BADCHARSET" [SP "(" charset *(SP charset) ")" ] /
-      #                   capability-data / "PARSE" /
-      #                   "PERMANENTFLAGS" SP "("
-      #                   [flag-perm *(SP flag-perm)] ")" /
-      #                   "READ-ONLY" / "READ-WRITE" / "TRYCREATE" /
-      #                   "UIDNEXT" SP nz-number / "UIDVALIDITY" SP nz-number /
-      #                   "UNSEEN" SP nz-number /
-      #                   atom [SP 1*<any TEXT-CHAR except "]">]
+      # RFC4315 (UIDPLUS), RFC9051 (IMAP4rev2):
+      #   resp-code-apnd   = "APPENDUID" SP nz-number SP append-uid
+      #   resp-code-copy   = "COPYUID" SP nz-number SP uid-set SP uid-set
+      #   resp-text-code   =/ resp-code-apnd / resp-code-copy / "UIDNOTSTICKY"
       #
-      # +UIDPLUS+ ABNF:: https://www.rfc-editor.org/rfc/rfc4315.html#section-4
-      #   resp-text-code  =/ resp-code-apnd / resp-code-copy / "UIDNOTSTICKY"
+      # RFC7162 (CONDSTORE):
+      #   resp-text-code   =/ "HIGHESTMODSEQ" SP mod-sequence-value /
+      #                       "NOMODSEQ" /
+      #                       "MODIFIED" SP sequence-set
       def resp_text_code
-        token = match(T_ATOM)
-        name = token.value.upcase
+        name = resp_text_code__name
         case name
-        when /\A(?:ALERT|PARSE|READ-ONLY|READ-WRITE|TRYCREATE|NOMODSEQ)\z/n
+        when "ALERT", "PARSE", "READ-ONLY", "READ-WRITE", "TRYCREATE", "NOMODSEQ"
           result = ResponseCode.new(name, nil)
-        when /\A(?:BADCHARSET)\z/n
+        when "BADCHARSET"
           result = ResponseCode.new(name, charset_list)
-        when /\A(?:CAPABILITY)\z/ni
+        when "CAPABILITY"
           result = ResponseCode.new(name, capability__list)
-        when /\A(?:PERMANENTFLAGS)\z/n
-          match(T_SPACE)
+        when "PERMANENTFLAGS"
+          SP!
           result = ResponseCode.new(name, flag_list)
-        when /\A(?:UIDVALIDITY|UIDNEXT|UNSEEN)\z/n
-          match(T_SPACE)
+        when "UIDVALIDITY", "UIDNEXT", "UNSEEN"
+          SP!
           result = ResponseCode.new(name, number)
-        when /\A(?:APPENDUID)\z/n
+        when "APPENDUID"
           result = ResponseCode.new(name, resp_code_apnd__data)
-        when /\A(?:COPYUID)\z/n
+        when "COPYUID"
           result = ResponseCode.new(name, resp_code_copy__data)
         else
-          token = lookahead
-          if token.symbol == T_SPACE
-            shift_token
+          if SP?
             result = ResponseCode.new(name, text_chars_except_rbra)
           else
             result = ResponseCode.new(name, nil)
@@ -1518,6 +1522,8 @@ module Net
         end
         return result
       end
+
+      alias resp_text_code__name case_insensitive__atom
 
       # 1*<any TEXT-CHAR except "]">
       def text_chars_except_rbra

--- a/lib/net/imap/response_parser.rb
+++ b/lib/net/imap/response_parser.rb
@@ -1505,8 +1505,8 @@ module Net
           when "UIDNEXT"            then SP!; nz_number
           when "UIDVALIDITY"        then SP!; nz_number
           when "UNSEEN"             then SP!; nz_number            # rev1 only
-          when "APPENDUID"          then resp_code_apnd__data
-          when "COPYUID"            then resp_code_copy__data
+          when "APPENDUID"          then SP!; resp_code_apnd__data # rev2, UIDPLUS
+          when "COPYUID"            then SP!; resp_code_copy__data # rev2, UIDPLUS
           when "BADCHARSET"         then charset_list
           when "ALERT", "PARSE", "READ-ONLY", "READ-WRITE", "TRYCREATE"
           when "NOMODSEQ"           # CONDSTORE
@@ -1549,8 +1549,8 @@ module Net
       # match uid_set even if that returns a single-member array.
       #
       def resp_code_apnd__data
-        match(T_SPACE); validity = number
-        match(T_SPACE); dst_uids = uid_set # uniqueid ⊂ uid-set
+        validity = number; SP!
+        dst_uids = uid_set # uniqueid ⊂ uid-set
         UIDPlusData.new(validity, nil, dst_uids)
       end
 
@@ -1558,9 +1558,9 @@ module Net
       #
       # resp-code-copy  = "COPYUID" SP nz-number SP uid-set SP uid-set
       def resp_code_copy__data
-        match(T_SPACE); validity = number
-        match(T_SPACE); src_uids = uid_set
-        match(T_SPACE); dst_uids = uid_set
+        validity = number;  SP!
+        src_uids = uid_set; SP!
+        dst_uids = uid_set
         UIDPlusData.new(validity, src_uids, dst_uids)
       end
 

--- a/lib/net/imap/response_parser.rb
+++ b/lib/net/imap/response_parser.rb
@@ -1496,26 +1496,21 @@ module Net
       #                       "MODIFIED" SP sequence-set
       def resp_text_code
         name = resp_text_code__name
-        case name
-        when "ALERT", "PARSE", "READ-ONLY", "READ-WRITE", "TRYCREATE", "NOMODSEQ"
-          data = nil
-        when "BADCHARSET"
-          data = charset_list
-        when "CAPABILITY"
-          data = capability__list
-        when "PERMANENTFLAGS"
-          SP!
-          data = flag_list
-        when "UIDVALIDITY", "UIDNEXT", "UNSEEN"
-          SP!
-          data = number
-        when "APPENDUID"
-          data = resp_code_apnd__data
-        when "COPYUID"
-          data = resp_code_copy__data
-        else
-          data = SP? && text_chars_except_rbra
-        end
+        data =
+          case name
+          when "ALERT", "PARSE", "READ-ONLY", "READ-WRITE", "TRYCREATE"
+          when "NOMODSEQ"           # CONDSTORE
+          when "BADCHARSET"         then charset_list
+          when "CAPABILITY"         then capability__list
+          when "PERMANENTFLAGS"     then SP!; flag_list
+          when "UIDVALIDITY"        then SP!; number
+          when "UIDNEXT"            then SP!; number
+          when "UNSEEN"             then SP!; number
+          when "APPENDUID"          then resp_code_apnd__data
+          when "COPYUID"            then resp_code_copy__data
+          else
+            SP? and text_chars_except_rbra
+          end
         ResponseCode.new(name, data)
       end
 

--- a/lib/net/imap/response_parser.rb
+++ b/lib/net/imap/response_parser.rb
@@ -1498,9 +1498,6 @@ module Net
         name = resp_text_code__name
         data =
           case name
-          when "ALERT", "PARSE", "READ-ONLY", "READ-WRITE", "TRYCREATE"
-          when "NOMODSEQ"           # CONDSTORE
-          when "BADCHARSET"         then charset_list
           when "CAPABILITY"         then capability__list
           when "PERMANENTFLAGS"     then SP!; flag_list
           when "UIDVALIDITY"        then SP!; number
@@ -1508,6 +1505,9 @@ module Net
           when "UNSEEN"             then SP!; number
           when "APPENDUID"          then resp_code_apnd__data
           when "COPYUID"            then resp_code_copy__data
+          when "BADCHARSET"         then charset_list
+          when "ALERT", "PARSE", "READ-ONLY", "READ-WRITE", "TRYCREATE"
+          when "NOMODSEQ"           # CONDSTORE
           else
             SP? and text_chars_except_rbra
           end

--- a/lib/net/imap/response_parser.rb
+++ b/lib/net/imap/response_parser.rb
@@ -1502,9 +1502,9 @@ module Net
           case name
           when "CAPABILITY"         then resp_code__capability
           when "PERMANENTFLAGS"     then SP? ? flag_perm__list : []
-          when "UIDVALIDITY"        then SP!; number
-          when "UIDNEXT"            then SP!; number
-          when "UNSEEN"             then SP!; number
+          when "UIDNEXT"            then SP!; nz_number
+          when "UIDVALIDITY"        then SP!; nz_number
+          when "UNSEEN"             then SP!; nz_number            # rev1 only
           when "APPENDUID"          then resp_code_apnd__data
           when "COPYUID"            then resp_code_copy__data
           when "BADCHARSET"         then charset_list

--- a/lib/net/imap/response_parser.rb
+++ b/lib/net/imap/response_parser.rb
@@ -1346,10 +1346,12 @@ module Net
       end
 
       # As a workaround for buggy servers, allow a trailing SP:
-      #     *(SP capapility) [SP]
+      #     *(SP capability) [SP]
       def capability__list
-        data = []; while _ = SP? && capability? do data << _ end; data
+        list = []; while SP? && (capa = capability?) do list << capa end; list
       end
+
+      alias resp_code__capability capability__list
 
       # capability      = ("AUTH=" auth-type) / atom
       #                     ; New capabilities MUST begin with "X" or be
@@ -1498,7 +1500,7 @@ module Net
         name = resp_text_code__name
         data =
           case name
-          when "CAPABILITY"         then capability__list
+          when "CAPABILITY"         then resp_code__capability
           when "PERMANENTFLAGS"     then SP!; flag_list
           when "UIDVALIDITY"        then SP!; number
           when "UIDNEXT"            then SP!; number

--- a/lib/net/imap/response_parser.rb
+++ b/lib/net/imap/response_parser.rb
@@ -1501,7 +1501,7 @@ module Net
         data =
           case name
           when "CAPABILITY"         then resp_code__capability
-          when "PERMANENTFLAGS"     then SP!; flag_list
+          when "PERMANENTFLAGS"     then SP? ? flag_perm__list : []
           when "UIDVALIDITY"        then SP!; number
           when "UIDNEXT"            then SP!; number
           when "UNSEEN"             then SP!; number
@@ -1638,6 +1638,8 @@ module Net
         end
       end
 
+      # TODO: not quite correct.  flag-perm != flag
+      alias flag_perm__list flag_list
 
       # See https://www.rfc-editor.org/errata/rfc3501
       #


### PR DESCRIPTION
Similar to #202 and #205, but for `resp-text-code`:
* #202
* #205

**Please note:** My primary goal with this PR and the other related PRs is to merge the _foundation_ that I've been using for a wide variety of other parser improvements.  Improving performance is only a secondary goal.  Compatibility with `IMAP4rev2` and a variety of popular extensions is still more important.