### PR TITLE
📚 Update SASL documentation

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -1242,6 +1242,9 @@ module Net
     # +SASL-IR+ capability, below).  Defaults to the #config value for
     # {sasl_ir}[rdoc-ref:Config#sasl_ir], which defaults to +true+.
     #
+    # The +registry+ kwarg can be used to select the mechanism implementation
+    # from a custom registry.  See SASL.authenticator and SASL::Authenticators.
+    #
     # All other arguments are forwarded to the registered SASL authenticator for
     # the requested mechanism.  <em>The documentation for each individual
     # mechanism must be consulted for its specific parameters.</em>

--- a/lib/net/imap/sasl.rb
+++ b/lib/net/imap/sasl.rb
@@ -114,8 +114,8 @@ module Net
       # messages has not passed integrity checks.
       AuthenticationFailed = Class.new(Error)
 
-      # Indicates that authentication cannot proceed because one of the server's
-      # ended authentication prematurely.
+      # Indicates that authentication cannot proceed because the server ended
+      # authentication prematurely.
       class AuthenticationIncomplete < AuthenticationFailed
         # The success response from the server
         attr_reader :response
@@ -159,7 +159,10 @@ module Net
       # Returns the default global SASL::Authenticators instance.
       def self.authenticators; @authenticators ||= Authenticators.new end
 
-      # Delegates to <tt>registry.new</tt>  See Authenticators#new.
+      # Creates a new SASL authenticator, using SASL::Authenticators#new.
+      #
+      # +registry+ defaults to SASL.authenticators.  All other arguments are
+      # forwarded to to <tt>registry.new</tt>.
       def self.authenticator(*args, registry: authenticators, **kwargs, &block)
         registry.new(*args, **kwargs, &block)
       end

--- a/lib/net/imap/sasl/client_adapter.rb
+++ b/lib/net/imap/sasl/client_adapter.rb
@@ -19,31 +19,53 @@ module Net
       class ClientAdapter
         include ProtocolAdapters::Generic
 
-        attr_reader :client, :command_proc
+        # The client that handles communication with the protocol server.
+        attr_reader :client
 
         # +command_proc+ can used to avoid exposing private methods on #client.
-        # It should run a command with the arguments sent to it, yield each
-        # continuation payload, respond to the server with the result of each
-        # yield, and return the result.  Non-successful results *MUST* raise an
-        # exception.  Exceptions in the block *MUST* cause the command to fail.
+        # It's value is set by the block that is passed to ::new, and it is used
+        # by the default implementation of #run_command.  Subclasses that
+        # override #run_command may use #command_proc for any other purpose they
+        # find useful.
         #
-        # Subclasses that override #run_command may use #command_proc for
-        # other purposes.
+        # In the default implementation of #run_command, command_proc is called
+        # with the protocols authenticate +command+ name, the +mechanism+ name,
+        # an _optional_ +initial_response+ argument, and a +continuations+
+        # block.  command_proc must run the protocol command with the arguments
+        # sent to it, _yield_ the payload of each continuation, respond to the
+        # continuation with the result of each _yield_, and _return_ the
+        # command's successful result.  Non-successful results *MUST* raise
+        # an exception.
+        attr_reader :command_proc
+
+        # By default, this simply sets the #client and #command_proc attributes.
+        # Subclasses may override it, for example: to set the appropriate
+        # command_proc automatically.
         def initialize(client, &command_proc)
           @client, @command_proc = client, command_proc
         end
 
-        # Delegates to AuthenticationExchange.authenticate.
+        # Attempt to authenticate #client to the server.
+        #
+        # By default, this simply delegates to
+        # AuthenticationExchange.authenticate.
         def authenticate(...) AuthenticationExchange.authenticate(self, ...) end
 
-        # Do the protocol and server both support an initial response?
+        # Do the protocol, server, and client all support an initial response?
+        #
+        # By default, this simply delegates to <tt>client.sasl_ir_capable?</tt>.
         def sasl_ir_capable?; client.sasl_ir_capable? end
 
         # Does the server advertise support for the mechanism?
+        #
+        # By default, this simply delegates to <tt>client.auth_capable?</tt>.
         def auth_capable?(mechanism); client.auth_capable?(mechanism) end
 
-        # Runs the authenticate command with +mechanism+ and +initial_response+.
-        # When +initial_response+ is nil, an initial response must NOT be sent.
+        # Calls command_proc with +command_name+ (see
+        # SASL::ProtocolAdapters::Generic#command_name),
+        # +mechanism+, +initial_response+, and a +continuations_handler+ block.
+        # The +initial_response+ is optional; when it's nil, it won't be sent to
+        # command_proc.
         #
         # Yields each continuation payload, responds to the server with the
         # result of each yield, and returns the result.  Non-successful results
@@ -51,10 +73,10 @@ module Net
         # command to fail.
         #
         # Subclasses that override this may use #command_proc differently.
-        def run_command(mechanism, initial_response = nil, &block)
+        def run_command(mechanism, initial_response = nil, &continuations_handler)
           command_proc or raise Error, "initialize with block or override"
           args = [command_name, mechanism, initial_response].compact
-          command_proc.call(*args, &block)
+          command_proc.call(*args, &continuations_handler)
         end
 
         # Returns an array of server responses errors raised by run_command.
@@ -62,9 +84,13 @@ module Net
         def response_errors; [] end
 
         # Drop the connection gracefully.
+        #
+        # By default, this simply delegates to <tt>client.drop_connection</tt>.
         def drop_connection;  client.drop_connection end
 
         # Drop the connection abruptly.
+        #
+        # By default, this simply delegates to <tt>client.drop_connection!</tt>.
         def drop_connection!; client.drop_connection! end
       end
     end


### PR DESCRIPTION
This mostly updates the rdoc for `SASL::AuthenticationExchange` and `SASL::ClientAdapter`.  I'm working towards the finishing bits for #194, but all of these docs should be accurate without any changes.