### PR TITLE
💥🔥 Remove deprecated #client_thread attr_reader

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -944,20 +944,12 @@ module Net
       @sock = tcp_socket(@host, @port)
       start_tls_session if ssl_ctx
       start_imap_connection
-
-      # DEPRECATED: to remove in next version
-      @client_thread = Thread.current
     end
 
     # Returns true after the TLS negotiation has completed and the remote
     # hostname has been verified.  Returns false when TLS has been established
     # but peer verification was disabled.
     def tls_verified?; @tls_verified end
-
-    def client_thread # :nodoc:
-      warn "Net::IMAP#client_thread is deprecated and will be removed soon."
-      @client_thread
-    end
 
     # Disconnects from the server.
     #


### PR DESCRIPTION
I don't know what the original purpose for `#client_thread` was, and it was deprecated by v0.4.0.

There's nothing particularly special about the Thread that created the client instance.  Net::IMAP doesn't use it, clients can use multiple threads, and users of Net::IMAP can track this for themselves if they need to.