### PR TITLE
🥅 Improve SequenceSet frozen errors

### DIFF
--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -675,6 +675,7 @@ module Net
       # Unlike #add, #merge, or #union, the new value is appended to #string.
       # This may result in a #string which has duplicates or is out-of-order.
       def append(object)
+        modifying!
         tuple = input_to_tuple object
         entry = tuple_to_str tuple
         tuple_add tuple
@@ -1310,6 +1311,12 @@ module Net
           range.include?(min) || range.include?(max) || (min..max).cover?(range)
       end
 
+      def modifying!
+        if frozen?
+          raise FrozenError, "can't modify frozen #{self.class}: %p" % [self]
+        end
+      end
+
       def tuples_add(tuples)      tuples.each do tuple_add _1      end; self end
       def tuples_subtract(tuples) tuples.each do tuple_subtract _1 end; self end
 
@@ -1324,6 +1331,7 @@ module Net
       #   ---------??===lower==|--|==|----|===upper===|-- join until upper
       #   ---------??===lower==|--|==|--|=====upper===|-- join to upper
       def tuple_add(tuple)
+        modifying!
         min, max = tuple
         lower, lower_idx = tuple_gte_with_index(min - 1)
         if    lower.nil?              then tuples << tuple
@@ -1360,6 +1368,7 @@ module Net
       # -------??=====lower====|--|====|---|====upper====|-- 7. delete until
       # -------??=====lower====|--|====|--|=====upper====|-- 8. delete and trim
       def tuple_subtract(tuple)
+        modifying!
         min, max = tuple
         lower, idx = tuple_gte_with_index(min)
         if    lower.nil?        then nil # case 1.

--- a/test/net/imap/test_sequence_set.rb
+++ b/test/net/imap/test_sequence_set.rb
@@ -57,6 +57,32 @@ class IMAPSequenceSetTest < Test::Unit::TestCase
     assert_equal set, set.freeze
   end
 
+  data "#clear",       :clear
+  data "#replace seq", ->{ _1.replace SequenceSet[1] }
+  data "#replace num", ->{ _1.replace   1 }
+  data "#replace str", ->{ _1.replace  ?1 }
+  data "#string=",     ->{ _1.string = ?1 }
+  data "#add",         ->{ _1.add       1 }
+  data "#add?",        ->{ _1.add?      1 }
+  data "#<<",          ->{ _1 <<        1 }
+  data "#append",      ->{ _1.append    1 }
+  data "#delete",      ->{ _1.delete    3 }
+  data "#delete?",     ->{ _1.delete?   3 }
+  data "#delete_at",   ->{ _1.delete_at 3 }
+  data "#slice!",      ->{ _1.slice!    1 }
+  data "#merge",       ->{ _1.merge     1 }
+  data "#subtract",    ->{ _1.subtract  1 }
+  data "#limit!",      ->{ _1.limit! max: 10 }
+  data "#complement!", :complement!
+  data "#normalize!",  :normalize!
+  test "frozen error message" do |modification|
+    set = SequenceSet["2:4,7:11,99,999"]
+    msg = "can't modify frozen Net::IMAP::SequenceSet: %p" % [set]
+    assert_raise_with_message FrozenError, msg do
+      modification.to_proc.(set)
+    end
+  end
+
   %i[clone dup].each do |method|
     test "##{method}" do
       orig = SequenceSet.new "2:4,7:11,99,999"


### PR DESCRIPTION
Previously, SequenceSet modification methods would raise a frozen error when it updated its internal data structure (currently implemented as an array of arrays), which was "can't modify frozen Array: [int, int]". This was unexpected, confusing, and misleading.

This changes the SequenceSet modification methods to raise the expected FrozenError _prior_ to attempting to modify the internal data structure.