### PR TITLE
✨ Add `#extract_responses` method

### DIFF
--- a/test/net/imap/fake_server.rb
+++ b/test/net/imap/fake_server.rb
@@ -103,6 +103,9 @@ class Net::IMAP::FakeServer
   # See CommandRouter#on
   def on(...) connection&.on(...) end
 
+  # See Connection#unsolicited
+  def unsolicited(...) @mutex.synchronize { connection&.unsolicited(...) } end
+
   private
 
   attr_reader :tcp_server, :connection

--- a/test/net/imap/fake_server/connection.rb
+++ b/test/net/imap/fake_server/connection.rb
@@ -19,6 +19,7 @@ class Net::IMAP::FakeServer
 
     def commands; state.commands end
     def on(...) router.on(...) end
+    def unsolicited(...) writer.untagged(...) end
 
     def run
       writer.greeting

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -1423,4 +1423,16 @@ EOF
   def server_addr
     Addrinfo.tcp("localhost", 0).ip_address
   end
+
+  def wait_for_response_count(imap, type:, count:,
+                              timeout: 0.5, interval: 0.001)
+    deadline = Time.now + timeout
+    loop do
+      current_count = imap.responses(type, &:size)
+      break :count    if count <= current_count
+      break :deadline if deadline < Time.now
+      sleep interval
+    end
+  end
+
 end

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -1110,7 +1110,7 @@ EOF
     end
   end
 
-  def test_responses
+  test "#responses" do
     with_fake_server do |server, imap|
       # responses available before SELECT/EXAMINE
       assert_equal(%w[IMAP4REV1 NAMESPACE MOVE IDLE UTF8=ACCEPT],
@@ -1144,7 +1144,7 @@ EOF
     end
   end
 
-  def test_clear_responses
+  test "#clear_responses" do
     with_fake_server do |server, imap|
       resp = imap.select "INBOX"
       assert_equal([Net::IMAP::TaggedResponse, "RUBY0001", "OK"],
@@ -1165,6 +1165,49 @@ EOF
       assert_equal(3, responses["PERMANENTFLAGS"].last&.size)
       assert_equal({}, imap.responses(&:itself))
       assert_equal({}, imap.clear_responses)
+    end
+  end
+
+  test "#extract_responses" do
+    with_fake_server do |server, imap|
+      resp = imap.select "INBOX"
+      assert_equal([Net::IMAP::TaggedResponse, "RUBY0001", "OK"],
+                   [resp.class, resp.tag, resp.name])
+      # Need to send a string type and a block
+      assert_raise(ArgumentError) do imap.extract_responses { true } end
+      assert_raise(ArgumentError) do imap.extract_responses(nil) { true } end
+      assert_raise(ArgumentError) do imap.extract_responses("OK") end
+      # matching nothing
+      assert_equal([172], imap.responses("EXISTS", &:dup))
+      assert_equal([],    imap.extract_responses("EXISTS") { String === _1 })
+      assert_equal([172], imap.responses("EXISTS", &:dup))
+      # matching everything
+      assert_equal([172], imap.responses("EXISTS", &:dup))
+      assert_equal([172], imap.extract_responses("EXISTS", &:even?))
+      assert_equal([],    imap.responses("EXISTS", &:dup))
+      # matching some
+      server.unsolicited("101 FETCH (UID 1111 FLAGS (\\Seen))")
+      server.unsolicited("102 FETCH (UID 2222 FLAGS (\\Seen \\Flagged))")
+      server.unsolicited("103 FETCH (UID 3333 FLAGS (\\Deleted))")
+      wait_for_response_count(imap, type: "FETCH", count: 3)
+
+      result = imap.extract_responses("FETCH") { _1.flags.include?(:Flagged) }
+      assert_equal(
+        [
+          Net::IMAP::FetchData.new(
+            102, {"UID" => 2222, "FLAGS" => [:Seen, :Flagged]}
+          ),
+        ],
+        result,
+      )
+      assert_equal 2, imap.responses("FETCH", &:count)
+
+      result = imap.extract_responses("FETCH") { _1.flags.include?(:Deleted) }
+      assert_equal(
+        [Net::IMAP::FetchData.new(103, {"UID" => 3333, "FLAGS" => [:Deleted]})],
+        result
+      )
+      assert_equal 1, imap.responses("FETCH", &:count)
     end
   end
 


### PR DESCRIPTION
This adds `Net::IMAP#extract_responses`, which behaves similarly to ActiveSupport's [Array#extract!](https://api.rubyonrails.org/classes/Array.html#method-i-extract-21) (which is a method I _often_ wish we had in ruby core!).

Yields all of the unhandled `#responses` for a single response type.  Removes and returns the responses for which the block returns a true value.

Extracting responses is synchronized with other threads.  The lock is released before returning.