### PR TITLE
✨ Add support for the `CONDSTORE` extension (RFC7162)

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -505,6 +505,10 @@ module Net
   # ==== RFC7162: +CONDSTORE+
   #
   # - Updates #status with the +HIGHESTMODSEQ+ status attribute.
+  # - Updates #search, #uid_search, #sort, and #uid_sort with the +MODSEQ+
+  #   search criterion, and adds SearchResult#modseq to the search response.
+  # - Updates #thread and #uid_thread with the +MODSEQ+ search criterion
+  #   <em>(but thread responses are unchanged)</em>.
   #
   # ==== RFC8438: <tt>STATUS=SIZE</tt>
   # - Updates #status with the +SIZE+ status attribute.
@@ -1887,6 +1891,10 @@ module Net
     # string holding the entire search string, or a single-dimension array of
     # search keywords and arguments.
     #
+    # Returns a SearchResult object.  SearchResult inherits from Array (for
+    # backward compatibility) but adds SearchResult#modseq when the +CONDSTORE+
+    # capability has been enabled.
+    #
     # Related: #uid_search
     #
     # ===== Search criteria
@@ -1935,6 +1943,15 @@ module Net
     #   p imap.search(["SUBJECT", "hello", "NOT", "NEW"])
     #   #=> [1, 6, 7, 8]
     #
+    # ===== Capabilities
+    #
+    # If [CONDSTORE[https://www.rfc-editor.org/rfc/rfc7162.html]] is supported
+    # and enabled for the selected mailbox, a non-empty SearchResult will
+    # include a +MODSEQ+ value.
+    #   imap.select("mbox", condstore: true)
+    #   result = imap.search(["SUBJECT", "hi there", "not", "new")
+    #   #=> Net::IMAP::SearchResult[1, 6, 7, 8, modseq: 5594]
+    #   result.modseq # => 5594
     def search(keys, charset = nil)
       return search_internal("SEARCH", keys, charset)
     end
@@ -1942,6 +1959,10 @@ module Net
     # Sends a {UID SEARCH command [IMAP4rev1 §6.4.8]}[https://www.rfc-editor.org/rfc/rfc3501#section-6.4.8]
     # to search the mailbox for messages that match the given searching
     # criteria, and returns unique identifiers (<tt>UID</tt>s).
+    #
+    # Returns a SearchResult object.  SearchResult inherits from Array (for
+    # backward compatibility) but adds SearchResult#modseq when the +CONDSTORE+
+    # capability has been enabled.
     #
     # See #search for documentation of search criteria.
     def uid_search(keys, charset = nil)

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -502,6 +502,10 @@ module Net
   #
   # - See #enable for information about support for UTF-8 string encoding.
   #
+  # ==== RFC7162: +CONDSTORE+
+  #
+  # - Updates #status with the +HIGHESTMODSEQ+ status attribute.
+  #
   # ==== RFC8438: <tt>STATUS=SIZE</tt>
   # - Updates #status with the +SIZE+ status attribute.
   #
@@ -1689,7 +1693,7 @@ module Net
       end
     end
 
-    # Sends a {STATUS commands [IMAP4rev1 §6.3.10]}[https://www.rfc-editor.org/rfc/rfc3501#section-6.3.10]
+    # Sends a {STATUS command [IMAP4rev1 §6.3.10]}[https://www.rfc-editor.org/rfc/rfc3501#section-6.3.10]
     # and returns the status of the indicated +mailbox+. +attr+ is a list of one
     # or more attributes whose statuses are to be requested.
     #
@@ -1716,10 +1720,13 @@ module Net
     #     The approximate size of the mailbox---must be greater than or equal to
     #     the sum of all messages' +RFC822.SIZE+ fetch item values.
     #
+    # +HIGHESTMODSEQ+::
+    #    The highest mod-sequence value of all messages in the mailbox.  See
+    #    +CONDSTORE+ {[RFC7162]}[https://www.rfc-editor.org/rfc/rfc7162.html].
+    #
     # +MAILBOXID+::
-    #     A server-allocated unique _string_ identifier for the mailbox.
-    #     See +OBJECTID+
-    #     {[RFC8474]}[https://www.rfc-editor.org/rfc/rfc8474.html#section-4].
+    #     A server-allocated unique _string_ identifier for the mailbox.  See
+    #     +OBJECTID+ {[RFC8474]}[https://www.rfc-editor.org/rfc/rfc8474.html].
     #
     # +RECENT+::
     #     The number of messages with the <tt>\Recent</tt> flag.
@@ -1740,6 +1747,9 @@ module Net
     # {[RFC8483]}[https://www.rfc-editor.org/rfc/rfc8483.html].
     #
     # +DELETED+ requires the server's capabilities to include +IMAP4rev2+.
+    #
+    # +HIGHESTMODSEQ+ requires the server's capabilities to include +CONDSTORE+
+    # {[RFC7162]}[https://www.rfc-editor.org/rfc/rfc7162.html].
     #
     # +MAILBOXID+ requires the server's capabilities to include +OBJECTID+
     # {[RFC8474]}[https://www.rfc-editor.org/rfc/rfc8474.html].

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -504,6 +504,8 @@ module Net
   #
   # ==== RFC7162: +CONDSTORE+
   #
+  # - Updates #enable with +CONDSTORE+ parameter.  +CONDSTORE+ will also be
+  #   enabled by using any of the extension's command parameters, listed below.
   # - Updates #status with the +HIGHESTMODSEQ+ status attribute.
   # - Updates #select and #examine with the +condstore+ modifier, and adds
   #   either a +HIGHESTMODSEQ+ or +NOMODSEQ+ ResponseCode to the responses.
@@ -683,6 +685,16 @@ module Net
   #   Resnick, P., Ed., Newman, C., Ed., and S. Shen, Ed.,
   #   "IMAP Support for UTF-8", RFC 6855, DOI 10.17487/RFC6855, March 2013,
   #   <https://www.rfc-editor.org/info/rfc6855>.
+  # [CONDSTORE[https://tools.ietf.org/html/rfc7162]]::
+  # [QRESYNC[https://tools.ietf.org/html/rfc7162]]::
+  #   Melnikov, A. and D. Cridland, "IMAP Extensions: Quick Flag Changes
+  #   Resynchronization (CONDSTORE) and Quick Mailbox Resynchronization
+  #   (QRESYNC)", RFC 7162, DOI 10.17487/RFC7162, May 2014,
+  #   <https://www.rfc-editor.org/info/rfc7162>.
+  # [OBJECTID[https://tools.ietf.org/html/rfc8474]]::
+  #   Gondwana, B., Ed., "IMAP Extension for Object Identifiers",
+  #   RFC 8474, DOI 10.17487/RFC8474, September 2018,
+  #   <https://www.rfc-editor.org/info/rfc8474>.
   #
   # === IANA registries
   # * {IMAP Capabilities}[http://www.iana.org/assignments/imap4-capabilities]
@@ -2305,6 +2317,13 @@ module Net
     # Additionally, the server capabilities must include a capability matching
     # each enabled extension (usually the same name as the enabled extension).
     # The following capabilities may be enabled:
+    #
+    # [+CONDSTORE+ {[RFC7162]}[https://www.rfc-editor.org/rfc/rfc7162.html]]
+    #
+    #   Updates various commands to return +CONDSTORE+ extension responses.  It
+    #   is not necessary to explicitly enable +CONDSTORE+—using any of the
+    #   command parameters defined by the extension will implicitly enable it.
+    #   See {[RFC7162 §3.1]}[https://www.rfc-editor.org/rfc/rfc7162.html#section-3.1].
     #
     # [+:utf8+ --- an alias for <tt>"UTF8=ACCEPT"</tt>]
     #

--- a/lib/net/imap/response_data.rb
+++ b/lib/net/imap/response_data.rb
@@ -292,6 +292,16 @@ module Net
     #   because the server doesn't allow deletion of mailboxes with children.
     #   #data is +nil+.
     #
+    # ==== +CONDSTORE+ extension
+    # See {[RFC7162]}[https://www.rfc-editor.org/rfc/rfc7162.html].
+    # * +NOMODSEQ+, when selecting a mailbox that does not support
+    #   mod-sequences.  #data is +nil+.  See IMAP#select.
+    # * +HIGHESTMODSEQ+, #data is an Integer, the highest mod-sequence value of
+    #   all messages in the mailbox.  See IMAP#select.
+    # * +MODIFIED+, #data is a SequenceSet, the messages that have been modified
+    #   since the +UNCHANGEDSINCE+ mod-sequence given to +STORE+ or <tt>UID
+    #   STORE</tt>.
+    #
     # ==== +OBJECTID+ extension
     # See {[RFC8474]}[https://www.rfc-editor.org/rfc/rfc8474.html].
     # * +MAILBOXID+, #data is a string

--- a/lib/net/imap/response_data.rb
+++ b/lib/net/imap/response_data.rb
@@ -3,6 +3,7 @@
 module Net
   class IMAP < Protocol
     autoload :FetchData,        "#{__dir__}/fetch_data"
+    autoload :SearchResult,     "#{__dir__}/search_result"
     autoload :SequenceSet,      "#{__dir__}/sequence_set"
 
     # Net::IMAP::ContinuationRequest represents command continuation requests.

--- a/lib/net/imap/response_parser.rb
+++ b/lib/net/imap/response_parser.rb
@@ -1802,6 +1802,8 @@ module Net
       #   resp-text-code   =/ "HIGHESTMODSEQ" SP mod-sequence-value /
       #                       "NOMODSEQ" /
       #                       "MODIFIED" SP sequence-set
+      # RFC7162 (QRESYNC):
+      #   resp-text-code   =/ "CLOSED"
       #
       # RFC8474: OBJECTID
       #   resp-text-code   =/ "MAILBOXID" SP "(" objectid ")"
@@ -1823,7 +1825,9 @@ module Net
             "EXPUNGEISSUED", "CORRUPTION", "SERVERBUG", "CLIENTBUG", "CANNOT",
             "LIMIT", "OVERQUOTA", "ALREADYEXISTS", "NONEXISTENT", "CLOSED",
             "NOTSAVED", "UIDNOTSTICKY", "UNKNOWN-CTE", "HASCHILDREN"
-          when "NOMODSEQ"           # CONDSTORE
+          when "NOMODSEQ"           then nil                       # CONDSTORE
+          when "HIGHESTMODSEQ"      then SP!; mod_sequence_value   # CONDSTORE
+          when "MODIFIED"           then SP!; sequence_set         # CONDSTORE
           when "MAILBOXID"          then SP!; parens__objectid     # RFC8474: OBJECTID
           else
             SP? and text_chars_except_rbra

--- a/lib/net/imap/response_parser.rb
+++ b/lib/net/imap/response_parser.rb
@@ -1467,9 +1467,10 @@ module Net
         while _ = SP? && nz_number? do data << _ end
         if lpar?
           label("MODSEQ"); SP!
-          mod_sequence_value
+          modseq = mod_sequence_value
           rpar
         end
+        data = SearchResult.new(data, modseq: modseq)
         UntaggedResponse.new(name, data, @str)
       end
       alias sort_data mailbox_data__search

--- a/lib/net/imap/response_parser.rb
+++ b/lib/net/imap/response_parser.rb
@@ -1594,6 +1594,7 @@ module Net
           when "UIDVALIDITY"   then nz_number           # RFC3501, RFC9051
           when "RECENT"        then number              # RFC3501 (obsolete)
           when "SIZE"          then number64            # RFC8483, RFC9051
+          when "HIGHESTMODSEQ" then mod_sequence_valzer # RFC7162
           when "MAILBOXID"     then parens__objectid    # RFC8474
           else
             number? || ExtensionData.new(tagged_ext_val)
@@ -1965,6 +1966,10 @@ module Net
       # permsg-modsequence  = mod-sequence-value
       #                        ;; Per-message mod-sequence.
       alias permsg_modsequence mod_sequence_value
+
+      # RFC7162:
+      # mod-sequence-valzer = "0" / mod-sequence-value
+      alias mod_sequence_valzer number64
 
       def parens__modseq; lpar; _ = permsg_modsequence; rpar; _ end
 

--- a/lib/net/imap/search_result.rb
+++ b/lib/net/imap/search_result.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+module Net
+  class IMAP
+
+    # An array of sequence numbers returned by Net::IMAP#search, or unique
+    # identifiers returned by Net::IMAP#uid_search.
+    #
+    # For backward compatibility, SearchResult inherits from Array.
+    class SearchResult < Array
+
+      # Returns a frozen SearchResult populated with the given +seq_nums+.
+      #
+      #     Net::IMAP::SearchResult[1, 3, 5, modseq: 9]
+      #     # => Net::IMAP::SearchResult[1, 3, 5, modseq: 9]
+      def self.[](*seq_nums, modseq: nil)
+        new(seq_nums, modseq: modseq)
+      end
+
+      # A modification sequence number, as described by the +CONDSTORE+
+      # extension in {[RFC7162
+      # §3.1.6]}[https://www.rfc-editor.org/rfc/rfc7162.html#section-3.1.6].
+      attr_reader :modseq
+
+      # Returns a frozen SearchResult populated with the given +seq_nums+.
+      #
+      #     Net::IMAP::SearchResult.new([1, 3, 5], modseq: 9)
+      #     # => Net::IMAP::SearchResult[1, 3, 5, modseq: 9]
+      def initialize(seq_nums, modseq: nil)
+        super(seq_nums.to_ary.map { Integer _1 })
+        @modseq = Integer modseq if modseq
+        freeze
+      end
+
+      # Returns a frozen copy of +other+.
+      def initialize_copy(other); super; freeze end
+
+      # Returns whether +other+ is a SearchResult with the same values and the
+      # same #modseq.  The order of numbers is irrelevant.
+      #
+      #     Net::IMAP::SearchResult[123, 456, modseq: 789] ==
+      #       Net::IMAP::SearchResult[123, 456, modseq: 789]
+      #     # => true
+      #     Net::IMAP::SearchResult[123, 456, modseq: 789] ==
+      #       Net::IMAP::SearchResult[456, 123, modseq: 789]
+      #     # => true
+      #
+      #     Net::IMAP::SearchResult[123, 456, modseq: 789] ==
+      #       Net::IMAP::SearchResult[987, 654, modseq: 789]
+      #     # => false
+      #     Net::IMAP::SearchResult[123, 456, modseq: 789] ==
+      #       Net::IMAP::SearchResult[1, 2, 3, modseq: 9999]
+      #     # => false
+      #
+      # SearchResult can be compared directly with Array, if #modseq is nil and
+      # the array is sorted.
+      #
+      #     Net::IMAP::SearchResult[9, 8, 6, 4, 1] == [1, 4, 6, 8, 9] # => true
+      #     Net::IMAP::SearchResult[3, 5, 7, modseq: 99] == [3, 5, 7] # => false
+      #
+      # Note that Array#== does require matching order and ignores #modseq.
+      #
+      #     [9, 8, 6, 4, 1] == Net::IMAP::SearchResult[1, 4, 6, 8, 9] # => false
+      #     [3, 5, 7] == Net::IMAP::SearchResult[3, 5, 7, modseq: 99] # => true
+      #
+      def ==(other)
+        (modseq ?
+         other.is_a?(self.class) && modseq == other.modseq :
+         other.is_a?(Array)) &&
+          size == other.size &&
+          sort == other.sort
+      end
+
+      # Hash equality.  Unlike #==, order will be taken into account.
+      def hash
+        return super if modseq.nil?
+        [super, self.class, modseq].hash
+      end
+
+      # Hash equality.  Unlike #==, order will be taken into account.
+      def eql?(other)
+        return super if modseq.nil?
+        self.class == other.class && hash == other.hash
+      end
+
+      # Returns a string that represents the SearchResult.
+      #
+      #    Net::IMAP::SearchResult[123, 456, 789].inspect
+      #    # => "[123, 456, 789]"
+      #
+      #    Net::IMAP::SearchResult[543, 210, 678, modseq: 2048].inspect
+      #    # => "Net::IMAP::SearchResult[543, 210, 678, modseq: 2048]"
+      #
+      def inspect
+        return super if modseq.nil?
+        "%s[%s, modseq: %p]" % [self.class, join(", "), modseq]
+      end
+
+      # Returns a string that follows the formal \IMAP syntax.
+      #
+      #    data = Net::IMAP::SearchResult[2, 8, 32, 128, 256, 512]
+      #    data.to_s           # => "* SEARCH 2 8 32 128 256 512"
+      #    data.to_s("SEARCH") # => "* SEARCH 2 8 32 128 256 512"
+      #    data.to_s("SORT")   # => "* SORT 2 8 32 128 256 512"
+      #    data.to_s(nil)      # => "2 8 32 128 256 512"
+      #
+      #    data = Net::IMAP::SearchResult[1, 3, 16, 1024, modseq: 2048].to_s
+      #    data.to_s           # => "* SEARCH 1 3 16 1024 (MODSEQ 2048)"
+      #    data.to_s("SORT")   # => "* SORT 1 3 16 1024 (MODSEQ 2048)"
+      #    data.to_s           # => "1 3 16 1024 (MODSEQ 2048)"
+      #
+      def to_s(type = "SEARCH")
+        str = +""
+        str << "* %s " % [type.to_str] unless type.nil?
+        str << join(" ")
+        str << " (MODSEQ %d)" % [modseq] if modseq
+        -str
+      end
+
+      # Converts the SearchResult into a SequenceSet.
+      #
+      #     Net::IMAP::SearchResult[9, 1, 2, 4, 10, 12, 3, modseq: 123_456]
+      #       .to_sequence_set
+      #     # => Net::IMAP::SequenceSet["1:4,9:10,12"]
+      def to_sequence_set; SequenceSet[*self] end
+
+      def pretty_print(pp)
+        return super if modseq.nil?
+        pp.text self.class.name + "["
+        pp.group_sub do
+          pp.nest(2) do
+            pp.breakable ""
+            each do |num|
+              pp.pp num
+              pp.text ","
+              pp.fill_breakable
+            end
+            pp.breakable ""
+            pp.text "modseq: "
+            pp.pp modseq
+          end
+          pp.breakable ""
+          pp.text "]"
+        end
+      end
+
+    end
+
+  end
+end

--- a/test/net/imap/fake_server/command_reader.rb
+++ b/test/net/imap/fake_server/command_reader.rb
@@ -33,7 +33,7 @@ class Net::IMAP::FakeServer
       /\A([^ ]+) ((?:UID )?\w+)(?: (.+))?\r\n\z/min =~ buf or
         raise "bad request: %p" [buf]
       case $2.upcase
-      when "LOGIN", "SELECT", "ENABLE", "AUTHENTICATE"
+      when "LOGIN", "SELECT", "EXAMINE", "ENABLE", "AUTHENTICATE"
         Command.new $1, $2, scan_astrings($3), buf
       else
         Command.new $1, $2, $3, buf # TODO...

--- a/test/net/imap/fixtures/response_parser/rfc7162_condstore_qresync_responses.yml
+++ b/test/net/imap/fixtures/response_parser/rfc7162_condstore_qresync_responses.yml
@@ -1,0 +1,119 @@
+---
+:tests:
+
+  "RFC7162 CONDSTORE 3.1.2.1. HIGHESTMODSEQ Response Code":
+    :response: "* OK [HIGHESTMODSEQ 715194045007]\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: OK
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: HIGHESTMODSEQ
+          data: 715194045007
+        text: ''
+      raw_data: "* OK [HIGHESTMODSEQ 715194045007]\r\n"
+
+  "RFC7162 CONDSTORE 3.1.2.2. NOMODSEQ Response Code":
+    :response: "* OK [NOMODSEQ] Sorry, this mailbox format doesn't support
+      modsequences\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: OK
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: NOMODSEQ
+          data:
+        text: Sorry, this mailbox format doesn't support modsequences
+      raw_data: "* OK [NOMODSEQ] Sorry, this mailbox format doesn't support
+        modsequences\r\n"
+
+  "RFC7162 CONDSTORE 3.1.3. Example 3 (FETCH MODSEQ)":
+    :response: "* 4 FETCH (UID 8 MODSEQ (12121230956))\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: FETCH
+      data: !ruby/struct:Net::IMAP::FetchData
+        seqno: 4
+        attr:
+          UID: 8
+          MODSEQ: 12121230956
+      raw_data: "* 4 FETCH (UID 8 MODSEQ (12121230956))\r\n"
+
+  "RFC7162 CONDSTORE 3.1.3. Example 4 (FETCH MODSEQ)":
+    :response: "* 50 FETCH (MODSEQ (12111230048))\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: FETCH
+      data: !ruby/struct:Net::IMAP::FetchData
+        seqno: 50
+        attr:
+          MODSEQ: 12111230048
+      raw_data: "* 50 FETCH (MODSEQ (12111230048))\r\n"
+
+  "RFC7162 CONDSTORE 3.1.3. Example 6 (MODIFIED Response Code)":
+    :response: "d105 OK [MODIFIED 7,9] Conditional STORE failed\r\n"
+    :expected: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: d105
+      name: OK
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: MODIFIED
+          data: !ruby/object:Net::IMAP::SequenceSet
+            str: '7,9'
+            tuples:
+            - - 7
+              - 7
+            - - 9
+              - 9
+        text: Conditional STORE failed
+      raw_data: "d105 OK [MODIFIED 7,9] Conditional STORE failed\r\n"
+
+  "RFC7162 CONDSTORE 3.1.5. MODSEQ Search Criterion in SEARCH":
+    :response: "* SEARCH 2 5 6 7 11 12 18 19 20 23 (MODSEQ 917162500)\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: SEARCH
+      data: !ruby/array:Net::IMAP::SearchResult
+        internal:
+        - 2
+        - 5
+        - 6
+        - 7
+        - 11
+        - 12
+        - 18
+        - 19
+        - 20
+        - 23
+        ivars:
+          :@modseq: 917162500
+      raw_data: "* SEARCH 2 5 6 7 11 12 18 19 20 23 (MODSEQ 917162500)\r\n"
+
+  "RFC7162 CONDSTORE 3.1.7. HIGHESTMODSEQ Status Data Items":
+    :response: "* STATUS blurdybloop (MESSAGES 231 UIDNEXT 44292 HIGHESTMODSEQ
+      7011231777)\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: STATUS
+      data: !ruby/struct:Net::IMAP::StatusData
+        mailbox: blurdybloop
+        attr:
+          MESSAGES: 231
+          UIDNEXT: 44292
+          HIGHESTMODSEQ: 7011231777
+      raw_data: "* STATUS blurdybloop (MESSAGES 231 UIDNEXT 44292 HIGHESTMODSEQ
+        7011231777)\r\n"
+
+  "RFC7162 QRESYNC 3.2.5.1. Modification Sequence and UID Parameters":
+    :response: "* VANISHED (EARLIER) 41,43:116,118,120:211,214:540\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: VANISHED
+      data: !ruby/struct:Net::IMAP::UnparsedData
+        unparsed_data: "(EARLIER) 41,43:116,118,120:211,214:540"
+      raw_data: "* VANISHED (EARLIER) 41,43:116,118,120:211,214:540\r\n"
+    comment: |
+      Note that QRESYNC isn't supported yet, so the data is unparsed.
+
+  "RFC7162 QRESYNC 3.2.7. EXPUNGE Command":
+    :response: "* VANISHED 405,407,410,425\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: VANISHED
+      data: !ruby/struct:Net::IMAP::UnparsedData
+        unparsed_data: '405,407,410,425'
+      raw_data: "* VANISHED 405,407,410,425\r\n"
+    comment: |
+      Note that QRESYNC isn't supported yet, so the data is unparsed.

--- a/test/net/imap/fixtures/response_parser/search_responses.yml
+++ b/test/net/imap/fixtures/response_parser/search_responses.yml
@@ -17,35 +17,34 @@
     :response: "* SEARCH\r\n"
     :expected: !ruby/struct:Net::IMAP::UntaggedResponse
       name: SEARCH
-      data: []
-      # data: !ruby/array:Net::IMAP::SearchResult
-      #   internal: []
-      #   ivars:
-      #     "@modseq":
+      data: !ruby/array:Net::IMAP::SearchResult
+        internal: []
+        ivars:
+          "@modseq":
       raw_data: "* SEARCH\r\n"
 
   test_search_response_single_seq_nums_returned:
     :response: "* SEARCH 1\r\n"
     :expected: !ruby/struct:Net::IMAP::UntaggedResponse
       name: SEARCH
-      data: # !ruby/array:Net::IMAP::SearchResult
-      #   internal:
+      data: !ruby/array:Net::IMAP::SearchResult
+        internal:
         - 1
-      #   ivars:
-      #     "@modseq":
+        ivars:
+          "@modseq":
       raw_data: "* SEARCH 1\r\n"
 
   test_search_response_multiple_seq_nums_returned:
     :response: "* SEARCH 1 2 3\r\n"
     :expected: !ruby/struct:Net::IMAP::UntaggedResponse
       name: SEARCH
-      data: # !ruby/array:Net::IMAP::SearchResult
-        # internal:
+      data: !ruby/array:Net::IMAP::SearchResult
+        internal:
         - 1
         - 2
         - 3
-        # ivars:
-          # "@modseq":
+        ivars:
+          "@modseq":
       raw_data: "* SEARCH 1 2 3\r\n"
 
   test_invalid_search_response_single_result_with_trailing_space:
@@ -53,11 +52,11 @@
     :response: "* SEARCH 1 \r\n"
     :expected: !ruby/struct:Net::IMAP::UntaggedResponse
       name: SEARCH
-      data: # !ruby/array:Net::IMAP::SearchResult
-        # internal:
+      data: !ruby/array:Net::IMAP::SearchResult
+        internal:
         - 1
-        # ivars:
-          # "@modseq":
+        ivars:
+          "@modseq":
       raw_data: "* SEARCH 1 \r\n"
 
   test_invalid_search_response_multiple_result_with_trailing_space:
@@ -65,13 +64,13 @@
     :response: "* SEARCH 1 2 3 \r\n"
     :expected: !ruby/struct:Net::IMAP::UntaggedResponse
       name: SEARCH
-      data: # !ruby/array:Net::IMAP::SearchResult
-        # internal:
+      data: !ruby/array:Net::IMAP::SearchResult
+        internal:
         - 1
         - 2
         - 3
-        # ivars:
-          # "@modseq":
+        ivars:
+          "@modseq":
       raw_data: "* SEARCH 1 2 3 \r\n"
 
   test_search_response_with_condstore_modseq:
@@ -80,10 +79,10 @@
     :response: "* SEARCH 87216 87221 (MODSEQ 7667567)\r\n"
     :expected: !ruby/struct:Net::IMAP::UntaggedResponse
       name: SEARCH
-      data: # !ruby/array:Net::IMAP::SearchResult
-        # internal:
+      data: !ruby/array:Net::IMAP::SearchResult
+        internal:
         - 87216
         - 87221
-        # ivars:
-          # "@modseq": 7667567
+        ivars:
+          "@modseq": 7667567
       raw_data: "* SEARCH 87216 87221 (MODSEQ 7667567)\r\n"

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -1151,6 +1151,24 @@ EOF
     end
   end
 
+  test "#fetch with changedsince" do
+    with_fake_server select: "inbox" do |server, imap|
+      server.on("FETCH", &:done_ok)
+      imap.fetch 1..-1, %w[FLAGS], changedsince: 12345
+      assert_equal("RUBY0002 FETCH 1:* (FLAGS) (CHANGEDSINCE 12345)",
+                   server.commands.pop.raw.strip)
+    end
+  end
+
+  test "#uid_fetch with changedsince" do
+    with_fake_server select: "inbox" do |server, imap|
+      server.on("UID FETCH", &:done_ok)
+      imap.uid_fetch 1..-1, %w[FLAGS], changedsince: 12345
+      assert_equal("RUBY0002 UID FETCH 1:* (FLAGS) (CHANGEDSINCE 12345)",
+                   server.commands.pop.raw.strip)
+    end
+  end
+
   def test_close
     with_fake_server(select: "inbox") do |server, imap|
       resp = imap.close

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -1135,6 +1135,22 @@ EOF
     end
   end
 
+  test "#select with condstore" do
+    with_fake_server do |server, imap|
+      imap.select "inbox", condstore: true
+      assert_equal("RUBY0001 SELECT inbox (CONDSTORE)",
+                   server.commands.pop.raw.strip)
+    end
+  end
+
+  test "#examine with condstore" do
+    with_fake_server do |server, imap|
+      imap.examine "inbox", condstore: true
+      assert_equal("RUBY0001 EXAMINE inbox (CONDSTORE)",
+                   server.commands.pop.raw.strip)
+    end
+  end
+
   def test_close
     with_fake_server(select: "inbox") do |server, imap|
       resp = imap.close

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -1169,6 +1169,28 @@ EOF
     end
   end
 
+  test "#store with unchangedsince" do
+    with_fake_server select: "inbox" do |server, imap|
+      server.on("STORE", &:done_ok)
+      imap.store 1..-1, "FLAGS", %i[Deleted], unchangedsince: 12345
+      assert_equal(
+        "RUBY0002 STORE 1:* (UNCHANGEDSINCE 12345) FLAGS (\\Deleted)",
+        server.commands.pop.raw.strip
+      )
+    end
+  end
+
+  test "#uid_store with changedsince" do
+    with_fake_server select: "inbox" do |server, imap|
+      server.on("UID STORE", &:done_ok)
+      imap.uid_store 1..-1, "FLAGS", %i[Deleted], unchangedsince: 987
+      assert_equal(
+        "RUBY0002 UID STORE 1:* (UNCHANGEDSINCE 987) FLAGS (\\Deleted)",
+        server.commands.pop.raw.strip
+      )
+    end
+  end
+
   def test_close
     with_fake_server(select: "inbox") do |server, imap|
       resp = imap.close

--- a/test/net/imap/test_imap_response_parser.rb
+++ b/test/net/imap/test_imap_response_parser.rb
@@ -90,6 +90,9 @@ class IMAPResponseParserTest < Test::Unit::TestCase
   # RFC 5256: THREAD response
   generate_tests_from fixture_file: "thread_responses.yml"
 
+  # RFC 7164: CONDSTORE and QRESYNC responses
+  generate_tests_from fixture_file: "rfc7162_condstore_qresync_responses.yml"
+
   # RFC 8474: OBJECTID responses
   generate_tests_from fixture_file: "rfc8474_objectid_responses.yml"
 

--- a/test/net/imap/test_search_result.rb
+++ b/test/net/imap/test_search_result.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "net/imap"
+require "test/unit"
+
+class SearchDataTests < Test::Unit::TestCase
+  SearchResult = Net::IMAP::SearchResult
+
+  test "#frozen?" do
+    assert SearchResult.new([1, 3, 5]).frozen?
+    assert SearchResult[1, 3, 5].frozen?
+    assert SearchResult[1, 3, 5, modseq: 9].frozen?
+    assert SearchResult[1, 3, 5, modseq: 9].clone.frozen?
+    assert SearchResult[1, 3, 5, modseq: 9].dup.dup.frozen?
+  end
+
+  test "#modseq" do
+    assert_nil SearchResult[12, 34].modseq
+    assert_equal 123_456_789, SearchResult[12, 34, modseq: 123_456_789].modseq
+  end
+
+  test "#== ignores the order of elements" do
+    unsorted = SearchResult[4, 2, 2048, 99]
+    sorted   = SearchResult[2, 4, 99, 2048]
+    array    = [2, 4, 99, 2048]
+    assert_equal sorted, array
+    assert_equal unsorted, array
+  end
+
+  test "#== checks modseq" do
+    unsorted = SearchResult[4, 2, 2048, 99, modseq: 99_999]
+    sorted   = SearchResult[2, 4, 99, 2048, modseq: 99_999]
+    assert_equal unsorted, sorted
+    assert_equal sorted, unsorted
+  end
+
+  test "SearchResult[*nz_numbers] == Array[*nz_numbers]" do
+    array  = [1, 5, 20, 3, 98]
+    result = SearchResult[*array]
+    assert_equal array, result
+    assert_equal result, array
+  end
+
+  test "SearchResult.new(nz_numbers) == Array.new(nz_numbers)" do
+    nz_numbers = [11, 35, 39, 1083, 958]
+    result = SearchResult.new(nz_numbers)
+    array  = Array.new(nz_numbers)
+    assert_equal array, result
+    assert_equal result, array
+  end
+
+  test "SearchResult[*nz_numbers, modseq: nz_number] != Array[*nz_numbers]" do
+    array  = [1, 5, 20, 3, 98]
+    result = SearchResult[*array, modseq: 123456]
+    refute_equal result, array
+  end
+
+  test "Array[*nz_numbers] == SearchResult[*nz_numbers, modseq: nz_number]" do
+    array  = [1, 5, 20, 3, 98]
+    result = SearchResult[*array, modseq: 123456]
+    assert_equal array, result
+  end
+
+  test "SearchResult[*nz_numbers] == Array[*differently_sorted]" do
+    array  = [1, 5, 20, 3, 98]
+    result = SearchResult[*array.reverse]
+    assert_equal result, array
+  end
+
+  test "Array[*nz_numbers] != SearchResult[*differently_sorted]" do
+    array  = [1, 5, 20, 3, 98]
+    result = SearchResult[*array.reverse]
+    refute_equal array, result
+  end
+
+  test "#inspect" do
+    assert_equal "[1, 2, 3]", Net::IMAP::SearchResult[1, 2, 3].inspect
+    assert_equal("Net::IMAP::SearchResult[1, 3, modseq: 9]",
+                 Net::IMAP::SearchResult[1, 3, modseq: 9].inspect)
+  end
+
+  test "#to_s" do
+    assert_equal "* SEARCH 1 2 3", Net::IMAP::SearchResult[1, 2, 3].to_s
+    assert_equal("* SEARCH 3 2 1 (MODSEQ 9)",
+                 Net::IMAP::SearchResult[3, 2, 1, modseq: 9].to_s)
+  end
+
+  test "#to_s(type)" do
+    assert_equal "* SEARCH 1 3", Net::IMAP::SearchResult[1, 3].to_s("SEARCH")
+    assert_equal "* SORT 1 2 3", Net::IMAP::SearchResult[1, 2, 3].to_s("SORT")
+    assert_equal("* SORT 99 111 44 (MODSEQ 999)",
+                 Net::IMAP::SearchResult[99, 111, 44, modseq: 999].to_s("SORT"))
+    assert_equal("99 111 44 (MODSEQ 999)",
+                 Net::IMAP::SearchResult[99, 111, 44, modseq: 999].to_s(nil))
+  end
+end


### PR DESCRIPTION
_NOTE:_ Both `#search` and `#uid_search` have been updated to return `SearchResult` rather than `Array`.  `SearchResult` inherits from `Array`, for backward compatibility.

Similarly, the `MODIFIED` response code on the tagged response to `#store` and `#uid_store` is currently only accessible by using a response handler: response code data on tagged responses isn't saved to `#responses`.  _Unlike_ with the search methods returning `SearchResult`, I did _not_ change the behavior of `#store` to return a new result object inheriting from Array.  IMO, that change would require a backward compatibility config option and a deprecation period.

* Fixes #106
* [x] Document `IMAP extension support` in `Net::IMAP` class rdoc
* [x] New response codes (`HIGHESTMODSEQ`, `NOMODSEQ`, `MODIFIED`)
  * [x] Parse (and test parser)
  * [x] Document in `ResponseCode`
  * [x] Update `#select` and `#examine` documentation (`NOMODSEQ`, `HIGHESTMODSEQ`)
  * [x] Update `#store` and `#uid_store` documentation (`MODIFIED`)
    * [x] Add `SequenceSet` class
      * [x] basic version was added for #225
      * [x] #239 
* [x] Updated `FETCH` response with `MODSEQ`.
  * [x] Parse _(Done by @shugo in 2017, by 398a64ef.)_
  * [x] Document in `FetchData` _(Done by #220.)_
* [x] Updates `SEARCH` untagged response
  * [x] Parse `* SEARCH 1 2 3 (MODSEQ 123)`  _(Done by @shugo in 2014, by 4bad059c.)_
  * [x] Add `SearchResult` and `SearchResult#modseq`.
  * [x] Document `SearchResult` (including on `#search` and `#uid_search`)
  * [x] Basic test coverage over SearchResult code
* [x] New `HIGHESTMODSEQ` status attribute
  * [x] Parse (and test parser)
  * [x] Document in `#status`
* [x] Keyword args (and test client method calls)
  * [x] #122
  * [x] #132
        _(Note: `CHANGEDSINCE` can be used already, via an undocumented non-keyword argument.)_
  * [x] #237
