### PR TITLE
🔧 Add config option for `sasl_ir`

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -1212,7 +1212,7 @@ module Net
     end
 
     # :call-seq:
-    #   authenticate(mechanism, *, sasl_ir: true, registry: Net::IMAP::SASL.authenticators, **, &) -> ok_resp
+    #   authenticate(mechanism, *, sasl_ir: config.sasl_ir, registry: Net::IMAP::SASL.authenticators, **, &) -> ok_resp
     #
     # Sends an {AUTHENTICATE command [IMAP4rev1 §6.2.2]}[https://www.rfc-editor.org/rfc/rfc3501#section-6.2.2]
     # to authenticate the client.  If successful, the connection enters the
@@ -1317,7 +1317,9 @@ module Net
     # Previously cached #capabilities will be cleared when this method
     # completes.  If the TaggedResponse to #authenticate includes updated
     # capabilities, they will be cached.
-    def authenticate(mechanism, *creds, sasl_ir: true, **props, &callback)
+    def authenticate(mechanism, *creds,
+                     sasl_ir: config.sasl_ir,
+                     **props, &callback)
       mechanism = mechanism.to_s.tr("_", "-").upcase
       authenticator = SASL.authenticator(mechanism, *creds, **props, &callback)
       cmdargs = ["AUTHENTICATE", mechanism]

--- a/lib/net/imap/config.rb
+++ b/lib/net/imap/config.rb
@@ -104,6 +104,16 @@ module Net
       # The default value is +5+ seconds.
       attr_accessor :idle_response_timeout, type: Integer
 
+      # :markup: markdown
+      #
+      # Whether to use the +SASL-IR+ extension with IMAP#authenticate.
+      #
+      # | Starting with version | The default value is                     |
+      # |-----------------------|------------------------------------------|
+      # | _original_            | +false+ <em>(extension unsupported)</em> |
+      # | v0.4                  | +true+  <em>(support added)</em>         |
+      attr_accessor :sasl_ir, type: :boolean
+
       # Creates a new config object and initialize its attribute with +attrs+.
       #
       # If +parent+ is not given, the global config is used by default.
@@ -119,6 +129,7 @@ module Net
         debug: false,
         open_timeout: 30,
         idle_response_timeout: 5,
+        sasl_ir: true,
       ).freeze
 
       @global = default.new


### PR DESCRIPTION
This config option becomes the default value for the `Net::IMAP#authenticate` kwarg with the same name.

By making it configurable, users can more easily opt out of the new behavior, which can force a `CAPABILITY` call.  It shouldn't generally shouldn't be necessary to avoid calling `CAPABILITY`, but... see #278!

_(NOTE: this PR depends on #291)_