### PR TITLE
✨ Preserving sequence set order

### DIFF
--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -60,6 +60,21 @@ module Net
     #     set = Net::IMAP::SequenceSet[1, 2, [3..7, 5], 6..10, 2048, 1024]
     #     set.valid_string  #=> "1:10,55,1024:2048"
     #
+    # == Normalized form
+    #
+    # When a sequence set is created with a single String value, that #string
+    # representation is preserved.  SequenceSet's internal representation
+    # implicitly sorts all entries, de-duplicates numbers, and coalesces
+    # adjacent or overlapping ranges.  Most enumeration methods and offset-based
+    # methods use this normalized representation.  Most modification methods
+    # will convert #string to its normalized form.
+    #
+    # In some cases the order of the string representation is significant, such
+    # as the +ESORT+, <tt>CONTEXT=SORT</tt>, and +UIDPLUS+ extensions.  Use
+    # #entries or #each_entry to enumerate the set in its original order.  To
+    # preserve #string order while modifying a set, use #append, #string=, or
+    # #replace.
+    #
     # == Using <tt>*</tt>
     #
     # \IMAP sequence sets may contain a special value <tt>"*"</tt>, which

--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -226,6 +226,8 @@ module Net
     # - #add?: If the given object is not an element in the set, adds it and
     #   returns +self+; otherwise, returns +nil+.
     # - #merge: Merges multiple elements into the set; returns +self+.
+    # - #append: Adds a given object to the set, appending it to the existing
+    #   string, and returns +self+.
     # - #string=: Assigns a new #string value and replaces #elements to match.
     # - #replace: Replaces the contents of the set with the contents
     #   of a given object.
@@ -659,6 +661,18 @@ module Net
         normalize!
       end
       alias << add
+
+      # Adds a range or number to the set and returns +self+.
+      #
+      # Unlike #add, #merge, or #union, the new value is appended to #string.
+      # This may result in a #string which has duplicates or is out-of-order.
+      def append(object)
+        tuple = input_to_tuple object
+        entry = tuple_to_str tuple
+        tuple_add tuple
+        @string = -(string ? "#{@string},#{entry}" : entry)
+        self
+      end
 
       # :call-seq: add?(object) -> self or nil
       #

--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -151,7 +151,7 @@ module Net
     #   +nil+ if the object cannot be converted to a compatible type.
     # - #cover? (aliased as #===):
     #   Returns whether a given object is fully contained within +self+.
-    # - #intersect?:
+    # - #intersect? (aliased as #overlap?):
     #   Returns whether +self+ and a given object have any common elements.
     # - #disjoint?:
     #   Returns whether +self+ and a given object have no common elements.
@@ -502,6 +502,7 @@ module Net
       def intersect?(other)
         valid? && input_to_tuples(other).any? { intersect_tuple? _1 }
       end
+      alias overlap? intersect?
 
       # Returns +true+ if the set and a given object have no common elements,
       # +false+ otherwise.

--- a/test/net/imap/test_sequence_set.rb
+++ b/test/net/imap/test_sequence_set.rb
@@ -288,6 +288,14 @@ class IMAPSequenceSetTest < Test::Unit::TestCase
     assert_equal SequenceSet["1:*"], SequenceSet.new("5:*") << (1..4)
   end
 
+  test "#append" do
+    assert_equal "1,5",     SequenceSet.new("1").append("5").string
+    assert_equal "*,1",     SequenceSet.new("*").append(1).string
+    assert_equal "1:6,4:9", SequenceSet.new("1:6").append("4:9").string
+    assert_equal "1:4,5:*", SequenceSet.new("1:4").append(5..).string
+    assert_equal "5:*,1:4", SequenceSet.new("5:*").append(1..4).string
+  end
+
   test "#merge" do
     seqset = -> { SequenceSet.new _1 }
     assert_equal seqset["1,5"],       seqset["1"].merge("5")


### PR DESCRIPTION
* ✨ Add `SequenceSet#entries` and `#each_entry`, for unsorted iteration
* ✨ Add `SequenceSet#append`, to keep unsorted order when modifying the set
* 📚 Document `SequenceSet` "Normalized form"

Unsorted access (preserving the original order from the server response) is especially important for using with the `ESORT`, `CONTEXT=SORT`, and `UIDPLUS` extensions.

In addition to preserving the original order, duplicate numbers are not removed, nor are adjacent or overlapping ranges or numbers coalesced.