### PR TITLE
Add base64 dev dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,10 @@ source "https://rubygems.org"
 
 gemspec
 
+gem "digest"
+gem "strscan"
+gem "base64"
+
 gem "rake"
 gem "rdoc"
 gem "test-unit"

--- a/net-imap.gemspec
+++ b/net-imap.gemspec
@@ -35,8 +35,4 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "net-protocol"
   spec.add_dependency "date"
-
-  spec.add_development_dependency "digest"
-  spec.add_development_dependency "strscan"
-  spec.add_development_dependency "base64"
 end

--- a/net-imap.gemspec
+++ b/net-imap.gemspec
@@ -38,4 +38,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "digest"
   spec.add_development_dependency "strscan"
+  spec.add_development_dependency "base64"
 end


### PR DESCRIPTION
`base64` is extracted as bundled gems for Ruby 3.4. We should add it to dev deps.