### PR TITLE
Consider extra empty space in BODYSTRUCTURE

### DIFF
--- a/lib/net/imap/response_parser.rb
+++ b/lib/net/imap/response_parser.rb
@@ -1155,9 +1155,9 @@ module Net
       # RFC3501, RFC9051:
       # body-fld-param  = "(" string SP string *(SP string SP string) ")" / nil
       def body_fld_param
+        quirky_SP? # See comments on test_bodystructure_extra_space
         return if NIL?
         param = {}
-        shift_token if @token.symbol == T_SPACE
         lpar
         name = case_insensitive__string; SP!; param[name] = string
         while SP?

--- a/lib/net/imap/response_parser.rb
+++ b/lib/net/imap/response_parser.rb
@@ -1157,6 +1157,7 @@ module Net
       def body_fld_param
         return if NIL?
         param = {}
+        shift_token if @token.symbol == T_SPACE
         lpar
         name = case_insensitive__string; SP!; param[name] = string
         while SP?

--- a/test/net/imap/fixtures/response_parser/body_structure_responses.yml
+++ b/test/net/imap/fixtures/response_parser/body_structure_responses.yml
@@ -433,6 +433,77 @@
         4383638 NIL (\"attachment\" (\"filename\" \"test.xml\")) NIL NIL) \"mixed\"
         (\"boundary\" \"001a1137a5047848e405157ddaa3\") NIL))\r\n"
 
+  test_bodystructure_extra_space:
+    :response: "* 1 FETCH (UID 1 BODYSTRUCTURE (((\"text\" \"plain\"  (\"charset\" \"UTF-8\") NIL
+      NIL \"7bit\" 409 7 NIL NIL NIL)(\"text\" \"html\"  (\"charset\" \"UTF-8\") NIL NIL \"7bit\"
+      592 10 NIL NIL NIL) \"alternative\" (\"boundary\" \"--==_mimepart_5277b641dcc3_57d5887e8325d8\"
+      \"charset\" \"UTF-8\") NIL NIL) \"mixed\" (\"boundary\" \"--==_mimepart_5277b64110f79_57d5887e832634\"
+      \"charset\" \"UTF-8\") NIL NIL))\r\n"
+
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: FETCH
+      data: !ruby/struct:Net::IMAP::FetchData
+        seqno: 1
+        attr:
+          UID: 1
+          BODYSTRUCTURE: !ruby/struct:Net::IMAP::BodyTypeMultipart
+            media_type: MULTIPART
+            subtype: MIXED
+            parts:
+            - !ruby/struct:Net::IMAP::BodyTypeMultipart
+              media_type: MULTIPART
+              subtype: ALTERNATIVE
+              parts:
+              - !ruby/struct:Net::IMAP::BodyTypeText
+                media_type: TEXT
+                subtype: PLAIN
+                param:
+                  CHARSET: UTF-8
+                content_id:
+                description:
+                encoding: 7BIT
+                size: 409
+                lines: 7
+                md5:
+                disposition:
+                language:
+                location:
+                extension:
+              - !ruby/struct:Net::IMAP::BodyTypeText
+                media_type: TEXT
+                subtype: HTML
+                param:
+                  CHARSET: UTF-8
+                content_id:
+                description:
+                encoding: 7BIT
+                size: 592
+                lines: 10
+                md5:
+                disposition:
+                language:
+                location:
+                extension:
+              param:
+                BOUNDARY: --==_mimepart_5277b641dcc3_57d5887e8325d8
+                CHARSET: UTF-8
+              disposition:
+              language:
+              location:
+              extension:
+            param:
+              BOUNDARY: --==_mimepart_5277b64110f79_57d5887e832634
+              CHARSET: UTF-8
+            disposition:
+            language:
+            location:
+            extension:
+      raw_data: "* 1 FETCH (UID 1 BODYSTRUCTURE (((\"text\" \"plain\"  (\"charset\" \"UTF-8\") NIL NIL
+        \"7bit\" 409 7 NIL NIL NIL)(\"text\" \"html\"  (\"charset\" \"UTF-8\") NIL NIL \"7bit\"
+        592 10 NIL NIL NIL) \"alternative\" (\"boundary\" \"--==_mimepart_5277b641dcc3_57d5887e8325d8\"
+        \"charset\" \"UTF-8\") NIL NIL) \"mixed\" (\"boundary\" \"--==_mimepart_5277b64110f79_57d5887e832634\"
+        \"charset\" \"UTF-8\") NIL NIL))\r\n"
+
   test_bodystructure_mixed_boundary:
     :response: "* 2688 FETCH (UID 179161 BODYSTRUCTURE ((\"TEXT\" \"PLAIN\" (\"CHARSET\"
       \"iso-8859-1\") NIL NIL \"QUOTED-PRINTABLE\" 200 4 NIL NIL NIL)(\"MESSAGE\"

--- a/test/net/imap/fixtures/response_parser/body_structure_responses.yml
+++ b/test/net/imap/fixtures/response_parser/body_structure_responses.yml
@@ -434,6 +434,10 @@
         (\"boundary\" \"001a1137a5047848e405157ddaa3\") NIL))\r\n"
 
   test_bodystructure_extra_space:
+    :comments: |
+      [GH-271] Responses from some IMAP servers contained extra space like this.
+      The fix has been used since Jan 2014, seems to be easy, and doesn't seem to
+      cause any harm.
     :response: "* 1 FETCH (UID 1 BODYSTRUCTURE (((\"text\" \"plain\"  (\"charset\" \"UTF-8\") NIL
       NIL \"7bit\" 409 7 NIL NIL NIL)(\"text\" \"html\"  (\"charset\" \"UTF-8\") NIL NIL \"7bit\"
       592 10 NIL NIL NIL) \"alternative\" (\"boundary\" \"--==_mimepart_5277b641dcc3_57d5887e8325d8\"


### PR DESCRIPTION
Hi! I'm working on (very old) project that's excessively using net-imap to access remote IMAP servers.  Since ages we have some 'imap hacks' implemented on top of net-imap. These hacks were introduced to cope with some unusual responses from IMAP servers of our customers. I thought that I'd try to 'backport' some of them if you'd consider them viable/useful. 

In this my first PR I'm 'backporting' one fix we had since 2016. Responses from some IMAP servers contained extra space like so `((\"text\" \"plain\"  (\"charset\" \"UTF-8\")`. The fix seems to be easy and should not do harm I guess. I'm not sure if the fix is idiomatic according to the recent changes in net-imap (we're bumping net-imap frim 0.3.7 to 0.4.10 right now, so how we implemented the fix long time ago might not be pretty in 0.4.10).

Thank you for your time!