### PR TITLE
💥 Replace MessageSet with SequenceSet

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -1950,7 +1950,7 @@ module Net
     # [RFC4315[https://www.rfc-editor.org/rfc/rfc4315.html]].
     def uid_expunge(uid_set)
       synchronize do
-        send_command("UID EXPUNGE", MessageSet.new(uid_set))
+        send_command("UID EXPUNGE", SequenceSet.new(uid_set))
         clear_responses("EXPUNGE")
       end
     end
@@ -2912,9 +2912,9 @@ module Net
       synchronize do
         clear_responses("FETCH")
         if mod
-          send_command(cmd, MessageSet.new(set), attr, mod)
+          send_command(cmd, SequenceSet.new(set), attr, mod)
         else
-          send_command(cmd, MessageSet.new(set), attr)
+          send_command(cmd, SequenceSet.new(set), attr)
         end
         clear_responses("FETCH")
       end
@@ -2922,7 +2922,7 @@ module Net
 
     def store_internal(cmd, set, attr, flags, unchangedsince: nil)
       attr = RawData.new(attr) if attr.instance_of?(String)
-      args = [MessageSet.new(set)]
+      args = [SequenceSet.new(set)]
       args << ["UNCHANGEDSINCE", Integer(unchangedsince)] if unchangedsince
       args << attr << flags
       synchronize do
@@ -2933,7 +2933,7 @@ module Net
     end
 
     def copy_internal(cmd, set, mailbox)
-      send_command(cmd, MessageSet.new(set), mailbox)
+      send_command(cmd, SequenceSet.new(set), mailbox)
     end
 
     def sort_internal(cmd, sort_keys, search_keys, charset)
@@ -2964,7 +2964,7 @@ module Net
       keys.collect! do |i|
         case i
         when -1, Range, Array
-          MessageSet.new(i)
+          SequenceSet.new(i)
         else
           i
         end

--- a/lib/net/imap/command_data.rb
+++ b/lib/net/imap/command_data.rb
@@ -179,6 +179,7 @@ module Net
       end
     end
 
+    # *DEPRECATED*.  Replaced by SequenceSet.
     class MessageSet # :nodoc:
       def send_data(imap, tag)
         imap.__send__(:put_string, format_internal(@data))
@@ -192,6 +193,15 @@ module Net
 
       def initialize(data)
         @data = data
+        warn "DEPRECATED: #{MessageSet} should be replaced with #{SequenceSet}."
+        begin
+          # to ensure the input works with SequenceSet, too
+          SequenceSet.new(data)
+        rescue
+          warn "MessageSet input is incompatible with SequenceSet: [%s] %s" % [
+            $!.class, $!.message
+          ]
+        end
       end
 
       def format_internal(data)


### PR DESCRIPTION
There are some small differences in how `MessageSet` and `SequenceSet` behave.  I'll add a backward incompatibility warning to the release notes.

But, although the following list of changes does _seem_ long, I don't think the changes should break any existing code.  Most of the changes are bugfixes or allow something new to work that didn't work before.

These are the differences that I've noted (there may be others):

### Validation
SequenceSet does almost all of its validation during construction.  The _only_ invalid SequenceSet is an _empty_ SequenceSet.  MessageSet only validates when `validate` is called.  In practice, this shouldn't make much of a difference.

MessageSet does not validate ranges at all.  This can result in exceptions _while sending the data_, which might leave the connection in a weird state, with a partially sent command.  It can also result in invalid ranges being sent, e.g: `MessageSet.new("foo".."bar")`.

### Invalid inputs to MessageSet

#### Fail to validate
Some values can be _formatted_ by MessageSet, but raise an exception when validating.  SequenceSet allows these:
* `-1` by itself or in array (MessageSet only allows -1 to validate in a range)

#### Fail to validate or format
SequenceSet allows inputs that MessageSet doesn't:
* `Set` of numbers or `nz-number` formatted strings
* `*` can be input as a Symbol, in addition to a string or `-1`
* `Range`
  * begin and end may be `nz-number` formatted strings, `:*`, or `"*"`
  * beginless ranges => `"1:#{range.end}"`
  * endless ranges => `"#{range.begin}:*"`
* `Net::IMAP::SearchResult` implements `#to_sequence_set`

### Buggy MessageSet formatting

The MessageSet handling for `Net::IMAP::ThreadMember` is not quite right, and it has no tests.  `ThreadMember#to_sequence_set` has a test that covers these bugs, and I believe it has the correct behavior.

Since ranges are not validated, and integers aren't re-validated during formatting, zero and negative numbers in a range will be output directly.  Only `-1` is special-cased.

### Invalid inputs to SequenceSet
SequenceSet raises an exception for backwards ranges, e.g: `5..3` or `-1..55`.  While these are _syntactically_ similar to IMAP `sequence-set`, the semantics are very different:
* In IMAP, the order is insignificant, for both membership and order within the set, so `5:3` is the same as `3,4,5`
* In Ruby, the order is significant, so `(5..3).to_a` is empty.

### Normalization

Normalized form is semantically equivalent, _except when the order of entries is significant._

* MessageSet outputs everything you give it in the same order it was given.
* SequenceSet preserves the form _for a simple string input_.  When the input is more complex (arrays, sets, etc), SequenceSet automatically normalizes the output string.  It will be sorted, its numbers deduplicated, and its ranges coalesced.

***Note that*** `Net::IMAP::UIDPlusData` still uses arrays instead of `SequenceSet`, and `Net::IMAP::ResponseParser` preserves any response's `sequence-set` order.
