### PR TITLE
📚 Workaround rdoc issue with `:yield:` and visibility

### DIFF
--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -907,7 +907,7 @@ module Net
       # normalized form, this will yield the same values as #each_element.
       #
       # Related: #entries, #each_element
-      def each_entry(&block)
+      def each_entry(&block) # :yields: integer or range or :*
         return to_enum(__method__) unless block_given?
         return each_element(&block) unless @string
         @string.split(",").each do yield tuple_to_entry str_to_tuple _1 end


### PR DESCRIPTION
Rdoc seems to get confused with the yield in this method.  It somehow causes all of private methods to be documented as public.  Adding `:yield:` fixes it.  (I think that changing the block containing yield to be multiline _also_ fixes it, but this yield needed better docs anyway.)