### PR TITLE
♻️ Use Integer.try_convert (new in ruby 3.1+)

### DIFF
--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -1284,8 +1284,7 @@ module Net
       # String, Set, Array, or... any type of object.
       def input_try_convert(input)
         SequenceSet.try_convert(input) ||
-          # Integer.try_convert(input) || # ruby 3.1+
-          input.respond_to?(:to_int) && Integer(input.to_int) ||
+          Integer.try_convert(input) ||
           String.try_convert(input) ||
           input
       end


### PR DESCRIPTION
Now that the minimum ruby version is v3.1.0, we can use `Integer.try_convert`.  This code was originally written using `Integer.try_convert`, but had to be changed for backward compatibility with ruby 2.7.