### PR TITLE
✨ Add basic ESearch support

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3277,6 +3277,10 @@ module Net
         esearch = false
       in [_, Array[RETURN_WHOLE, _, *] | RETURN_START]
         raise ArgumentError, "conflicting return options"
+      in [_, Array[RETURN_WHOLE, _, *]] # workaround for https://bugs.ruby-lang.org/issues/20956
+        raise ArgumentError, "conflicting return options"
+      in [_, RETURN_START]              # workaround for https://bugs.ruby-lang.org/issues/20956
+        raise ArgumentError, "conflicting return options"
       in [return_opts, keys]
         return_opts = convert_return_opts(return_opts)
         esearch = true

--- a/lib/net/imap/esearch_result.rb
+++ b/lib/net/imap/esearch_result.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+module Net
+  class IMAP
+    # An "extended search" response (+ESEARCH+).  ESearchResult should be
+    # returned (instead of SearchResult) by IMAP#search, IMAP#uid_search,
+    # IMAP#sort, and IMAP#uid_sort under any of the following conditions:
+    #
+    # * Return options were specified for IMAP#search or IMAP#uid_search.
+    #   The server must support a search extension which allows
+    #   RFC4466[https://www.rfc-editor.org/rfc/rfc4466.html] +return+ options,
+    #   such as +ESEARCH+, +PARTIAL+, or +IMAP4rev2+.
+    # * Return options were specified for IMAP#sort or IMAP#uid_sort.
+    #   The server must support the +ESORT+ extension
+    #   {[RFC5267]}[https://www.rfc-editor.org/rfc/rfc5267.html#section-3].
+    #
+    #   *NOTE:* IMAP#search and IMAP#uid_search do not support +ESORT+ yet.
+    # * The server supports +IMAP4rev2+ but _not_ +IMAP4rev1+, or +IMAP4rev2+
+    #   has been enabled.  +IMAP4rev2+ requires +ESEARCH+ results.
+    #
+    # Note that some servers may claim to support a search extension which
+    # requires an +ESEARCH+ result, such as +PARTIAL+, but still only return a
+    # +SEARCH+ result when +return+ options are specified.
+    #
+    # Some search extensions may result in the server sending ESearchResult
+    # responses after the initiating command has completed.  Use
+    # IMAP#add_response_handler to handle these responses.
+    class ESearchResult < Data.define(:tag, :uid, :data)
+      def initialize(tag: nil, uid: nil, data: nil)
+        tag  => String       | nil; tag = -tag if tag
+        uid  => true | false | nil; uid = !!uid
+        data => Array        | nil; data ||= []; data.freeze
+        super
+      end
+
+      # :call-seq: to_a -> Array of integers
+      #
+      # When #all contains a SequenceSet of message sequence
+      # numbers or UIDs, +to_a+ returns that set as an array of integers.
+      #
+      # When #all is +nil+, either because the server
+      # returned no results or because +ALL+ was not included in
+      # the IMAP#search +RETURN+ options, #to_a returns an empty array.
+      #
+      # Note that SearchResult also implements +to_a+, so it can be used without
+      # checking if the server returned +SEARCH+ or +ESEARCH+ data.
+      def to_a; all&.numbers || [] end
+
+      ##
+      # attr_reader: tag
+      #
+      # The tag string for the command that caused this response to be returned.
+      #
+      # When +nil+, this response was not caused by a particular command.
+
+      ##
+      # attr_reader: uid
+      #
+      # Indicates whether #data in this response refers to UIDs (when +true+) or
+      # to message sequence numbers (when +false+).
+
+      ##
+      alias uid? uid
+
+      ##
+      # attr_reader: data
+      #
+      # Search return data, as an array of <tt>[name, value]</tt> pairs.  Most
+      # return data corresponds to a search +return+ option with the same name.
+      #
+      # Note that some return data names may be used more than once per result.
+      #
+      # This data can be more simply retrieved by #min, #max, #all, #count,
+      # #modseq, and other methods.
+
+      # :call-seq: min -> integer or nil
+      #
+      # The lowest message number/UID that satisfies the SEARCH criteria.
+      #
+      # Returns +nil+ when the associated search command has no results, or when
+      # the +MIN+ return option wasn't specified.
+      #
+      # Requires +ESEARCH+ {[RFC4731]}[https://www.rfc-editor.org/rfc/rfc4731.html#section-3.1] or
+      # +IMAP4rev2+ {[RFC9051]}[https://www.rfc-editor.org/rfc/rfc9051.html#section-7.3.4].
+      def min;        data.assoc("MIN")&.last        end
+
+      # :call-seq: max -> integer or nil
+      #
+      # The highest message number/UID that satisfies the SEARCH criteria.
+      #
+      # Returns +nil+ when the associated search command has no results, or when
+      # the +MAX+ return option wasn't specified.
+      #
+      # Requires +ESEARCH+ {[RFC4731]}[https://www.rfc-editor.org/rfc/rfc4731.html#section-3.1] or
+      # +IMAP4rev2+ {[RFC9051]}[https://www.rfc-editor.org/rfc/rfc9051.html#section-7.3.4].
+      def max;        data.assoc("MAX")&.last        end
+
+      # :call-seq: all -> sequence set or nil
+      #
+      # A SequenceSet containing all message sequence numbers or UIDs that
+      # satisfy the SEARCH criteria.
+      #
+      # Returns +nil+ when the associated search command has no results, or when
+      # the +ALL+ return option was not specified but other return options were.
+      #
+      # Requires +ESEARCH+ {[RFC4731]}[https://www.rfc-editor.org/rfc/rfc4731.html#section-3.1] or
+      # +IMAP4rev2+ {[RFC9051]}[https://www.rfc-editor.org/rfc/rfc9051.html#section-7.3.4].
+      #
+      # See also: #to_a
+      def all;        data.assoc("ALL")&.last        end
+
+      # :call-seq: count -> integer or nil
+      #
+      # Returns the number of messages that satisfy the SEARCH criteria.
+      #
+      # Returns +nil+ when the associated search command has no results, or when
+      # the +COUNT+ return option wasn't specified.
+      #
+      # Requires +ESEARCH+ {[RFC4731]}[https://www.rfc-editor.org/rfc/rfc4731.html#section-3.1] or
+      # +IMAP4rev2+ {[RFC9051]}[https://www.rfc-editor.org/rfc/rfc9051.html#section-7.3.4].
+      def count;      data.assoc("COUNT")&.last      end
+
+      # :call-seq: modseq -> integer or nil
+      #
+      # The highest +mod-sequence+ of all messages being returned.
+      #
+      # Returns +nil+ when the associated search command has no results, or when
+      # the +MODSEQ+ search criterion wasn't specified.
+      #
+      # Note that there is no search +return+ option for +MODSEQ+.  It will be
+      # returned whenever the +CONDSTORE+ extension has been enabled.  Using the
+      # +MODSEQ+ search criteria will implicitly enable +CONDSTORE+.
+      #
+      # Requires +CONDSTORE+ {[RFC7162]}[https://www.rfc-editor.org/rfc/rfc7162.html]
+      # and +ESEARCH+ {[RFC4731]}[https://www.rfc-editor.org/rfc/rfc4731.html#section-3.2].
+      def modseq;     data.assoc("MODSEQ")&.last     end
+
+    end
+  end
+end

--- a/lib/net/imap/response_data.rb
+++ b/lib/net/imap/response_data.rb
@@ -2,6 +2,7 @@
 
 module Net
   class IMAP < Protocol
+    autoload :ESearchResult,    "#{__dir__}/esearch_result"
     autoload :FetchData,        "#{__dir__}/fetch_data"
     autoload :SearchResult,     "#{__dir__}/search_result"
     autoload :SequenceSet,      "#{__dir__}/sequence_set"

--- a/lib/net/imap/response_parser/parser_utils.rb
+++ b/lib/net/imap/response_parser/parser_utils.rb
@@ -185,6 +185,11 @@ module Net
           @str[@pos, str.length] == str
         end
 
+        def peek_re?(re)
+          assert_no_lookahead if Net::IMAP.debug
+          re.match?(@str, @pos)
+        end
+
         def peek_re(re)
           assert_no_lookahead if config.debug?
           re.match(@str, @pos)

--- a/test/lib/helper.rb
+++ b/test/lib/helper.rb
@@ -42,4 +42,16 @@ class Test::Unit::TestCase
       sleep interval
     end
   end
+
+  # Copied from minitest
+  def assert_pattern
+    flunk "assert_pattern requires a block to capture errors." unless block_given?
+    assert_block do
+      yield
+      true
+    rescue NoMatchingPatternError => e
+      flunk e.message
+    end
+  end
+
 end

--- a/test/net/imap/fixtures/response_parser/esearch_responses.yml
+++ b/test/net/imap/fixtures/response_parser/esearch_responses.yml
@@ -1,0 +1,331 @@
+---
+:tests:
+  rfc9051_6.4.4_ESEARCH_example_1:
+    :response: "* ESEARCH (TAG \"A282\") MIN 2 COUNT 3\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: ESEARCH
+      data: !ruby/object:Net::IMAP::ESearchResult
+        tag: A282
+        uid: false
+        data:
+        - - MIN
+          - 2
+        - - COUNT
+          - 3
+      raw_data: "* ESEARCH (TAG \"A282\") MIN 2 COUNT 3\r\n"
+
+  rfc9051_6.4.4_ESEARCH_example_2:
+    :response: "* ESEARCH (TAG \"A283\") ALL 2,10:11\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: ESEARCH
+      data: !ruby/object:Net::IMAP::ESearchResult
+        tag: A283
+        uid: false
+        data:
+        - - ALL
+          - !ruby/object:Net::IMAP::SequenceSet
+            string: 2,10:11
+            tuples:
+            - - 2
+              - 2
+            - - 10
+              - 11
+      raw_data: "* ESEARCH (TAG \"A283\") ALL 2,10:11\r\n"
+
+  rfc9051_6.4.4_ESEARCH_example_3:
+    :response: "* ESEARCH (TAG \"A284\")\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: ESEARCH
+      data: !ruby/object:Net::IMAP::ESearchResult
+        tag: A284
+        uid: false
+        data: []
+      raw_data: "* ESEARCH (TAG \"A284\")\r\n"
+
+  rfc9051_6.4.4_ESEARCH_example_4:
+    :response: "* ESEARCH (TAG \"A285\") ALL 43\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: ESEARCH
+      data: !ruby/object:Net::IMAP::ESearchResult
+        tag: A285
+        uid: false
+        data:
+        - - ALL
+          - !ruby/object:Net::IMAP::SequenceSet
+            string: '43'
+            tuples:
+            - - 43
+              - 43
+      raw_data: "* ESEARCH (TAG \"A285\") ALL 43\r\n"
+
+  rfc9051_6.4.4_ESEARCH_example_5:
+    :response: "* ESEARCH (TAG \"A284\") MIN 4\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: ESEARCH
+      data: !ruby/object:Net::IMAP::ESearchResult
+        tag: A284
+        uid: false
+        data:
+        - - MIN
+          - 4
+      raw_data: "* ESEARCH (TAG \"A284\") MIN 4\r\n"
+
+  rfc9051_6.4.4_ESEARCH_example_6:
+    :response: "* ESEARCH (TAG \"A285\") UID MIN 7 MAX 3800\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: ESEARCH
+      data: !ruby/object:Net::IMAP::ESearchResult
+        tag: A285
+        uid: true
+        data:
+        - - MIN
+          - 7
+        - - MAX
+          - 3800
+      raw_data: "* ESEARCH (TAG \"A285\") UID MIN 7 MAX 3800\r\n"
+
+  rfc9051_6.4.4_ESEARCH_example_7:
+    :response: "* ESEARCH (TAG \"A286\") COUNT 15\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: ESEARCH
+      data: !ruby/object:Net::IMAP::ESearchResult
+        tag: A286
+        uid: false
+        data:
+        - - COUNT
+          - 15
+      raw_data: "* ESEARCH (TAG \"A286\") COUNT 15\r\n"
+
+  rfc9051_6.4.4.4_ESEARCH_example_1:
+    :response: "* ESEARCH (TAG \"A301\") UID ALL 17,900,901\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: ESEARCH
+      data: !ruby/object:Net::IMAP::ESearchResult
+        tag: A301
+        uid: true
+        data:
+        - - ALL
+          - !ruby/object:Net::IMAP::SequenceSet
+            string: '17,900,901'
+            tuples:
+            - - 17
+              - 17
+            - - 900
+              - 901
+      raw_data: "* ESEARCH (TAG \"A301\") UID ALL 17,900,901\r\n"
+
+  rfc9051_6.4.4.4_ESEARCH_example_2:
+    :response: "* ESEARCH (TAG \"P283\") ALL 882,1102,3003,3005:3006\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: ESEARCH
+      data: !ruby/object:Net::IMAP::ESearchResult
+        tag: P283
+        uid: false
+        data:
+        - - ALL
+          - !ruby/object:Net::IMAP::SequenceSet
+            string: 882,1102,3003,3005:3006
+            tuples:
+            - - 882
+              - 882
+            - - 1102
+              - 1102
+            - - 3003
+              - 3003
+            - - 3005
+              - 3006
+      raw_data: "* ESEARCH (TAG \"P283\") ALL 882,1102,3003,3005:3006\r\n"
+
+  rfc9051_6.4.4.4_ESEARCH_example_3:
+    :response: "* ESEARCH (TAG \"G283\") ALL 3:15,27,29:103\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: ESEARCH
+      data: !ruby/object:Net::IMAP::ESearchResult
+        tag: G283
+        uid: false
+        data:
+        - - ALL
+          - !ruby/object:Net::IMAP::SequenceSet
+            string: 3:15,27,29:103
+            tuples:
+            - - 3
+              - 15
+            - - 27
+              - 27
+            - - 29
+              - 103
+      raw_data: "* ESEARCH (TAG \"G283\") ALL 3:15,27,29:103\r\n"
+
+  rfc9051_6.4.4.4_ESEARCH_example_4:
+    :response: "* ESEARCH (TAG \"C283\") ALL 2,10:15,21\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: ESEARCH
+      data: !ruby/object:Net::IMAP::ESearchResult
+        tag: C283
+        uid: false
+        data:
+        - - ALL
+          - !ruby/object:Net::IMAP::SequenceSet
+            string: 2,10:15,21
+            tuples:
+            - - 2
+              - 2
+            - - 10
+              - 15
+            - - 21
+              - 21
+      raw_data: "* ESEARCH (TAG \"C283\") ALL 2,10:15,21\r\n"
+
+  rfc9051_6.4.4.4_ESEARCH_example_5:
+    :response: "* ESEARCH (TAG \"C284\") MIN 2\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: ESEARCH
+      data: !ruby/object:Net::IMAP::ESearchResult
+        tag: C284
+        uid: false
+        data:
+        - - MIN
+          - 2
+      raw_data: "* ESEARCH (TAG \"C284\") MIN 2\r\n"
+
+  rfc9051_6.4.4.4_ESEARCH_example_6:
+    :response: "* ESEARCH (TAG \"C285\") MIN 2 MAX 21\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: ESEARCH
+      data: !ruby/object:Net::IMAP::ESearchResult
+        tag: C285
+        uid: false
+        data:
+        - - MIN
+          - 2
+        - - MAX
+          - 21
+      raw_data: "* ESEARCH (TAG \"C285\") MIN 2 MAX 21\r\n"
+
+  rfc9051_6.4.4.4_ESEARCH_example_7:
+    :response: "* ESEARCH (TAG \"C286\") MIN 2 MAX 21 COUNT 8\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: ESEARCH
+      data: !ruby/object:Net::IMAP::ESearchResult
+        tag: C286
+        uid: false
+        data:
+        - - MIN
+          - 2
+        - - MAX
+          - 21
+        - - COUNT
+          - 8
+      raw_data: "* ESEARCH (TAG \"C286\") MIN 2 MAX 21 COUNT 8\r\n"
+
+  rfc9051_6.4.4.4_ESEARCH_example_8:
+    :response: "* ESEARCH (TAG \"C286\") MIN 2 ALL 2,10:15,21\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: ESEARCH
+      data: !ruby/object:Net::IMAP::ESearchResult
+        tag: C286
+        uid: false
+        data:
+        - - MIN
+          - 2
+        - - ALL
+          - !ruby/object:Net::IMAP::SequenceSet
+            string: 2,10:15,21
+            tuples:
+            - - 2
+              - 2
+            - - 10
+              - 15
+            - - 21
+              - 21
+      raw_data: "* ESEARCH (TAG \"C286\") MIN 2 ALL 2,10:15,21\r\n"
+
+  rfc9051_7.1_ESEARCH_example_1:
+    :response: "* ESEARCH (TAG \"h\") ALL 1:3,5,8,13,21,42\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: ESEARCH
+      data: !ruby/object:Net::IMAP::ESearchResult
+        tag: h
+        uid: false
+        data:
+        - - ALL
+          - !ruby/object:Net::IMAP::SequenceSet
+            string: 1:3,5,8,13,21,42
+            tuples:
+            - - 1
+              - 3
+            - - 5
+              - 5
+            - - 8
+              - 8
+            - - 13
+              - 13
+            - - 21
+              - 21
+            - - 42
+              - 42
+      raw_data: "* ESEARCH (TAG \"h\") ALL 1:3,5,8,13,21,42\r\n"
+
+  rfc9051_7.3.4_ESEARCH_example_1:
+    :response: "* ESEARCH UID COUNT 17 ALL 4:18,21,28\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: ESEARCH
+      data: !ruby/object:Net::IMAP::ESearchResult
+        tag:
+        uid: true
+        data:
+        - - COUNT
+          - 17
+        - - ALL
+          - !ruby/object:Net::IMAP::SequenceSet
+            string: 4:18,21,28
+            tuples:
+            - - 4
+              - 18
+            - - 21
+              - 21
+            - - 28
+              - 28
+      raw_data: "* ESEARCH UID COUNT 17 ALL 4:18,21,28\r\n"
+
+  rfc9051_7.3.4_ESEARCH_example_2:
+    :response: "* ESEARCH (TAG \"a567\") UID COUNT 17 ALL 4:18,21,28\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: ESEARCH
+      data: !ruby/object:Net::IMAP::ESearchResult
+        tag: a567
+        uid: true
+        data:
+        - - COUNT
+          - 17
+        - - ALL
+          - !ruby/object:Net::IMAP::SequenceSet
+            string: 4:18,21,28
+            tuples:
+            - - 4
+              - 18
+            - - 21
+              - 21
+            - - 28
+              - 28
+      raw_data: "* ESEARCH (TAG \"a567\") UID COUNT 17 ALL 4:18,21,28\r\n"
+
+  rfc9051_7.3.4_ESEARCH_example_3:
+    :response: "* ESEARCH COUNT 18 ALL 1:17,21\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: ESEARCH
+      data: !ruby/object:Net::IMAP::ESearchResult
+        tag:
+        uid: false
+        data:
+        - - COUNT
+          - 18
+        - - ALL
+          - !ruby/object:Net::IMAP::SequenceSet
+            string: 1:17,21
+            tuples:
+            - - 1
+              - 17
+            - - 21
+              - 21
+      raw_data: "* ESEARCH COUNT 18 ALL 1:17,21\r\n"

--- a/test/net/imap/fixtures/response_parser/rfc7162_condstore_qresync_responses.yml
+++ b/test/net/imap/fixtures/response_parser/rfc7162_condstore_qresync_responses.yml
@@ -98,6 +98,46 @@
       raw_data: "* STATUS blurdybloop (MESSAGES 231 UIDNEXT 44292 HIGHESTMODSEQ
         7011231777)\r\n"
 
+  "RFC7162 CONDSTORE 3.1.10. Example 19 (Interaction with ESEARCH)":
+    :response: "* ESEARCH (TAG \"a\") ALL 1:3,5 MODSEQ 1236\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: ESEARCH
+      data: !ruby/object:Net::IMAP::ESearchResult
+        tag: a
+        uid: false
+        data:
+        - - ALL
+          - !ruby/object:Net::IMAP::SequenceSet
+            string: 1:3,5
+            tuples:
+            - - 1
+              - 3
+            - - 5
+              - 5
+        - - MODSEQ
+          - 1236
+      raw_data: "* ESEARCH (TAG \"a\") ALL 1:3,5 MODSEQ 1236\r\n"
+
+  "RFC7162 CONDSTORE 3.1.10. Example 20 (Interaction with ESEARCH)":
+    :response: "* ESEARCH (TAG \"a\") ALL 5,3,2,1 MODSEQ 1236\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: ESEARCH
+      data: !ruby/object:Net::IMAP::ESearchResult
+        tag: a
+        uid: false
+        data:
+        - - ALL
+          - !ruby/object:Net::IMAP::SequenceSet
+            string: '5,3,2,1'
+            tuples:
+            - - 1
+              - 3
+            - - 5
+              - 5
+        - - MODSEQ
+          - 1236
+      raw_data: "* ESEARCH (TAG \"a\") ALL 5,3,2,1 MODSEQ 1236\r\n"
+
   "RFC7162 QRESYNC 3.2.5.1. Modification Sequence and UID Parameters":
     :response: "* VANISHED (EARLIER) 41,43:116,118,120:211,214:540\r\n"
     :expected: !ruby/struct:Net::IMAP::UntaggedResponse

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -1277,6 +1277,18 @@ EOF
       )
       cmd = server.commands.pop
       assert_equal "RETURN (PARTIAL -500:-1) UID 1234:*", cmd.args
+
+      assert_equal search_result, imap.search(
+        ["UID", 1234..], return: [:PARTIAL, "-500:-1"]
+      )
+      cmd = server.commands.pop
+      assert_equal "RETURN (PARTIAL -500:-1) UID 1234:*", cmd.args
+
+      assert_equal search_result, imap.search(
+        ["UID", 1234..], return: [:PARTIAL, -500..-1, :FOO, 1..]
+      )
+      cmd = server.commands.pop
+      assert_equal "RETURN (PARTIAL -500:-1 FOO 1:*) UID 1234:*", cmd.args
     end
   end
 

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -1265,6 +1265,18 @@ EOF
       ])
       cmd = server.commands.pop
       assert_equal "RETURN (MIN MAX COUNT) NOT (FLAGGED (OR SEEN ANSWERED))", cmd.args
+
+      assert_equal search_result, imap.search(
+        ["NOT", ["FLAGGED", %w(OR SEEN ANSWERED)]], return: %w(MIN MAX COUNT)
+      )
+      cmd = server.commands.pop
+      assert_equal "RETURN (MIN MAX COUNT) NOT (FLAGGED (OR SEEN ANSWERED))", cmd.args
+
+      assert_equal search_result, imap.search(
+        ["UID", 1234..], return: %w(PARTIAL -500:-1)
+      )
+      cmd = server.commands.pop
+      assert_equal "RETURN (PARTIAL -500:-1) UID 1234:*", cmd.args
     end
   end
 
@@ -1292,6 +1304,19 @@ EOF
       # assert_raise(ArgumentError) do
       #   imap.search("return () charset foo ALL", "bar")
       # end
+
+      assert_raise(ArgumentError) do
+        imap.search(["retURN", %w(foo bar), "ALL"], return: %w[foo bar])
+      end
+      assert_raise(ArgumentError) do
+        imap.search("RETURN (foo bar) ALL", return: %w[foo bar])
+      end
+      assert_raise(TypeError) do
+        imap.search("ALL", return: "foo bar")
+      end
+      assert_raise(TypeError) do
+        imap.search(["retURN", "foo bar", "ALL"])
+      end
     end
   end
 

--- a/test/net/imap/test_imap_response_parser.rb
+++ b/test/net/imap/test_imap_response_parser.rb
@@ -55,6 +55,9 @@ class IMAPResponseParserTest < Test::Unit::TestCase
   # §7.3.3: STATUS response
   generate_tests_from fixture_file: "status_responses.yml"
 
+  # §7.3.4: ESEARCH response
+  generate_tests_from fixture_file: "esearch_responses.yml"
+
   # RFC3501 §7.2.5: SEARCH response (obsolete in IMAP4rev2):
   generate_tests_from fixture_file: "search_responses.yml"
 
@@ -91,7 +94,7 @@ class IMAPResponseParserTest < Test::Unit::TestCase
   # RFC 5256: THREAD response
   generate_tests_from fixture_file: "thread_responses.yml"
 
-  # RFC 7164: CONDSTORE and QRESYNC responses
+  # RFC 7162: CONDSTORE and QRESYNC responses
   generate_tests_from fixture_file: "rfc7162_condstore_qresync_responses.yml"
 
   # RFC 8474: OBJECTID responses


### PR DESCRIPTION
Parse `ESEARCH` into `ESearchResult`, with support for generic RFC4466 syntax and RFC4731 `ESEARCH` return data.  For compatibility, `ESearchResult#to_a` returns an array of integers (sequence numbers or UIDs) whenever any `ALL` result is available.

Gather ESEARCH response to #search/#uid_search.  If the server returns both `ESEARCH` and `SEARCH`, both are cleared from the responses hash, but only the `ESEARCH` is returned.

When the server doesn't send any search responses and return options are passed, return an empty ESearchResult.  This empty result will have the appropriate `tag` and `uid` values, but no `data`.  Otherwise return an empty `SearchResult`.

Add keyword param for search return options, and process it differently from `criteria`.  Also extract a `return` argument out of the `criteria` array, and process it like the `return` kwarg.  (FYI: I discovered https://bugs.ruby-lang.org/issues/20956 while working on this).

### TODO list

- [x] `ESearchResponse < Data.define(:tag, :uid, :data)`
  - [x] `#data` is a generic Array of `[name, value]` pairs.  Not using `Hash` because some names can be repeated, and the order is significant _even between different names_.  `data.assoc(name)` can be used for quick lookup.
    - [x] TODO: test cases for unknown extensions
    - [x] TODO: document that `ExtensionData` will be used for unknown return data
  - [x] Methods for compatibility with `SearchResult`:
    - [x] `#to_a` returns numbers from `#all`, `#partial`, or an empty array
    - [x] `#modseq`
  - [x] Methods for `ESEARCH` return data: `#min`, `#max`, `#all`, `#count`
  - [x] Methods for `ESEARCH` + `CONDSEQ`: `#modseq`
- [x] Parse `ESEARCH` into `ESearchResponse`
  - [x] Return data for unknown extensions: use `ExtensionData.new(tagged_ext_value)`
  - [x] Return data for `ESEARCH` and `CONDSTORE` (`MIN`, `MAX`, `ALL`, `COUNT`, `MODSEQ`): parse as Integer or SequenceSet
- [x] Support in `#search` and `#uid_search`
  - [x] Support for return options
    - [x] `return` kwarg: must be an Array, and process differently than `criteria`.
    - [x] extract `return` from array `criteria` _and process differently than `criteria`_
    - [x] When server doesn't return any response but return options are used, return an empty `ESearchResponse` rather than an empty `SearchResponse`.
    - [x] Document supported return options
  - [x] Gather `ESEARCH` responses in addition to `SEARCH` responses.  If server sends both, prefer to return the `ESEARCH` responses.
- [x] For consistency, add `charset` kwarg to `#search`, `#uid_search`

**TODO:** Remove the following from this PR (make new PRs for them):
- [x] `ESearchResponse` methods and data classes
  - [x] remove `#to_a` returning numbers from `#partial`
  - [x] remove `#partial`
    - [x] remove `ESearchResponse::PartialResult`
  - [x] remove `#updates`
  - [x] remove `#relevancy`
- [x] Parse `PARTIAL`, `ADDTO`, `REMOVEFROM`, `RELEVANCY` as generic `ExtensionData`

### Related future PRs:
- Support for `PARTIAL` (RFC9394, RFC5267)
- Support for `CONTEXT=*` (RFC5267)
  - Automatically update a specified `SequenceSet`?
  - Register a special updates response handler?
- Support for `ESORT` (RFC5267)
- Support for `SEARCH=FUZZY` (RFC6203)
  - Method to zip `#relevancy` scores with numbers from `#all` or `#partial`
  - Unsorted ESearchResult `#to_a`, `#all`, `#partial`
- SequenceSet methods:
  - unsorted `#numbers`
  - More methods for accessing or mutating SequenceSet without affecting the order
  - `#prepend` - like `#append` but adds to the beginning
  - `#insert(index, value)`
  - `#remove(index_or_range)`
  - unsorted version of `#[]`, `#at`, `#slice`
  - unsorted `#zip` with array of numbers (for `RELEVANCY`)
  - unsorted `#zip` with another SequenceSet (for `COPYUID`)