### PR TITLE
📧 Update gem email address and git mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,13 @@
+nicholas a. evans <nick@rubinick.dev>
+nicholas a. evans <nick@rubinick.dev> <nick@410labs.com>
+nicholas a. evans <nick@rubinick.dev> <nick@ekenosen.net>
+nicholas a. evans <nick@rubinick.dev> <nicholas.evans@gmail.com>
+
+Shugo Maeda <shugo@ruby-lang.org>
+Shugo Maeda <shugo@ruby-lang.org> <shugo@b2dd03c8-39d4-4d8f-98ff-823fe69b080e>
+
+Nobuyoshi Nakada <nobu@ruby-lang.org>
+Nobuyoshi Nakada <nobu@ruby-lang.org> <nobu@b2dd03c8-39d4-4d8f-98ff-823fe69b080e>
+
+Hiroshi SHIBATA <hsbt@ruby-lang.org>
+Hiroshi SHIBATA <hsbt@ruby-lang.org> <hsbt@b2dd03c8-39d4-4d8f-98ff-823fe69b080e>

--- a/net-imap.gemspec
+++ b/net-imap.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
     `git ls-files -z 2>/dev/null`.split("\x0")
-      .reject {|f| f.match(%r{^(bin|test|spec|benchmarks|features|rfcs)/}) }
+      .grep_v(%r{^(\.git|\.mailmap|bin|test|spec|benchmarks|features|rfcs)/})
   end
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }

--- a/net-imap.gemspec
+++ b/net-imap.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.name          = name
   spec.version       = version
   spec.authors       = ["Shugo Maeda", "nicholas a. evans"]
-  spec.email         = ["shugo@ruby-lang.org", "nick@ekenosen.net"]
+  spec.email         = ["shugo@ruby-lang.org", "nick@rubinick.dev"]
 
   spec.summary       = %q{Ruby client api for Internet Message Access Protocol}
   spec.description   = %q{Ruby client api for Internet Message Access Protocol}


### PR DESCRIPTION
I've changed my rubygems.org email address and my primary github email address (the others are still valid).

@shugo, @nobu, @hsbt In the git `.mailmap` file, I've aliased the UUID-generated email addresses from your svn commits to your ruby-lang.org email addresses.  Is this okay with you?