### PR TITLE
🔍 Simplify handling of ResponseParser test failures

### DIFF
--- a/test/net/imap/net_imap_test_helpers.rb
+++ b/test/net/imap/net_imap_test_helpers.rb
@@ -50,6 +50,9 @@ module NetIMAPTestHelpers
               actual = parser.parse response
               binding.irb if debug
               assert_equal expected, actual
+            rescue Test::Unit::AssertionFailedError
+              puts YAML.dump name => {response: response, expected: actual}
+              raise
             end
           end
 


### PR DESCRIPTION
Nothing fancy here... it just prints out the YAML that should make the test pass, to simplify updating the test fixture.  It's still up to the developer to inspect that YAML and make sure it's correct.