### PR TITLE
📚 SequenceSet API is considered stable now

### DIFF
--- a/lib/net/imap/data_encoding.rb
+++ b/lib/net/imap/data_encoding.rb
@@ -186,7 +186,7 @@ module Net
 
       # Ensure argument is 'number' or raise DataFormatError
       def ensure_number(num)
-        return if valid_number?(num)
+        return num if valid_number?(num)
 
         msg = "number must be unsigned 32-bit integer: #{num}"
         raise DataFormatError, msg
@@ -194,7 +194,7 @@ module Net
 
       # Ensure argument is 'nz_number' or raise DataFormatError
       def ensure_nz_number(num)
-        return if valid_nz_number?(num)
+        return num if valid_nz_number?(num)
 
         msg = "nz_number must be non-zero unsigned 32-bit integer: #{num}"
         raise DataFormatError, msg
@@ -202,7 +202,7 @@ module Net
 
       # Ensure argument is 'mod_sequence_value' or raise DataFormatError
       def ensure_mod_sequence_value(num)
-        return if valid_mod_sequence_value?(num)
+        return num if valid_mod_sequence_value?(num)
 
         msg = "mod_sequence_value must be unsigned 64-bit integer: #{num}"
         raise DataFormatError, msg

--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -1406,12 +1406,11 @@ module Net
       end
 
       def nz_number(num)
-        case num
-        when Integer, /\A[1-9]\d*\z/ then num = Integer(num)
-        else raise DataFormatError, "%p is not a valid nz-number" % [num]
-        end
-        NumValidator.ensure_nz_number(num)
-        num
+        String === num && !/\A[1-9]\d*\z/.match?(num) and
+          raise DataFormatError, "%p is not a valid nz-number" % [num]
+        NumValidator.ensure_nz_number Integer num
+      rescue TypeError # To catch errors from Integer()
+        raise DataFormatError, $!.message
       end
 
       # intentionally defined after the class implementation

--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -37,8 +37,8 @@ module Net
     #
     # SequenceSet.new may receive a single optional argument: a non-zero 32 bit
     # unsigned integer, a range, a <tt>sequence-set</tt> formatted string,
-    # another sequence set, a Set (containing only numbers), or an enumerable
-    # containing any of these (which may be nested).
+    # another sequence set, a Set (containing only numbers), or an Array
+    # containing any of these (array inputs may be nested).
     #
     #     set = Net::IMAP::SequenceSet.new(1)
     #     set.valid_string  #=> "1"
@@ -290,8 +290,7 @@ module Net
       private_constant :STAR_INT, :STARS
 
       COERCIBLE = ->{ _1.respond_to? :to_sequence_set }
-      ENUMABLE  = ->{ _1.respond_to?(:each) && _1.respond_to?(:empty?) }
-      private_constant :COERCIBLE, :ENUMABLE
+      private_constant :COERCIBLE
 
       class << self
 
@@ -1273,7 +1272,7 @@ module Net
         when String      then str_to_tuples obj
         when SequenceSet then obj.tuples
         when Set         then obj.map      { to_tuple_int _1 }
-        when ENUMABLE    then obj.flat_map { input_to_tuples _1 }
+        when Array       then obj.flat_map { input_to_tuples _1 }
         when nil         then []
         else
           raise DataFormatError,

--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -14,13 +14,6 @@ module Net
     # receive a SequenceSet as an argument, for example IMAP#search, IMAP#fetch,
     # and IMAP#store.
     #
-    # == EXPERIMENTAL API
-    #
-    # SequenceSet is currently experimental.  Only two methods, ::[] and
-    # #valid_string, are considered stable.  Although the API isn't expected to
-    # change much, any other methods may be removed or changed without
-    # deprecation.
-    #
     # == Creating sequence sets
     #
     # SequenceSet.new with no arguments creates an empty sequence set.  Note

--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -37,7 +37,8 @@ module Net
     #
     # SequenceSet.new may receive a single optional argument: a non-zero 32 bit
     # unsigned integer, a range, a <tt>sequence-set</tt> formatted string,
-    # another sequence set, or an enumerable containing any of these.
+    # another sequence set, a Set (containing only numbers), or an enumerable
+    # containing any of these (which may be nested).
     #
     #     set = Net::IMAP::SequenceSet.new(1)
     #     set.valid_string  #=> "1"
@@ -1271,6 +1272,7 @@ module Net
         when *STARS, Integer, Range then [input_to_tuple(obj)]
         when String      then str_to_tuples obj
         when SequenceSet then obj.tuples
+        when Set         then obj.map      { to_tuple_int _1 }
         when ENUMABLE    then obj.flat_map { input_to_tuples _1 }
         when nil         then []
         else

--- a/test/net/imap/test_sequence_set.rb
+++ b/test/net/imap/test_sequence_set.rb
@@ -99,6 +99,8 @@ class IMAPSequenceSetTest < Test::Unit::TestCase
     assert_raise DataFormatError do SequenceSet.new "2 "         end
     assert_raise DataFormatError do SequenceSet.new "2,"         end
     assert_raise DataFormatError do SequenceSet.new Time.now     end
+    assert_raise DataFormatError do SequenceSet.new Set[1, [2]]  end
+    assert_raise DataFormatError do SequenceSet.new Set[1..20]   end
   end
 
   test ".new, input may be empty" do


### PR DESCRIPTION
SequenceSet's API should now be considered "stable".  This PR updates the SequenceSet documentation, to remove the "experimental" notice at the top.

This PR depends on #319, which makes a minor breaking change to the API.