### PR TITLE
💥 Drop ruby 2.7 and 3.0 support, and require 3.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
     with:
       engine: cruby
-      min_version: 2.7
+      min_version: 3.1
 
   build:
     needs: ruby-versions
@@ -26,6 +26,6 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-        rubygems: 3.4.22
+        rubygems: 3.5.14
     - name: Run test
       run: bundle exec rake test

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -717,7 +717,7 @@ module Net
   # * {IMAP URLAUTH Authorization Mechanism Registry}[https://www.iana.org/assignments/urlauth-authorization-mechanism-registry/urlauth-authorization-mechanism-registry.xhtml]
   #
   class IMAP < Protocol
-    VERSION = "0.4.14"
+    VERSION = "0.5.0-dev"
 
     # Aliases for supported capabilities, to be used with the #enable command.
     ENABLE_ALIASES = {

--- a/net-imap.gemspec
+++ b/net-imap.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{Ruby client api for Internet Message Access Protocol}
   spec.description   = %q{Ruby client api for Internet Message Access Protocol}
   spec.homepage      = "https://github.com/ruby/net-imap"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.7.3")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.1.0")
   spec.licenses       = ["Ruby", "BSD-2-Clause"]
 
   spec.metadata["homepage_uri"] = spec.homepage


### PR DESCRIPTION
Ruby 2.7 EOL was 2023-03-31.
Ruby 3.0 EOL was 2024-04-23.

Currently, net-imap remains compatible with ruby 2.7.  But some of my unmerged branches do use ruby 3.1 syntax (e.g: updated pattern matching and endless method definitions).  It will be nice if I don't need to update those branches for compatibility with EOL rubies.

----

_**NOTE:** The next release after this is merged should be v0.5.0._