### PR TITLE
🐛 Fix SequenceSet[input] for a SequenceSet input

### DIFF
--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -304,7 +304,7 @@ module Net
         # Use ::new to create a mutable or empty SequenceSet.
         def [](first, *rest)
           if rest.empty?
-            if first.is_a?(SequenceSet) && set.frozen? && set.valid?
+            if first.is_a?(SequenceSet) && first.frozen? && first.valid?
               first
             else
               new(first).validate.freeze

--- a/test/net/imap/test_sequence_set.rb
+++ b/test/net/imap/test_sequence_set.rb
@@ -101,6 +101,11 @@ class IMAPSequenceSetTest < Test::Unit::TestCase
     assert_raise DataFormatError do SequenceSet.new Time.now     end
   end
 
+  test ".[frozen SequenceSet] returns that SequenceSet" do
+    frozen_seqset = SequenceSet[123..456]
+    assert_same frozen_seqset, SequenceSet[frozen_seqset]
+  end
+
   test ".new, input may be empty" do
     assert_empty SequenceSet.new
     assert_empty SequenceSet.new []


### PR DESCRIPTION
I'm surprised there was no test for this!

(This is a backport of #326 to `v0.4-stable`)