### PR TITLE
📚 Fix many rdoc spelling mistakes

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -820,7 +820,7 @@ module Net
     #
     # ==== Examples
     #
-    # Connect to cleartext port 143 at mail.example.com and recieve the server greeting:
+    # Connect to cleartext port 143 at mail.example.com and receive the server greeting:
     #   imap = Net::IMAP.new('mail.example.com', ssl: false) # => #<Net::IMAP:0x00007f79b0872bd0>
     #   imap.port          => 143
     #   imap.tls_verified? => false
@@ -888,7 +888,7 @@ module Net
       @greeting = nil
       @capabilities = nil
 
-      # Client Protocol Reciever
+      # Client Protocol Receiver
       @parser = ResponseParser.new
       @responses = Hash.new {|h, k| h[k] = [] }
       @response_handlers = []

--- a/lib/net/imap/data_encoding.rb
+++ b/lib/net/imap/data_encoding.rb
@@ -136,7 +136,7 @@ module Net
       alias parse_datetime  decode_datetime
       alias parse_time      decode_time
 
-      # alias format_datetime encode_datetime  # n.b. this is overridden below...
+      # alias format_datetime encode_datetime  # n.b: this is overridden below...
     end
 
     # DEPRECATED:: The original version returned incorrectly formatted strings.

--- a/lib/net/imap/deprecated_client_options.rb
+++ b/lib/net/imap/deprecated_client_options.rb
@@ -20,7 +20,7 @@ module Net
       # deprecated by a future release.
       #
       # If a second positional argument is given and it is a hash (or is
-      # convertable via +#to_hash+), it is converted to keyword arguments.
+      # convertible via +#to_hash+), it is converted to keyword arguments.
       #
       #     # Obsolete:
       #     Net::IMAP.new("imap.example.com", options_hash)

--- a/lib/net/imap/errors.rb
+++ b/lib/net/imap/errors.rb
@@ -11,7 +11,7 @@ module Net
     class DataFormatError < Error
     end
 
-    # Error raised when a response from the server is non-parseable.
+    # Error raised when a response from the server is non-parsable.
     class ResponseParseError < Error
     end
 

--- a/lib/net/imap/flags.rb
+++ b/lib/net/imap/flags.rb
@@ -71,7 +71,7 @@ module Net
     # Mailbox name attributes are not case-sensitive.  <em>The current
     # implementation</em> normalizes mailbox attribute case using
     # String#capitalize, such as +:Noselect+ (not +:NoSelect+).  The constants
-    # (such as NO_SELECT) can also be used for comparison.  The contants have
+    # (such as NO_SELECT) can also be used for comparison.  The constants have
     # been defined both with and without underscores between words.
     #
     # <em>The descriptions here were copied from</em> {[RFC-9051 §

--- a/lib/net/imap/response_data.rb
+++ b/lib/net/imap/response_data.rb
@@ -58,7 +58,7 @@ module Net
 
     # Net::IMAP::IgnoredResponse represents intentionally ignored responses.
     #
-    # This includes untagged response "NOOP" sent by eg. Zimbra to avoid
+    # This includes untagged response "NOOP" sent by e.g. Zimbra to avoid
     # some clients to close the connection.
     #
     # It matches no IMAP standard.
@@ -280,7 +280,7 @@ module Net
     # ==== +QRESYNC+ extension
     # See {[RFC7162]}[https://www.rfc-editor.org/rfc/rfc7162.html].
     # * +CLOSED+, returned when the currently selected mailbox is closed
-    #   implicity by selecting or examining another mailbox.  #data is +nil+.
+    #   implicitly by selecting or examining another mailbox.  #data is +nil+.
     #
     # ==== +IMAP4rev2+ Response Codes
     # See {[RFC9051]}[https://www.rfc-editor.org/rfc/rfc9051] {§7.1, "Server
@@ -1045,7 +1045,7 @@ module Net
     # === Bug Analysis
     #
     # \IMAP body structures are parenthesized lists and assign their fields
-    # positionally, so missing fields change the intepretation of all
+    # positionally, so missing fields change the interpretation of all
     # following fields.  Additionally, different body types have a different
     # number of required fields, followed by optional "extension" fields.
     #
@@ -1060,7 +1060,7 @@ module Net
     # Normally, +envelope+ and +md5+ are incompatible, but Net::IMAP leniently
     # allowed buggy servers to send +NIL+ for +envelope+.  As a result, when a
     # server sent a <tt>message/rfc822</tt> part with +NIL+ for +md5+ and a
-    # non-<tt>NIL</tt> +dsp+, Net::IMAP mis-interpreted the
+    # non-<tt>NIL</tt> +dsp+, Net::IMAP misinterpreted the
     # <tt>Content-Disposition</tt> as if it were a strange body type.  In all
     # reported cases, the <tt>Content-Disposition</tt> was "attachment", so
     # BodyTypeAttachment was created as the workaround.
@@ -1068,7 +1068,7 @@ module Net
     # === Current behavior
     #
     # When interpreted strictly, +envelope+ and +md5+ are incompatible.  So the
-    # current parsing algorithm peeks ahead after it has recieved the seventh
+    # current parsing algorithm peeks ahead after it has received the seventh
     # body field.  If the next token is not the start of an +envelope+, we assume
     # the server has incorrectly sent us a <tt>body-type-basic</tt> and return
     # BodyTypeBasic.  As a result, what was previously BodyTypeMessage#body =>

--- a/lib/net/imap/sasl.rb
+++ b/lib/net/imap/sasl.rb
@@ -37,7 +37,7 @@ module Net
     #     See ExternalAuthenticator.
     #
     #     Authenticates using already established credentials, such as a TLS
-    #     certificate or IPsec.
+    #     certificate or IPSec.
     #
     # +OAUTHBEARER+::
     #     See OAuthBearerAuthenticator.

--- a/lib/net/imap/sasl/external_authenticator.rb
+++ b/lib/net/imap/sasl/external_authenticator.rb
@@ -9,7 +9,7 @@ module Net
       # Net::IMAP#authenticate.
       #
       # The EXTERNAL mechanism requests that the server use client credentials
-      # established external to SASL, for example by TLS certificate or IPsec.
+      # established external to SASL, for example by TLS certificate or IPSec.
       class ExternalAuthenticator
 
         # Authorization identity: an identity to act as or on behalf of.  The

--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -902,8 +902,8 @@ module Net
       # Yields each number or range in #string to the block and returns +self+.
       # Returns an enumerator when called without a block.
       #
-      # The entries are yielded in the same order they appear in #tring, with no
-      # sorting, deduplication, or coalescing.  When #string is in its
+      # The entries are yielded in the same order they appear in #string, with
+      # no sorting, deduplication, or coalescing.  When #string is in its
       # normalized form, this will yield the same values as #each_element.
       #
       # Related: #entries, #each_element


### PR DESCRIPTION
I simply enabled vim's `spell` option and looked at each of the files.