### PR TITLE
🔧 Add `Config#load_defaults`

### DIFF
--- a/lib/net/imap/config.rb
+++ b/lib/net/imap/config.rb
@@ -288,15 +288,19 @@ module Net
       def load_defaults(version)
         [Numeric, Symbol, String].any? { _1 === version } or
           raise ArgumentError, "expected number or symbol, got %p" % [version]
-        config = Config[version]
-        defaults = config.to_h.reject {|k,v| DEFAULT_TO_INHERIT.include?(k) }
-        update(**defaults)
+        update(**Config[version].defaults_hash)
       end
 
       # :call-seq: to_h -> hash
       #
       # Returns all config attributes in a hash.
       def to_h; data.members.to_h { [_1, send(_1)] } end
+
+      protected
+
+      def defaults_hash
+        to_h.reject {|k,v| DEFAULT_TO_INHERIT.include?(k) }
+      end
 
       @default = new(
         debug: false,
@@ -308,9 +312,7 @@ module Net
 
       @global = default.new
 
-      version_defaults[0.4] = Config[
-        default.to_h.reject {|k,v| DEFAULT_TO_INHERIT.include?(k) }
-      ]
+      version_defaults[0.4] = Config[default.send(:defaults_hash)]
 
       version_defaults[0] = Config[0.4].dup.update(
         sasl_ir: false,

--- a/test/net/imap/test_config.rb
+++ b/test/net/imap/test_config.rb
@@ -332,4 +332,27 @@ class ConfigTest < Test::Unit::TestCase
     assert_equal [11, 5, true], vals
   end
 
+  test "#load_defaults" do
+    config = Config.global.load_defaults 0.3
+    assert_same Config.global, config
+    assert_same true,  config.inherited?(:debug)
+    assert_same false, config.inherited?(:sasl_ir)
+    assert_same false, config.sasl_ir
+    # does not _reset_ default
+    config.debug = true
+    Config.global.load_defaults 0.3
+    assert_same false, config.inherited?(:debug)
+    assert_same true,  config.debug?
+    # does not change parent
+    child           = Config.global.new
+    grandchild      = child.new
+    greatgrandchild = grandchild.new
+    child.load_defaults :current
+    grandchild.load_defaults :next
+    greatgrandchild.load_defaults :future
+    assert_same Config.global, child.parent
+    assert_same child, grandchild.parent
+    assert_same grandchild, greatgrandchild.parent
+  end
+
 end


### PR DESCRIPTION
- Depends on
  - #300 
  - #302
- Completes #288.

-----

This is inspired by [Rails::Application::Configuration#load_defaults](https://edgeapi.rubyonrails.org/classes/Rails/Application/Configuration.html#method-i-load_defaults) in rails.

`Config#load_defaults` resets the current config to behave like the versioned default configuration for the requested version.  (See #302.)

For example, `#load_defaults` can be used to globally behave more like a specific version of `net-imap`:
```ruby
client = Net::IMAP.new(hostname)
client.config.sasl_ir              # => true
Net::IMAP.config.load_defaults 0.3
client.config.sasl_ir              # => false
```