### PR TITLE
⚡ Better Faster Cleaner `STATUS` parsing

### DIFF
--- a/lib/net/imap/response_data.rb
+++ b/lib/net/imap/response_data.rb
@@ -72,7 +72,7 @@ module Net
     # unknown extensions to response types without a well-defined extension
     # grammar.
     #
-    # See also: UnparsedNumericResponseData
+    # See also: UnparsedNumericResponseData, ExtensionData, IgnoredResponse
     class UnparsedData < Struct.new(:unparsed_data)
       ##
       # method: unparsed_data
@@ -88,7 +88,7 @@ module Net
     # Net::IMAP::UnparsedNumericResponseData represents data for unhandled
     # response types with a numeric prefix.  See the documentation for #number.
     #
-    # See also: UnparsedData
+    # See also: UnparsedData, ExtensionData, IgnoredResponse
     class UnparsedNumericResponseData < Struct.new(:number, :unparsed_data)
       ##
       # method: number
@@ -105,6 +105,23 @@ module Net
       # :call-seq: unparsed_data -> string
       #
       # The unparsed data, not including #number or UntaggedResponse#name.
+    end
+
+    # **Note:** This represents an intentionally _unstable_ API.  Where
+    # instances of this class are returned, future releases may return a
+    # different (incompatible) object <em>without deprecation or warning</em>.
+    #
+    # Net::IMAP::ExtensionData represents data that is parsable according to the
+    # forward-compatible extension syntax in RFC3501, RFC4466, or RFC9051, but
+    # isn't directly known or understood by Net::IMAP yet.
+    #
+    # See also: UnparsedData, UnparsedNumericResponseData, IgnoredResponse
+    class ExtensionData < Struct.new(:data)
+      ##
+      # method: data
+      # :call-seq: data -> string
+      #
+      # The parsed extension data.
     end
 
     # Net::IMAP::TaggedResponse represents tagged responses.

--- a/lib/net/imap/response_data.rb
+++ b/lib/net/imap/response_data.rb
@@ -2,7 +2,8 @@
 
 module Net
   class IMAP < Protocol
-    autoload :FetchData, File.expand_path("fetch_data", __dir__)
+    autoload :FetchData,        "#{__dir__}/fetch_data"
+    autoload :SequenceSet,      "#{__dir__}/sequence_set"
 
     # Net::IMAP::ContinuationRequest represents command continuation requests.
     #

--- a/lib/net/imap/response_parser.rb
+++ b/lib/net/imap/response_parser.rb
@@ -556,6 +556,50 @@ module Net
         NIL? ? nil : case_insensitive__string
       end
 
+      # tagged-ext-comp     = astring /
+      #                       tagged-ext-comp *(SP tagged-ext-comp) /
+      #                       "(" tagged-ext-comp ")"
+      #                       ; Extensions that follow this general
+      #                       ; syntax should use nstring instead of
+      #                       ; astring when appropriate in the context
+      #                       ; of the extension.
+      #                       ; Note that a message set or a "number"
+      #                       ; can always be represented as an "atom".
+      #                       ; A URL should be represented as
+      #                       ; a "quoted" string.
+      def tagged_ext_comp
+        vals = []
+        while true
+          vals << case lookahead!(*ASTRING_TOKENS, T_LPAR).symbol
+                  when T_LPAR   then lpar; ary = tagged_ext_comp; rpar; ary
+                  when T_NUMBER then number
+                  else               astring
+                  end
+          SP? or break
+        end
+        vals
+      end
+
+      # tagged-ext-simple is a subset of atom
+      # TODO: recognize sequence-set in the lexer
+      #
+      # tagged-ext-simple   = sequence-set / number / number64
+      def tagged_ext_simple
+        number? || sequence_set
+      end
+
+      # tagged-ext-val      = tagged-ext-simple /
+      #                       "(" [tagged-ext-comp] ")"
+      def tagged_ext_val
+        if lpar?
+          _ = peek_rpar? ? [] : tagged_ext_comp
+          rpar
+          _
+        else
+          tagged_ext_simple
+        end
+      end
+
       # valid number ranges are not enforced by parser
       #   number64        = 1*DIGIT
       #                       ; Unsigned 63-bit integer

--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Net
+  class IMAP
+
+    ##
+    # An IMAP {sequence
+    # set}[https://www.rfc-editor.org/rfc/rfc9051.html#section-4.1.1],
+    # is a set of message sequence numbers or unique identifier numbers
+    # ("UIDs").  It contains numbers and ranges of numbers.  The numbers are all
+    # non-zero unsigned 32-bit integers and one special value, <tt>*</tt>, that
+    # represents the largest value in the mailbox.
+    #
+    # *NOTE:* This SequenceSet class is currently a placeholder for unhandled
+    # extension data.  All it does now is validate.  It will be expanded to a
+    # full API in a future release.
+    class SequenceSet
+
+      def self.[](str) new(str).freeze end
+
+      def initialize(input)
+        @atom = -String.try_convert(input)
+        validate
+      end
+
+      # Returns the IMAP string representation.  In the IMAP grammar,
+      # +sequence-set+ is a subset of +atom+ which is a subset of +astring+.
+      attr_accessor :atom
+
+      # Returns #atom.  In the IMAP grammar, +atom+ is a subset of +astring+.
+      alias astring atom
+
+      # Returns the value of #atom
+      alias to_s atom
+
+      # Hash equality requires the same encoded #atom representation.
+      #
+      #   Net::IMAP::SequenceSet["1:3"]  .eql? Net::IMAP::SequenceSet["1:3"]  # => true
+      #   Net::IMAP::SequenceSet["1,2,3"].eql? Net::IMAP::SequenceSet["1:3"]  # => false
+      #   Net::IMAP::SequenceSet["1,3"]  .eql? Net::IMAP::SequenceSet["3,1"]  # => false
+      #   Net::IMAP::SequenceSet["9,1:*"].eql? Net::IMAP::SequenceSet["1:*"]  # => false
+      #
+      def eql?(other) self.class == other.class && atom == other.atom end
+      alias == eql?
+
+      # See #eql?
+      def hash; [self.class. atom].hash end
+
+      def inspect
+        (frozen? ? "%s[%p]" : "#<%s %p>") % [self.class, to_s]
+      end
+
+      # Unstable API, for internal use only (Net::IMAP#validate_data)
+      def validate # :nodoc:
+        ResponseParser::Patterns::SEQUENCE_SET_STR.match?(@atom) or
+          raise ArgumentError, "invalid sequence-set: %p" % [input]
+        true
+      end
+
+      # Unstable API, for internal use only (Net::IMAP#send_data)
+      def send_data(imap, tag) # :nodoc:
+        imap.__send__(:put_string, atom)
+      end
+
+    end
+  end
+end

--- a/test/net/imap/fixtures/response_parser/status_responses.yml
+++ b/test/net/imap/fixtures/response_parser/status_responses.yml
@@ -37,3 +37,36 @@
           UIDNEXT: 1
           UIDVALIDITY: 1234
       raw_data: "* STATUS INBOX (UIDNEXT 1 UIDVALIDITY 1234) \r\n"
+
+  test_imaginary_status_response_using_tagged-ext-val:
+    :response: &test_imaginary_status_response_using_tagged_ext_val
+      "* STATUS mbox (num 1 seq 1234:5,*:789654 comp-empty ()
+      comp-quoted (\"quoted string\") comp-astring (nil) comp-multi (1 \"str\"
+      2:3,7:77 nil (nested (several (layers)))))\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: STATUS
+      data: !ruby/struct:Net::IMAP::StatusData
+        mailbox: mbox
+        attr:
+          NUM: 1
+          SEQ: !ruby/struct:Net::IMAP::ExtensionData
+            data: !ruby/object:Net::IMAP::SequenceSet
+              atom: 1234:5,*:789654
+          COMP-EMPTY: !ruby/struct:Net::IMAP::ExtensionData
+            data: []
+          COMP-QUOTED: !ruby/struct:Net::IMAP::ExtensionData
+            data:
+            - quoted string
+          COMP-ASTRING: !ruby/struct:Net::IMAP::ExtensionData
+            data:
+            - nil
+          COMP-MULTI: !ruby/struct:Net::IMAP::ExtensionData
+            data:
+            - 1
+            - str
+            - 2:3,7:77
+            - nil
+            - - nested
+              - - several
+                - - layers
+      raw_data: *test_imaginary_status_response_using_tagged_ext_val


### PR DESCRIPTION
Although "number" is still the default `status-att-val`, this uses
ExtensionData with RFC4466's `tagged_ext_val` for any unknown
non-numeric `STATUS` attribute.

Running the benchmarks (on my phone, without YJIT) shows a 40% speedup!

    invalid_status_response_trailing_space
          v0.4.4-16-g0be6b65b:     43956.1 i/s
                        0.4.4:     31788.6 i/s - 1.38x  slower

     rfc3501_7.2.4_STATUS_response_example
          v0.4.4-16-g0be6b65b:     45436.2 i/s
                        0.4.4:     32458.5 i/s - 1.40x  slower

       status_response_uidnext_uidvalidity
          v0.4.4-16-g0be6b65b:     45334.2 i/s
                        0.4.4:     32709.1 i/s - 1.39x  slower