### PR TITLE
🔇 Fix ruby 2.7 warnings

### DIFF
--- a/lib/net/imap/config.rb
+++ b/lib/net/imap/config.rb
@@ -126,7 +126,7 @@ module Net
       def self.default; @default end
 
       # The global config object.  Also available from Net::IMAP.config.
-      def self.global; @global end
+      def self.global; @global if defined?(@global) end
 
       # A hash of hard-coded configurations, indexed by version number.
       def self.version_defaults; @version_defaults end
@@ -149,12 +149,11 @@ module Net
       #
       # Given a config, returns that same config.
       def self.[](config)
-        if config.is_a?(Config) || config.nil? && global.nil?
-          config
-        elsif config.respond_to?(:to_hash)
-          new(global, **config).freeze
+        if    config.is_a?(Config)         then config
+        elsif config.nil? && global.nil?   then nil
+        elsif config.respond_to?(:to_hash) then new(global, **config).freeze
         else
-          version_defaults.fetch(config) {
+          version_defaults.fetch(config) do
             case config
             when Numeric
               raise RangeError, "unknown config version: %p" % [config]
@@ -165,7 +164,7 @@ module Net
                 config.class, Config
               ]
             end
-          }
+          end
         end
       end
 

--- a/test/net/imap/test_deprecated_client_options.rb
+++ b/test/net/imap/test_deprecated_client_options.rb
@@ -24,7 +24,7 @@ class DeprecatedClientOptionsTest < Test::Unit::TestCase
 
     test "Convert obsolete options hash to keywords" do
       run_fake_server_in_thread do |server|
-        with_client(server.host, {port: server.port, ssl: false}) do |client|
+        with_client(server.host, {port: server.port, ssl: false}, **{}) do |client|
           assert_equal server.host, client.host
           assert_equal server.port, client.port
           assert_equal false, client.ssl_ctx_params

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -523,7 +523,7 @@ class IMAPTest < Test::Unit::TestCase
           t: Process.clock_gettime(Process::CLOCK_MONOTONIC),
         }
         #super
-        s = Socket.tcp(host, port, :connect_timeout => @open_timeout)
+        s = Socket.tcp(host, port)
         @@h[:in_tcp_socket_2] = {
           s: s.inspect,
           local_address: s.local_address,


### PR DESCRIPTION
Other than backports, maybe, these should be the last ruby 2.7 workarounds we need to make before raising the minimum ruby requirement to 3.1 (#276).