### PR TITLE
⚡ Update flag parsing: FLAGS, LIST, PERMANENTFLAGS

### DIFF
--- a/benchmarks/parser.yml
+++ b/benchmarks/parser.yml
@@ -116,6 +116,11 @@ benchmark:
       response = load_response("../test/net/imap/fixtures/response_parser/fetch_responses.yml",
                                "test_fetch_msg_att_uid")
   script: parser.parse(response)
+- name: flags_with_various_flag_types
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/flags_responses.yml",
+                               "test_flags_with_various_flag_types")
+  script: parser.parse(response)
 - name: id_gmail
   prelude: |2
       response = load_response("../test/net/imap/fixtures/response_parser/id_responses.yml",
@@ -191,10 +196,10 @@ benchmark:
       response = load_response("../test/net/imap/fixtures/response_parser/thread_responses.yml",
                                "test_invalid_thread_empty_response")
   script: parser.parse(response)
-- name: list_with_various_flag_types_and_capitalizations
+- name: list_with_various_flag_capitalizations
   prelude: |2
       response = load_response("../test/net/imap/fixtures/response_parser/list_responses.yml",
-                               "test_list_with_various_flag_types_and_capitalizations")
+                               "test_list_with_various_flag_capitalizations")
   script: parser.parse(response)
 - name: resp_code_ALREADYEXISTS_rfc9051_7.1_example
   prelude: |2
@@ -375,6 +380,11 @@ benchmark:
   prelude: |2
       response = load_response("../test/net/imap/fixtures/response_parser/resp_code_examples.yml",
                                "test_resp_code_UNSEEN_rfc3501_6.3.1_example")
+  script: parser.parse(response)
+- name: resp_text_PERMANENTFLAGS_with_various_flag_types
+  prelude: |2
+      response = load_response("../test/net/imap/fixtures/response_parser/resp_code_examples.yml",
+                               "test_resp_text_PERMANENTFLAGS_with_various_flag_types")
   script: parser.parse(response)
 - name: resp_text_with_T_LBRA
   prelude: |2

--- a/test/net/imap/fixtures/response_parser/flags_responses.yml
+++ b/test/net/imap/fixtures/response_parser/flags_responses.yml
@@ -14,3 +14,14 @@
       - :Seen
       - :Draft
       raw_data: "* FLAGS (\\Answered \\Flagged \\Deleted \\Seen \\Draft)\r\n"
+
+  test_flags_with_various_flag_types:
+    :response: "* FLAGS (\\foo bAR $Etc \\baz)\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: FLAGS
+      data:
+      - :Foo
+      - bAR
+      - $Etc
+      - :Baz
+      raw_data: "* FLAGS (\\foo bAR $Etc \\baz)\r\n"

--- a/test/net/imap/fixtures/response_parser/list_responses.yml
+++ b/test/net/imap/fixtures/response_parser/list_responses.yml
@@ -34,19 +34,19 @@
         name: "#news.comp.mail.misc"
       raw_data: "* LSUB () \".\" #news.comp.mail.misc\r\n"
 
-  test_list_with_various_flag_types_and_capitalizations:
-    :response: "* LIST (\\foo bAR $Etc \\baz) \".\" \"INBOX\"\r\n"
+  test_list_with_various_flag_capitalizations:
+    :response: "* LIST (\\foo \\bAR \\Etc \\baz) \".\" \"INBOX\"\r\n"
     :expected: !ruby/struct:Net::IMAP::UntaggedResponse
       name: LIST
       data: !ruby/struct:Net::IMAP::MailboxList
         attr:
         - :Foo
-        - bAR
-        - $Etc
+        - :Bar
+        - :Etc
         - :Baz
         delim: "."
         name: INBOX
-      raw_data: "* LIST (\\foo bAR $Etc \\baz) \".\" \"INBOX\"\r\n"
+      raw_data: "* LIST (\\foo \\bAR \\Etc \\baz) \".\" \"INBOX\"\r\n"
 
   test_xlist_inbox:
     :response: "* XLIST (\\Inbox) \".\" \"INBOX\"\r\n"

--- a/test/net/imap/fixtures/response_parser/resp_code_examples.yml
+++ b/test/net/imap/fixtures/response_parser/resp_code_examples.yml
@@ -86,6 +86,22 @@
         text: No permanent flags permitted
       raw_data: "* OK [PERMANENTFLAGS ()] No permanent flags permitted\r\n"
 
+  test_resp_text_PERMANENTFLAGS_with_various_flag_types:
+    :response: "* ok [PERMANENTFLAGS (\\foo \\* bAR $Etc \\baz)] flags saved\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: OK
+      data: !ruby/struct:Net::IMAP::ResponseText
+        text: flags saved
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: PERMANENTFLAGS
+          data:
+          - :Foo
+          - :*
+          - bAR
+          - $Etc
+          - :Baz
+      raw_data: "* ok [PERMANENTFLAGS (\\foo \\* bAR $Etc \\baz)] flags saved\r\n"
+
   test_resp_code_READ-ONLY_rfc3501_6.3.2_example:
     :response: "A932 OK [READ-ONLY] EXAMINE completed\r\n"
     :expected: !ruby/struct:Net::IMAP::TaggedResponse


### PR DESCRIPTION
Rather than treat all three identically, this uses a more strict parser tailored to each one.  One of my earlier tests was invalid, so that has also been fixed.

Rather than use `String#scan`, the flags lists are matched with a single regexp, and the match is split then mapped.  In my benchmarks, this is _slightly_ faster than using `String#scan`.