### PR TITLE
🐛 Fix broken `QUOTA`/`QUOTAROOT` response parsing

### DIFF
--- a/lib/net/imap/response_parser.rb
+++ b/lib/net/imap/response_parser.rb
@@ -1370,7 +1370,7 @@ module Net
         MailboxList.new(attr, delim, name)
       end
 
-      def getquota_response
+      def quota_response
         # If quota never established, get back
         # `NO Quota root does not exist'.
         # If quota removed, get `()' after the
@@ -1403,7 +1403,7 @@ module Net
         end
       end
 
-      def getquotaroot_response
+      def quotaroot_response
         # Similar to getquota, but only admin can use getquota.
         token = match(T_ATOM)
         name = token.value.upcase

--- a/test/net/imap/fixtures/response_parser/rfc9208_quota_responses.yml
+++ b/test/net/imap/fixtures/response_parser/rfc9208_quota_responses.yml
@@ -1,0 +1,100 @@
+---
+:tests:
+
+  rfc9208_4.1.1_example:
+    :response: "* QUOTA \"!partition/sda4\" (STORAGE 104 10923847)\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: QUOTA
+      data: !ruby/struct:Net::IMAP::MailboxQuota
+        mailbox: "!partition/sda4"
+        usage: '104'
+        quota: '10923847'
+      raw_data: "* QUOTA \"!partition/sda4\" (STORAGE 104 10923847)\r\n"
+
+  rfc9208_4.1.2_example_1:
+    :response: "* QUOTAROOT INBOX \"#user/alice\" \"!partition/sda4\"\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: QUOTAROOT
+      data: !ruby/struct:Net::IMAP::MailboxQuotaRoot
+        mailbox: INBOX
+        quotaroots:
+        - "#user/alice"
+        - "!partition/sda4"
+      raw_data: "* QUOTAROOT INBOX \"#user/alice\" \"!partition/sda4\"\r\n"
+
+  rfc9208_4.1.2_example_2:
+    :response: "* QUOTA \"#user/alice\" (MESSAGE 42 1000)\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: QUOTA
+      data: !ruby/struct:Net::IMAP::MailboxQuota
+        mailbox: "#user/alice"
+        usage: '42'
+        quota: '1000'
+      raw_data: "* QUOTA \"#user/alice\" (MESSAGE 42 1000)\r\n"
+
+  # rfc9208_4.1.3_example_1:
+  #   :response: "* QUOTA \"#user/alice\" (STORAGE 54 111 MESSAGE 42 1000)\r\n"
+
+  rfc9208_4.1.4_example:
+    :response: "* STATUS INBOX (MESSAGES 12 DELETED 4 DELETED-STORAGE 8)\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: STATUS
+      data: !ruby/struct:Net::IMAP::StatusData
+        mailbox: INBOX
+        attr:
+          MESSAGES: 12
+          DELETED: 4
+          DELETED-STORAGE: 8
+      raw_data: "* STATUS INBOX (MESSAGES 12 DELETED 4 DELETED-STORAGE 8)\r\n"
+
+  rfc9208_4.2.1_example:
+    :response: "* QUOTA \"\" (STORAGE 10 512)\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: QUOTA
+      data: !ruby/struct:Net::IMAP::MailboxQuota
+        mailbox: ''
+        usage: '10'
+        quota: '512'
+      raw_data: "* QUOTA \"\" (STORAGE 10 512)\r\n"
+
+  rfc9208_4.2.2_example_1:
+    :response: "* QUOTAROOT INBOX \"\"\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: QUOTAROOT
+      data: !ruby/struct:Net::IMAP::MailboxQuotaRoot
+        mailbox: INBOX
+        quotaroots:
+        - ''
+      raw_data: "* QUOTAROOT INBOX \"\"\r\n"
+
+  rfc9208_4.2.2_example_2:
+    :response: "* QUOTAROOT comp.mail.mime\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: QUOTAROOT
+      data: !ruby/struct:Net::IMAP::MailboxQuotaRoot
+        mailbox: comp.mail.mime
+        quotaroots: []
+      raw_data: "* QUOTAROOT comp.mail.mime\r\n"
+
+  rfc9208_4.3.1_example_1:
+    :response: "A003 NO [OVERQUOTA] APPEND Failed\r\n"
+    :expected: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: A003
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: OVERQUOTA
+          data:
+        text: APPEND Failed
+      raw_data: "A003 NO [OVERQUOTA] APPEND Failed\r\n"
+
+  rfc9208_4.3.1_example_2:
+    :response: "* NO [OVERQUOTA] Soft quota has been exceeded\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: OVERQUOTA
+          data:
+        text: Soft quota has been exceeded
+      raw_data: "* NO [OVERQUOTA] Soft quota has been exceeded\r\n"

--- a/test/net/imap/test_imap_response_parser.rb
+++ b/test/net/imap/test_imap_response_parser.rb
@@ -93,6 +93,9 @@ class IMAPResponseParserTest < Test::Unit::TestCase
   # RFC 8474: OBJECTID responses
   generate_tests_from fixture_file: "rfc8474_objectid_responses.yml"
 
+  # RFC 9208: QUOTA extension
+  generate_tests_from fixture_file: "rfc9208_quota_responses.yml"
+
   ############################################################################
   # Workarounds or unspecified extensions:
   generate_tests_from fixture_file: "quirky_behaviors.yml"


### PR DESCRIPTION
This has been broken since #203 (v0.4.3).  There was no test coverage over the QUOTA response parser, so I copied the example responses from RFC9208.  All but one of the examples can be parsed without any further updates to the parser, besides the bugfix.