### PR TITLE
🐛 Do not automatically freeze SearchResult

### DIFF
--- a/lib/net/imap/search_result.rb
+++ b/lib/net/imap/search_result.rb
@@ -9,7 +9,7 @@ module Net
     # For backward compatibility, SearchResult inherits from Array.
     class SearchResult < Array
 
-      # Returns a frozen SearchResult populated with the given +seq_nums+.
+      # Returns a SearchResult populated with the given +seq_nums+.
       #
       #     Net::IMAP::SearchResult[1, 3, 5, modseq: 9]
       #     # => Net::IMAP::SearchResult[1, 3, 5, modseq: 9]
@@ -22,18 +22,14 @@ module Net
       # §3.1.6]}[https://www.rfc-editor.org/rfc/rfc7162.html#section-3.1.6].
       attr_reader :modseq
 
-      # Returns a frozen SearchResult populated with the given +seq_nums+.
+      # Returns a SearchResult populated with the given +seq_nums+.
       #
       #     Net::IMAP::SearchResult.new([1, 3, 5], modseq: 9)
       #     # => Net::IMAP::SearchResult[1, 3, 5, modseq: 9]
       def initialize(seq_nums, modseq: nil)
         super(seq_nums.to_ary.map { Integer _1 })
         @modseq = Integer modseq if modseq
-        freeze
       end
-
-      # Returns a frozen copy of +other+.
-      def initialize_copy(other); super; freeze end
 
       # Returns whether +other+ is a SearchResult with the same values and the
       # same #modseq.  The order of numbers is irrelevant.

--- a/test/net/imap/test_search_result.rb
+++ b/test/net/imap/test_search_result.rb
@@ -6,14 +6,6 @@ require "test/unit"
 class SearchDataTests < Test::Unit::TestCase
   SearchResult = Net::IMAP::SearchResult
 
-  test "#frozen?" do
-    assert SearchResult.new([1, 3, 5]).frozen?
-    assert SearchResult[1, 3, 5].frozen?
-    assert SearchResult[1, 3, 5, modseq: 9].frozen?
-    assert SearchResult[1, 3, 5, modseq: 9].clone.frozen?
-    assert SearchResult[1, 3, 5, modseq: 9].dup.dup.frozen?
-  end
-
   test "#modseq" do
     assert_nil SearchResult[12, 34].modseq
     assert_equal 123_456_789, SearchResult[12, 34, modseq: 123_456_789].modseq


### PR DESCRIPTION
This was backward incompatible with existing usage of search results:
* Fixes #262