### PR TITLE
🐛 Fix parser benchmarks generation

### DIFF
--- a/rakelib/benchmarks.rake
+++ b/rakelib/benchmarks.rake
@@ -26,7 +26,7 @@ file "benchmarks/parser.yml" => PARSER_TEST_FIXTURES do |t|
   files = path.glob("*.yml")
   tests = files.flat_map {|file|
     file.read
-      .gsub(%r{([-:]) !ruby/(object|struct):\S+}) { $1 }
+      .gsub(%r{([-:]) !ruby/(object|struct|array):\S+}) { $1 }
       .then {
         YAML.safe_load(_1, filename: file,
                        permitted_classes: [Symbol, Regexp], aliases: true)


### PR DESCRIPTION
The bug was caused by the change to use SearchResult (which inherits from Array).