### PR TITLE
📦 Don't keep .github, .gitignore, .mailmap in gem

### DIFF
--- a/net-imap.gemspec
+++ b/net-imap.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+  spec.files         = Dir.chdir(__dir__) do
     `git ls-files -z 2>/dev/null`.split("\x0")
       .grep_v(%r{^(\.git(ignore)?|\.mailmap|(\.github|bin|test|spec|benchmarks|features|rfcs)/)})
   end

--- a/net-imap.gemspec
+++ b/net-imap.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
     `git ls-files -z 2>/dev/null`.split("\x0")
-      .grep_v(%r{^(\.git|\.mailmap|bin|test|spec|benchmarks|features|rfcs)/})
+      .grep_v(%r{^(\.git(ignore)?|\.mailmap|(\.github|bin|test|spec|benchmarks|features|rfcs)/)})
   end
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }


### PR DESCRIPTION
Previously, the gemspec's `spec.files` rejection regexp:
* only matched directory names, missing `.mailmap`
* didn't attempt to match `.github/` or `.gitignore`