### PR TITLE
💥⚡ Simplify `header-fld-name` parser (backward incompatible)

### DIFF
--- a/lib/net/imap/response_parser.rb
+++ b/lib/net/imap/response_parser.rb
@@ -1317,31 +1317,19 @@ module Net
       #   header-fld-name = astring
       #
       # NOTE: Previously, Net::IMAP recreated the raw original source string.
-      # Now, it grabs the raw encoded value using @str and @pos.  A future
-      # version may simply return the decoded astring value.  Although that is
-      # technically incompatible, it should almost never make a difference: all
-      # standard header field names are valid atoms:
+      # Now, it returns the decoded astring value.  Although this is technically
+      # incompatible, it should almost never make a difference: all standard
+      # header field names are valid atoms:
       #
       # https://www.iana.org/assignments/message-headers/message-headers.xhtml
       #
-      # Although RFC3501 allows any astring, RFC5322-valid header names are one
-      # or more of the printable US-ASCII characters, except SP and colon.  So
-      # empty string isn't valid, and literals aren't needed and should not be
-      # used.  This is explicitly unchanged by [I18N-HDRS] (RFC6532).
-      #
-      # RFC5233:
+      # See also RFC5233:
       #     optional-field  =   field-name ":" unstructured CRLF
       #     field-name      =   1*ftext
       #     ftext           =   %d33-57 /          ; Printable US-ASCII
       #                         %d59-126           ;  characters not including
       #                                            ;  ":".
-      def header_fld_name
-        assert_no_lookahead
-        start = @pos
-        astring
-        end_pos = @token ? @pos - 1 : @pos
-        @str[start...end_pos]
-      end
+      alias header_fld_name astring
 
       # mailbox-data    =  "FLAGS" SP flag-list / "LIST" SP mailbox-list /
       #                    "LSUB" SP mailbox-list / "SEARCH" *(SP nz-number) /

--- a/test/net/imap/fixtures/response_parser/fetch_responses.yml
+++ b/test/net/imap/fixtures/response_parser/fetch_responses.yml
@@ -70,7 +70,7 @@
       data: !ruby/struct:Net::IMAP::FetchData
         seqno: 10
         attr:
-          "BODY[HEADER.FIELDS (\"Content-Type\")]": "Content-Type: multipart/alternative;\r\n
+          "BODY[HEADER.FIELDS (Content-Type)]": "Content-Type: multipart/alternative;\r\n
             boundary=\"--==_mimepart_66cfb08b4f249_34306b61811e5\"\r\n\r\n"
       raw_data: *test_fetch_msg_att_HEADER_FIELDS_quoted
 


### PR DESCRIPTION
This speeds up my (newly added) benchmarks by ~15-20% over v0.4.3, and by 22-40% over earlier versions.

**NOTE:** In every version up to v0.4.3, `Net::IMAP` recreated the raw original source string.  After #217, it slices the raw original source string.  After this PR, it returns the _decoded_ astring value.  Although this is _technically_ incompatible, it should almost never make a difference.  See the [IANA Message Header Field Names list](https://www.iana.org/assignments/message-headers/message-headers.xhtml).  All standard header field names are valid IMAP atoms.  So I think this incompatibility should _almost_ never occur.

Valid RFC-5322 field names will never require string literals.  But they technically may include atom-special characters and thus need to be quoted.  Note that RFC-6532 (I18N headers) explicitly does _not_ change the RFC-5322 field _name_ syntax.

RFC-5322 syntax:
```abnf
field-name      =   1*ftext
ftext           =   %d33-57 /          ; Printable US-ASCII
                    %d59-126           ;  characters not including
                                       ;  ":".
```

Which is matched by the following Regexp:
```ruby
33.chr  => "!"
57.chr  => "9"
59.chr  => ";"
126.chr => "~"
[*33..57, *59..126].map{_1.chr}.join =>
  "!\"\#$%&'()*+,-./0123456789;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
VALID_RFC5322_FIELD_NAME = /\A[!-9;-~]+\z/
```

Although it shouldn't, if a server unnecessarily uses a quoted string (or a literal) for any _standard_ message headers, this PR _simplifies_ accessing the result by normalizing the field name back to its atom form.

The real incompatibility occurs when fetching non-standard but syntactically valid RFC-5322 field names, containing atom specials, which need to be quoted.  But the workaround is simple.

For example, with the following non-standard (but syntactically valid) field names:
```ruby
field_names = %w[
  \\Foo%
  ("BAR")
]
field_names.all?(VALID_RFC5322_FIELD_NAME) => true
```

The current version of `Net::IMAP#fetch` doesn't quote any attrs, so in order to fetch these we'd need to manually quote them:
```ruby
quoted_names = field_names
  .map { _1.gsub(/["\\]/) { "\\#$&" } }
  .join(" ")
joined_names = field_names.join(" ")

joined_names => "\\Foo% (\"BAR\")"
quoted_names => "\"\\\\Foo%\" \"(\\\"BAR\\\")\""

imap.fetch(1, "BODY[HEADER.FIELDS (#{quoted_names})]") => [fetch_data]
```

All of the above is unchanged by this PR.  The incompatibility is when retrieving the results from the `FetchData`:
```ruby
# In the current version (v0.4.3), access using quoted names:
fetch_data.attr['BODY[HEADER.FIELDS (#{quoted_names})'] => String

# After this PR, access using unquoted names:
fetch_data.attr['BODY[HEADER.FIELDS (#{joined_names})'] => String
```

However, I also prepared a version that is backward-compatible, with a smaller performance boost:
* #217 