### PR TITLE
✨ Add Config methods: `#to_h`, `#update`, and `#with`

### DIFF
--- a/lib/net/imap/config.rb
+++ b/lib/net/imap/config.rb
@@ -143,8 +143,26 @@ module Net
       # If a block is given, the new config object is yielded to it.
       def initialize(parent = Config.global, **attrs)
         super(parent)
-        attrs.each do send(:"#{_1}=", _2) end
+        update(**attrs)
         yield self if block_given?
+      end
+
+      # :call-seq: update(**attrs) -> self
+      #
+      # Assigns all of the provided +attrs+ to this config, and returns +self+.
+      #
+      # An ArgumentError is raised unless every key in +attrs+ matches an
+      # assignment method on Config.
+      #
+      # >>>
+      #   *NOTE:*  #update is not atomic.  If an exception is raised due to an
+      #   invalid attribute value, +attrs+ may be partially applied.
+      def update(**attrs)
+        unless (bad = attrs.keys.reject { respond_to?(:"#{_1}=") }).empty?
+          raise ArgumentError, "invalid config options: #{bad.join(", ")}"
+        end
+        attrs.each do send(:"#{_1}=", _2) end
+        self
       end
 
       # :call-seq: to_h -> hash

--- a/lib/net/imap/config.rb
+++ b/lib/net/imap/config.rb
@@ -165,6 +165,24 @@ module Net
         self
       end
 
+      # :call-seq:
+      #   with(**attrs) -> config
+      #   with(**attrs) {|config| } -> result
+      #
+      # Without a block, returns a new config which inherits from self.  With a
+      # block, yields the new config and returns the block's result.
+      #
+      # If no keyword arguments are given, an ArgumentError will be raised.
+      #
+      # If +self+ is frozen, the copy will also be frozen.
+      def with(**attrs)
+        attrs.empty? and
+          raise ArgumentError, "expected keyword arguments, none given"
+        copy = new(**attrs)
+        copy.freeze if frozen?
+        block_given? ? yield(copy) : copy
+      end
+
       # :call-seq: to_h -> hash
       #
       # Returns all config attributes in a hash.

--- a/lib/net/imap/config.rb
+++ b/lib/net/imap/config.rb
@@ -147,6 +147,11 @@ module Net
         yield self if block_given?
       end
 
+      # :call-seq: to_h -> hash
+      #
+      # Returns all config attributes in a hash.
+      def to_h; data.members.to_h { [_1, send(_1)] } end
+
       @default = new(
         debug: false,
         open_timeout: 30,

--- a/test/net/imap/test_config.rb
+++ b/test/net/imap/test_config.rb
@@ -253,4 +253,29 @@ class ConfigTest < Test::Unit::TestCase
     assert_same false, config.sasl_ir?     # unchanged
   end
 
+  test "#with" do
+    orig = Config.new(open_timeout: 123, sasl_ir: false)
+    assert_raise(ArgumentError) do
+      orig.with
+    end
+    copy = orig.with(open_timeout: 456, idle_response_timeout: 789)
+    refute copy.frozen?
+    assert_same orig, copy.parent
+    assert_equal 123, orig.open_timeout # unchanged
+    assert_equal 456, copy.open_timeout
+    assert_equal 789, copy.idle_response_timeout
+    vals = nil
+    result = orig.with(open_timeout: 99, idle_response_timeout: 88) do |c|
+      vals = [c.open_timeout, c.idle_response_timeout, c.frozen?]
+      :result
+    end
+    assert_equal :result, result
+    assert_equal [99, 88, false], vals
+    orig.freeze
+    result = orig.with(open_timeout: 11) do |c|
+      vals = [c.open_timeout, c.idle_response_timeout, c.frozen?]
+    end
+    assert_equal [11, 5, true], vals
+  end
+
 end

--- a/test/net/imap/test_config.rb
+++ b/test/net/imap/test_config.rb
@@ -209,4 +209,17 @@ class ConfigTest < Test::Unit::TestCase
     assert child.inherited?(:idle_response_timeout)
   end
 
+  test "#to_h" do
+    expected = {
+      debug: false, open_timeout: 30, idle_response_timeout: 5, sasl_ir: true,
+    }
+    attributes = Config::AttrAccessors::Struct.members
+    default_hash = Config.default.to_h
+    assert_equal expected, default_hash.slice(*expected.keys)
+    assert_equal attributes, default_hash.keys
+    global_hash = Config.global.to_h
+    assert_equal attributes, global_hash.keys
+    assert_equal expected, global_hash.slice(*expected.keys)
+  end
+
 end


### PR DESCRIPTION
These methods were originally used to implement `#load_defaults` (to finish #288), and it seems reasonable to add them to the public API.

Unlike `SequenceSet` (which I want to have a full API to match Set, Range, and Array), I want to be careful in adding any extra public methods to `Config`.  But I think these three are basic enough to be permitted.

### `#to_h`
> Returns all config attributes in a hash.

### `#update`
> Assigns all of the provided +attrs+ to this config, and returns +self+.
>
> Each key in +attrs+ must match an assignment method on Config.

In other words, `#update` does the same thing that `#initialize` does with its kwargs.

### `#with`
> Without a block, returns a new config which inherits from self.  With a block, yields the new config and returns the block's result.

I _originally_ made `#with` create a _copy_ (using `dup`), which meant it was a "sibling" to the receiver, not a child.  I did it that way because that's what I wanted for creating the versioned defaults (see #302) and I extracted the method from that code.  Also, that's how `Data#with` works and I had copied some of the rdoc from there.

But when I went back to add the tests, it seemed clear to me that the Principle of Least Surprise would expect `#with` to create a child config, inheriting from its creator.  I had already created the _instance_ method `#new` for that purpose, but `#with` is usefully different enough to justify its distinct existence (in my opinion)