### PR TITLE
📚 Add compatibility policy to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,37 @@ end
 imap.expunge
 ```
 
+## Maintenance Policy
+
+`net-imap` is bundled with Ruby releases.  As a [bundled gem], it can be
+uninstalled from a Ruby installation and must be declared in `Gemfile` when used
+with `bundler`.  Each Ruby `major.minor` release series bundles a specific
+`net-imap` release series.  Each `net-imap` release series will remain
+compatible with at least two older versions of Ruby.
+
+Each `net-imap` release series will receive security updates as long as they are
+bundled with [supported Ruby branches].  The `net-imap` release series bundled
+with Ruby's latest stable Ruby release series _may_ also receive backported
+bugfixes and features, at the maintainers' discretion.
+
+|     |Bundled with|First bundled release        |Minimum Ruby|Maintenance   |End of life |
+|-----|------------|-----------------------------|------------|--------------|------------|
+|0.5.x| _not yet_  | _not bundled with Ruby yet_ |Ruby 3.1    |new features  |            |
+|0.4.x| Ruby 3.3   |0.4.9, Ruby 3.3.0, 2023-12-25|Ruby 2.7.3  |some backports|_2027-03-31_|
+|0.3.x| Ruby 3.2   |0.3.4, Ruby 3.2.0, 2022-12-25|Ruby 2.6    |security only |_2026-03-31_|
+|0.2.x| Ruby 3.1   |0.2.2, Ruby 3.1.0, 2021-12-25|Ruby 2.5/2.6|security only |_2025-03-31_|
+|0.1.x| Ruby 3.0*  |0.1.1, Ruby 3.0.0, 2020-12-25|Ruby 2.5    |end of life   | 2024-04-23 |
+|     | in stdlib  |       Ruby 1.6.2, 2000-12-25|            |end of life   | 2023-03-31 |
+
+Version 0.1.x was packaged as a [default gem] for Ruby 3.0, and can not be
+uninstalled from a Ruby 3.0 installation.  Before being extracted into a gem,
+`net/imap` was only packaged as a part of Ruby's releases.  The first stable
+release to include `net/imap` was ruby 1.6.2, on 2000-12-25.
+
+[bundled gem]: https://docs.ruby-lang.org/en/master/standard_library_rdoc.html#label-Bundled+gems
+[default gem]: https://docs.ruby-lang.org/en/master/standard_library_rdoc.html
+[supported Ruby branches]: https://www.ruby-lang.org/en/downloads/branches/
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `bundle exec rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.


### PR DESCRIPTION
I saw a chart similar to this in [ruby/openssl's README](https://github.com/ruby/openssl/blob/97305cfafc4e06c67e8b2d96fd72acc83597db05/README.md), and it seems like this is a relatively simple way to communicate our versioning.

I'll propose documentation for a slightly more detailed deprecation and compatibility policy... in a _future_ PR.