### PR TITLE
🐛 Fix #header_fld_name to handle quoted strings correctly

### DIFF
--- a/lib/net/imap/response_parser.rb
+++ b/lib/net/imap/response_parser.rb
@@ -1339,7 +1339,8 @@ module Net
         assert_no_lookahead
         start = @pos
         astring
-        @str[start...@pos - 1]
+        end_pos = @token ? @pos - 1 : @pos
+        @str[start...end_pos]
       end
 
       # mailbox-data    =  "FLAGS" SP flag-list / "LIST" SP mailbox-list /

--- a/test/net/imap/fixtures/response_parser/fetch_responses.yml
+++ b/test/net/imap/fixtures/response_parser/fetch_responses.yml
@@ -61,6 +61,19 @@
             xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\r\n\r\n"
       raw_data: *test_fetch_msg_att_HEADER_FIELDS
 
+  test_fetch_msg_att_HEADER.FIELDS_quoted:
+    :response: &test_fetch_msg_att_HEADER_FIELDS_quoted
+      "* 10 FETCH (BODY[HEADER.FIELDS (\"Content-Type\")] {95}\r\nContent-Type: multipart/alternative;\r\n
+        boundary=\"--==_mimepart_66cfb08b4f249_34306b61811e5\"\r\n\r\n)\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: FETCH
+      data: !ruby/struct:Net::IMAP::FetchData
+        seqno: 10
+        attr:
+          "BODY[HEADER.FIELDS (\"Content-Type\")]": "Content-Type: multipart/alternative;\r\n
+            boundary=\"--==_mimepart_66cfb08b4f249_34306b61811e5\"\r\n\r\n"
+      raw_data: *test_fetch_msg_att_HEADER_FIELDS_quoted
+
   test_fetch_msg_att_HEADER.FIELDS.NOT:
     :response: &test_fetch_msg_att_HEADER_FIELDS_NOT
       "* 20368 FETCH (BODY[HEADER.FIELDS.NOT (Received DKIM-Signature List-Unsubscribe


### PR DESCRIPTION
## Summary

If a header field name is quoted, `ResponseParser#header_fld_name` drops the closing quotation mark.


## Reprodusing code

```ruby
parser = Net::IMAP::ResponseParser.new

parser.instance_variable_set("@str", %Q|"CONTENT-LOCATION")|)
parser.instance_variable_set("@pos", 0)
parser.instance_variable_set("@lex_state", Net::IMAP::ResponseParser::EXPR_BEG)

parser.send(:header_fld_name)
```

Expected: `"\"CONTENT-LOCATION\""`
Actual: `"\"CONTENT-LOCATION"`


## Cause

`header_fld_name` extract the raw encoded value using `@str` and `@pos`.  `header_fld_name` expects `astring` to lookahead a space or a closing parenthesis but if the field name is quoted, it calls `string` method and it doesn't lookahead a token.


## Fix

Adjust the range to extract depending on whether a token is looked ahead or not.
