### PR TITLE
✨ Allow `decode_datetime` to work without dquotes

### DIFF
--- a/lib/net/imap/data_encoding.rb
+++ b/lib/net/imap/data_encoding.rb
@@ -102,8 +102,16 @@ module Net
     #
     # Decodes +string+ as an IMAP4 formatted "date-time".
     #
-    # Note that double quotes are not optional.  See STRFTIME.
+    # NOTE: Although double-quotes are not optional in the IMAP grammar,
+    # Net::IMAP currently parses "date-time" values as "quoted" strings and this
+    # removes the quotation marks.  To be useful for strings which have already
+    # been parsed as a quoted string, this method makes double-quotes optional.
+    #
+    # See STRFTIME.
     def self.decode_datetime(string)
+      unless string.start_with?(?") && string.end_with?(?")
+        string = '"%s"' % [string]
+      end
       DateTime.strptime(string, STRFTIME)
     end
 

--- a/lib/net/imap/data_encoding.rb
+++ b/lib/net/imap/data_encoding.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "date"
+require "time"
 
 require_relative "errors"
 
@@ -121,7 +122,10 @@ module Net
     #
     # Same as +decode_datetime+, but returning a Time instead.
     def self.decode_time(string)
-      decode_datetime(string).to_time
+      unless string.start_with?(?") && string.end_with?(?")
+        string = '"%s"' % [string]
+      end
+      Time.strptime(string, STRFTIME)
     end
 
     class << self

--- a/test/net/imap/test_imap_data_encoding.rb
+++ b/test/net/imap/test_imap_data_encoding.rb
@@ -59,6 +59,8 @@ class IMAPDataEncodingTest < Test::Unit::TestCase
     expected = DateTime.new(2022, 10, 6, 1, 2, 3, "-04:00")
     actual   = Net::IMAP.decode_datetime('"06-Oct-2022 01:02:03 -0400"')
     assert_equal expected, actual
+    actual   = Net::IMAP.decode_datetime("06-Oct-2022 01:02:03 -0400")
+    assert_equal expected, actual
     actual   = Net::IMAP.parse_datetime '" 6-Oct-2022 01:02:03 -0400"'
     assert_equal expected, actual
   end
@@ -68,6 +70,8 @@ class IMAPDataEncodingTest < Test::Unit::TestCase
     actual   = Net::IMAP.parse_time '"07-Nov-2020 01:02:03 -0400"'
     assert_equal expected, actual
     actual   = Net::IMAP.decode_time '" 7-Nov-2020 01:02:03 -0400"'
+    assert_equal expected, actual
+    actual   = Net::IMAP.parse_time "07-Nov-2020 01:02:03 -0400"
     assert_equal expected, actual
   end
 


### PR DESCRIPTION
This modifies the code added in #66 to make it more useful when `date-time` is parsed as a `quoted` string (as it currently is).  I'd prefer that ResponseParser simply parse `date-time` values as DateTime objects, but that has backwards compatibility issues.