### PR TITLE
♻️ Extract SASL::Authenticators#normalize_name

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -1342,7 +1342,7 @@ module Net
     def authenticate(mechanism, *creds,
                      sasl_ir: config.sasl_ir,
                      **props, &callback)
-      mechanism = mechanism.to_s.tr("_", "-").upcase
+      mechanism = SASL::Authenticators.normalize_name(mechanism)
       authenticator = SASL.authenticator(mechanism, *creds, **props, &callback)
       cmdargs = ["AUTHENTICATE", mechanism]
       if sasl_ir && capable?("SASL-IR") && auth_capable?(mechanism) &&

--- a/lib/net/imap/sasl/authentication_exchange.rb
+++ b/lib/net/imap/sasl/authentication_exchange.rb
@@ -82,7 +82,7 @@ module Net
 
         def initialize(client, mechanism, authenticator, sasl_ir: true)
           @client = client
-          @mechanism = -mechanism.to_s.upcase.tr(?_, ?-)
+          @mechanism = Authenticators.normalize_name(mechanism)
           @authenticator = authenticator
           @sasl_ir = sasl_ir
           @processed = false

--- a/test/net/imap/test_imap_authenticators.rb
+++ b/test/net/imap/test_imap_authenticators.rb
@@ -5,6 +5,13 @@ require "test/unit"
 
 class IMAPAuthenticatorsTest < Test::Unit::TestCase
 
+  test "SASL::Authenticators.normalize_name" do
+    authenticators = Net::IMAP::SASL::Authenticators
+    assert_equal "FOO-BAR-BAZ", authenticators.normalize_name(:foo_bar_baz)
+    assert_equal "SCRAM-SHA1-PLUS", authenticators.normalize_name(:scram_sha1_plus)
+    assert_equal "PLAIN", authenticators.normalize_name("pLAin")
+  end
+
   def test_net_imap_authenticator_deprecated
     assert_warn(/Net::IMAP\.authenticator .+deprecated./) do
       Net::IMAP.authenticator("PLAIN", "user", "pass")


### PR DESCRIPTION
This was used in _six_ different places, so it's better to DRY up the implementation.