### PR TITLE
📚 Update `#status` docs for `DELETED` (IMAP4rev2)

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -1692,13 +1692,14 @@ module Net
     # and returns the status of the indicated +mailbox+. +attr+ is a list of one
     # or more attributes whose statuses are to be requested.
     #
-    # The return value is a hash of attributes.
+    # The return value is a hash of attributes.  Most status attributes return
+    # integer values, but some return other value types (documented below).
     #
     # A Net::IMAP::NoResponseError is raised if status values
     # for +mailbox+ cannot be returned; for instance, because it
     # does not exist.
     #
-    # ===== Supported attributes:
+    # ===== Supported attributes
     #
     # +MESSAGES+::    The number of messages in the mailbox.
     #
@@ -1715,13 +1716,16 @@ module Net
     #     the sum of all messages' +RFC822.SIZE+ fetch item values.
     #
     # +MAILBOXID+::
-    #     A server-allocated unique identifier for the mailbox.
+    #     A server-allocated unique _string_ identifier for the mailbox.
     #     See +OBJECTID+
     #     {[RFC8474]}[https://www.rfc-editor.org/rfc/rfc8474.html#section-4].
     #
     # +RECENT+::
     #     The number of messages with the <tt>\Recent</tt> flag.
     #     _NOTE:_ +RECENT+ was removed from IMAP4rev2.
+    #
+    # Unsupported attributes may be requested.  The attribute value will be
+    # either an Integer or an ExtensionData object.
     #
     # ===== For example:
     #

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -1734,6 +1734,8 @@ module Net
     # <tt>STATUS=SIZE</tt>
     # {[RFC8483]}[https://www.rfc-editor.org/rfc/rfc8483.html].
     #
+    # +DELETED+ requires the server's capabilities to include +IMAP4rev2+.
+    #
     # +MAILBOXID+ requires the server's capabilities to include +OBJECTID+
     # {[RFC8474]}[https://www.rfc-editor.org/rfc/rfc8474.html].
     def status(mailbox, attr)


### PR DESCRIPTION
The `DELETED` status attribute was added by `IMAP4rev2`.