### PR TITLE
🔒 📚  Improvements and docs for SASL::ClientAdapter

### DIFF
--- a/lib/net/imap/sasl/client_adapter.rb
+++ b/lib/net/imap/sasl/client_adapter.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "forwardable"
+
 module Net
   class IMAP
     module SASL
@@ -23,6 +25,8 @@ module Net
       # possible, ClientAdapter delegates the handling of these requirements to
       # SASL::ProtocolAdapters.
       class ClientAdapter
+        extend Forwardable
+
         include ProtocolAdapters::Generic
 
         # The client that handles communication with the protocol server.
@@ -59,11 +63,17 @@ module Net
         # AuthenticationExchange.authenticate.
         def authenticate(...) AuthenticationExchange.authenticate(self, ...) end
 
+        ##
+        # method: sasl_ir_capable?
         # Do the protocol, server, and client all support an initial response?
-        def sasl_ir_capable?; client.sasl_ir_capable? end
+        def_delegator :client, :sasl_ir_capable?
 
+        ##
+        # method: auth_capable?
+        # call-seq: auth_capable?(mechanism)
+        #
         # Does the server advertise support for the +mechanism+?
-        def auth_capable?(mechanism); client.auth_capable?(mechanism) end
+        def_delegator :client, :auth_capable?
 
         # Calls command_proc with +command_name+ (see
         # SASL::ProtocolAdapters::Generic#command_name),
@@ -83,21 +93,29 @@ module Net
           command_proc.call(*args, &continuations_handler)
         end
 
+        ##
+        # method: host
         # The hostname to which the client connected.
-        def host;             client.host end
+        def_delegator :client, :host
 
+        ##
+        # method: port
         # The destination port to which the client connected.
-        def port;             client.port end
+        def_delegator :client, :port
 
         # Returns an array of server responses errors raised by run_command.
         # Exceptions in this array won't drop the connection.
         def response_errors; [] end
 
+        ##
+        # method: drop_connection
         # Drop the connection gracefully, sending a "LOGOUT" command as needed.
-        def drop_connection;  client.drop_connection end
+        def_delegator :client, :drop_connection
 
+        ##
+        # method: drop_connection!
         # Drop the connection abruptly, closing the socket without logging out.
-        def drop_connection!; client.drop_connection! end
+        def_delegator :client, :drop_connection!
 
       end
     end

--- a/lib/net/imap/sasl/client_adapter.rb
+++ b/lib/net/imap/sasl/client_adapter.rb
@@ -79,6 +79,12 @@ module Net
           command_proc.call(*args, &continuations_handler)
         end
 
+        # The hostname to which the client connected.
+        def host;             client.host end
+
+        # The destination port to which the client connected.
+        def port;             client.port end
+
         # Returns an array of server responses errors raised by run_command.
         # Exceptions in this array won't drop the connection.
         def response_errors; [] end

--- a/lib/net/imap/sasl/protocol_adapters.rb
+++ b/lib/net/imap/sasl/protocol_adapters.rb
@@ -8,7 +8,7 @@ module Net
         # This API is experimental, and may change.
         module Generic
           def command_name;     "AUTHENTICATE" end
-          def service;          raise "Implement in subclass or module" end
+          def service;          "host" end
           def encode_ir(string) string.empty? ? "=" : encode(string) end
           def encode(string)    [string].pack("m0") end
           def decode(string)    string.unpack1("m0") end

--- a/lib/net/imap/sasl/protocol_adapters.rb
+++ b/lib/net/imap/sasl/protocol_adapters.rb
@@ -4,14 +4,72 @@ module Net
   class IMAP
     module SASL
 
+      # SASL::ProtocolAdapters modules are meant to be used as mixins for
+      # SASL::ClientAdapter and its subclasses.  Where the client adapter must
+      # be customized for each client library, the protocol adapter mixin
+      # handles \SASL requirements that are part of the protocol specification,
+      # but not specific to any particular client library.  In particular, see
+      # {RFC4422 §4}[https://www.rfc-editor.org/rfc/rfc4422.html#section-4]
+      #
+      # === Interface
+      #
+      # >>>
+      #   NOTE: This API is experimental, and may change.
+      #
+      # - {#command_name}[rdoc-ref:Generic#command_name] -- The name of the
+      #   command used to to initiate an authentication exchange.
+      # - {#service}[rdoc-ref:Generic#service] -- The GSSAPI service name.
+      # - {#encode_ir}[rdoc-ref:Generic#encode_ir]--Encodes an initial response.
+      # - {#decode}[rdoc-ref:Generic#decode] -- Decodes a server challenge.
+      # - {#encode}[rdoc-ref:Generic#encode] -- Encodes a client response.
+      # - {#cancel_response}[rdoc-ref:Generic#cancel_response] -- The encoded
+      #   client response used to cancel an authentication exchange.
+      #
+      # Other protocol requirements of the \SASL authentication exchange are
+      # handled by SASL::ClientAdapter.
+      #
+      # === Included protocol adapters
+      #
+      # - Generic -- a basic implementation of all of the methods listed above.
+      # - IMAP -- An adapter for the IMAP4 protocol.
+      # - SMTP -- An adapter for the \SMTP protocol with the +AUTH+ capability.
+      # - POP  -- An adapter for the POP3  protocol with the +SASL+ capability.
       module ProtocolAdapters
-        # This API is experimental, and may change.
+        # See SASL::ProtocolAdapters@Interface.
         module Generic
+          # The name of the protocol command used to initiate a \SASL
+          # authentication exchange.
+          #
+          # The generic implementation returns <tt>"AUTHENTICATE"</tt>.
           def command_name;     "AUTHENTICATE" end
+
+          # A service name from the {GSSAPI/Kerberos/SASL Service Names
+          # registry}[https://www.iana.org/assignments/gssapi-service-names/gssapi-service-names.xhtml].
+          #
+          # The generic implementation returns <tt>"host"</tt>, which is the
+          # generic GSSAPI host-based service name.
           def service;          "host" end
+
+          # Encodes an initial response string.
+          #
+          # The generic implementation returns the result of #encode, or returns
+          # <tt>"="</tt> when +string+ is empty.
           def encode_ir(string) string.empty? ? "=" : encode(string) end
+
+          # Encodes a client response string.
+          #
+          # The generic implementation returns the Base64 encoding of +string+.
           def encode(string)    [string].pack("m0") end
+
+          # Decodes a server challenge string.
+          #
+          # The generic implementation returns the Base64 decoding of +string+.
           def decode(string)    string.unpack1("m0") end
+
+          # Returns the message used by the client to abort an authentication
+          # exchange.
+          #
+          # The generic implementation returns <tt>"*"</tt>.
           def cancel_response;  "*" end
         end
 

--- a/lib/net/imap/sasl/protocol_adapters.rb
+++ b/lib/net/imap/sasl/protocol_adapters.rb
@@ -9,8 +9,6 @@ module Net
         module Generic
           def command_name;     "AUTHENTICATE" end
           def service;          raise "Implement in subclass or module" end
-          def host;             client.host end
-          def port;             client.port end
           def encode_ir(string) string.empty? ? "=" : encode(string) end
           def encode(string)    [string].pack("m0") end
           def decode(string)    string.unpack1("m0") end

--- a/lib/net/imap/sasl_adapter.rb
+++ b/lib/net/imap/sasl_adapter.rb
@@ -12,7 +12,6 @@ module Net
 
       def response_errors;          RESPONSE_ERRORS                 end
       def sasl_ir_capable?;         client.capable?("SASL-IR")      end
-      def auth_capable?(mechanism); client.auth_capable?(mechanism) end
       def drop_connection;          client.logout!                  end
       def drop_connection!;         client.disconnect               end
     end


### PR DESCRIPTION
Several minor updates, all related to the SASL::ClientAdapter API:
* Improved `SASL::ClientAdapter` documentation.
* Added documention to `SASL::ProtocolAdapters` and each of the methods in `SASL::ProtocolAdapters::Generic`.
* `#host` and `#port` didn't make sense in `SASL::ProtocolAdapters`.  Moved them to `SASL::ClientAdapter`.
* `#service` returns the generic GSSAPI service name (`"host"`) rather than raise an exception.
* Use Forwardable: almost all of the methods simply delegate to `#client`.
* Delete `IMAP::SASLAdapter#auth_capable?`: the superclass definition is identical.