### PR TITLE
🥅 Return empty array for missing server response

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -2188,7 +2188,7 @@ module Net
         .join(' ')
       synchronize do
         send_command("ENABLE #{capabilities}")
-        result = clear_responses("ENABLED").last
+        result = clear_responses("ENABLED").last || []
         @utf8_strings ||= result.include? "UTF8=ACCEPT"
         @utf8_strings ||= result.include? "IMAP4REV2"
         result
@@ -2642,7 +2642,7 @@ module Net
         else
           send_command(cmd, *keys)
         end
-        clear_responses("SEARCH").last
+        clear_responses("SEARCH").last || []
       end
     end
 
@@ -2691,7 +2691,7 @@ module Net
       normalize_searching_criteria(search_keys)
       synchronize do
         send_command(cmd, sort_keys, charset, *search_keys)
-        clear_responses("SORT").last
+        clear_responses("SORT").last || []
       end
     end
 
@@ -2704,7 +2704,7 @@ module Net
       normalize_searching_criteria(search_keys)
       synchronize do
         send_command(cmd, algorithm, charset, *search_keys)
-        clear_responses("THREAD").last
+        clear_responses("THREAD").last || []
       end
     end
 

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -1138,6 +1138,47 @@ EOF
     end
   end
 
+  test("missing server ENABLED response") do
+    with_fake_server do |server, imap|
+      server.on "ENABLE", &:done_ok
+      enabled = imap.enable "foo", "bar", "baz"
+      assert_equal [], enabled
+    end
+  end
+
+  test("missing server SEARCH response") do
+    with_fake_server do |server, imap|
+      server.on "SEARCH",     &:done_ok
+      server.on "UID SEARCH", &:done_ok
+      found = imap.search ["subject", "hello"]
+      assert_equal [], found
+      found = imap.uid_search ["subject", "hello"]
+      assert_equal [], found
+    end
+  end
+
+  test("missing server SORT response") do
+    with_fake_server do |server, imap|
+      server.on "SORT",       &:done_ok
+      server.on "UID SORT",   &:done_ok
+      found = imap.sort ["INTERNALDATE"], ["subject", "hello"], "UTF-8"
+      assert_equal [], found
+      found = imap.uid_sort ["INTERNALDATE"], ["subject", "hello"], "UTF-8"
+      assert_equal [], found
+    end
+  end
+
+  test("missing server THREAD response") do
+    with_fake_server do |server, imap|
+      server.on "THREAD",     &:done_ok
+      server.on "UID THREAD", &:done_ok
+      found = imap.thread "REFERENCES", ["subject", "hello"], "UTF-8"
+      assert_equal [], found
+      found = imap.uid_thread "REFERENCES", ["subject", "hello"], "UTF-8"
+      assert_equal [], found
+    end
+  end
+
   private
 
   def imaps_test(timeout: 10)


### PR DESCRIPTION
When the server fails to send a response for certain commands, we can workaround this by simply returning an empty array.  This should work for `SEARCH`, `SORT`, `THREAD`, and `ENABLED`, each of which expects a single response.

I did not do the same for `CAPABILITY` for two reasons:
* if a mistake is made, it could break the capabilities cache.
* the server _must_ at least return a single capability (`IMAP4rev1` or `IMAP4rev2`), so a missing response may indicate bigger problems.

Related:
* #192