### PR TITLE
🔥 Drop deprecated BodyType structs

### DIFF
--- a/test/net/imap/test_regexps.rb
+++ b/test/net/imap/test_regexps.rb
@@ -26,7 +26,6 @@ class IMAPRegexpsTest < Test::Unit::TestCase
       Net::IMAP,
       exclude_map: {
         Net::IMAP => %i[
-          BodyTypeAttachment BodyTypeExtension
           PlainAuthenticator
           XOauth2Authenticator
         ], # deprecated


### PR DESCRIPTION
These were always a bit buggy, and they've been marked as `deprecated_constant` since v0.4, so hopefully there won't too much impact on anyone.