### PR TITLE
✅ Document and test workaround for invalid "\*" in FLAGS

### DIFF
--- a/lib/net/imap/response_parser.rb
+++ b/lib/net/imap/response_parser.rb
@@ -1929,6 +1929,8 @@ module Net
         end
       end
 
+      # This allows illegal "]" in flag names (Gmail),
+      # or "\*" in a FLAGS response (greenmail).
       def quirky__flag_list(name)
         match_re(Patterns::QUIRKY_FLAGS_LIST, "quirks mode #{name}")[1]
           .scan(Patterns::QUIRKY_FLAG)

--- a/test/net/imap/fixtures/response_parser/quirky_behaviors.yml
+++ b/test/net/imap/fixtures/response_parser/quirky_behaviors.yml
@@ -138,3 +138,27 @@
         $Junk $MailFlagBit0 $MailFlagBit2 $NotJunk $NotPhishing $Phishing Forwarded
         JunkRecorded NotJunk OIB-Seen-INBOX OIB-Seen-Unsubscribe OIB-Seen-[Google
         Mail]/Alle Nachrichten)\r\n"
+
+  "greenmail sent \"\\*\" in a FLAGS response":
+    comment: |
+      net-imap issue: https://github.com/ruby/net-imap/issues/228
+
+      Greenmail did fix their bug very quickly after it was reported. :)
+      Upstream issue: https://github.com/greenmail-mail-test/greenmail/issues/633
+
+      Also, greenmail is a testing fake server and I haven't seen any evidence
+      of any "real" servers with this exact error yet. So I don't feel that it's
+      critical to be compatible with it.  But, since we needed the workaround
+      anyway, for #241, it's reasonable to document that it handles this too.
+    :response: "* FLAGS (\\Answered \\Deleted \\Draft \\Flagged \\Seen \\*)\r\n"
+    expect_rescued_error: true
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: FLAGS
+      data:
+      - :Answered
+      - :Deleted
+      - :Draft
+      - :Flagged
+      - :Seen
+      - :*
+      raw_data: "* FLAGS (\\Answered \\Deleted \\Draft \\Flagged \\Seen \\*)\r\n"


### PR DESCRIPTION
The workaround for #241 (PR #246) also applies to #228.

The upstream issue (https://github.com/greenmail-mail-test/greenmail/issues/633) was fixed promptly (thanks!).  Also, greenmail is a testing fake server and I haven't seen any evidence of any "real" servers with this exact error yet.  So I don't feel that it's critical to be compatible with it...  But we _do_ need this workaround for https://github.com/ruby/net-imap/issues/241.  So it makes sense to at least document this issue in our test fixtures, for posterity.