### PR TITLE
✨ New config option to return frozen dup from `#responses`

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -2490,6 +2490,12 @@ module Net
       end
     end
 
+    RESPONSES_DEPRECATION_MSG =
+      "Pass a type or block to #responses, " \
+      "set config.responses_without_block to :silence_deprecation_warning, " \
+      "or use #extract_responses or #clear_responses."
+    private_constant :RESPONSES_DEPRECATION_MSG
+
     # :call-seq:
     #   responses       {|hash|  ...} -> block result
     #   responses(type) {|array| ...} -> block result
@@ -2584,10 +2590,9 @@ module Net
       else
         case config.responses_without_block
         when :raise
-          raise ArgumentError, "Pass a block or use #clear_responses"
+          raise ArgumentError, RESPONSES_DEPRECATION_MSG
         when :warn
-          warn("DEPRECATED: pass a block or use #clear_responses",
-               uplevel: 1, category: :deprecated)
+          warn(RESPONSES_DEPRECATION_MSG, uplevel: 1, category: :deprecated)
         end
         @responses
       end

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -2528,11 +2528,11 @@ module Net
     #       Prints a warning and returns the mutable responses hash.
     #       <em>This is not thread-safe.</em>
     #
-    #     [+:frozen_dup+</em>]
+    #     [+:frozen_dup+ <em>(planned default for +v0.6+)</em>]
     #       Returns a frozen copy of the unhandled responses hash, with frozen
     #       array values.
     #
-    #     [+:raise+ <em>(planned future default)</em>]
+    #     [+:raise+]
     #       Raise an +ArgumentError+ with the deprecation warning.
     #
     # For example:

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -2492,11 +2492,13 @@ module Net
 
     RESPONSES_DEPRECATION_MSG =
       "Pass a type or block to #responses, " \
-      "set config.responses_without_block to :silence_deprecation_warning, " \
+      "set config.responses_without_block to :frozen_dup " \
+      "or :silence_deprecation_warning, " \
       "or use #extract_responses or #clear_responses."
     private_constant :RESPONSES_DEPRECATION_MSG
 
     # :call-seq:
+    #   responses       -> hash of {String => Array} (see config.responses_without_block)
     #   responses(type) -> frozen array
     #   responses       {|hash|  ...} -> block result
     #   responses(type) {|array| ...} -> block result
@@ -2525,6 +2527,10 @@ module Net
     #     [+:warn+ <em>(default since +v0.5+)</em>]
     #       Prints a warning and returns the mutable responses hash.
     #       <em>This is not thread-safe.</em>
+    #
+    #     [+:frozen_dup+</em>]
+    #       Returns a frozen copy of the unhandled responses hash, with frozen
+    #       array values.
     #
     #     [+:raise+ <em>(planned future default)</em>]
     #       Raise an +ArgumentError+ with the deprecation warning.
@@ -2597,6 +2603,13 @@ module Net
           raise ArgumentError, RESPONSES_DEPRECATION_MSG
         when :warn
           warn(RESPONSES_DEPRECATION_MSG, uplevel: 1, category: :deprecated)
+        when :frozen_dup
+          synchronize {
+            responses = @responses.transform_values(&:freeze)
+            responses.default_proc = nil
+            responses.default = [].freeze
+            return responses.freeze
+          }
         end
         @responses
       end

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -2494,37 +2494,78 @@ module Net
     #   responses       {|hash|  ...} -> block result
     #   responses(type) {|array| ...} -> block result
     #
-    # Yields unhandled responses and returns the result of the block.
-    #
+    # Yields unhandled server responses and returns the result of the block.
     # Unhandled responses are stored in a hash, with arrays of
     # <em>non-+nil+</em> UntaggedResponse#data keyed by UntaggedResponse#name
-    # and ResponseCode#data keyed by ResponseCode#name.  Call without +type+ to
-    # yield the entire responses hash.  Call with +type+ to yield only the array
-    # of responses for that type.
+    # and ResponseCode#data keyed by ResponseCode#name.
+    #
+    # [With +type+]
+    #   Yield only the array of responses for that +type+.
+    #   When no block is given, an +ArgumentError+ is raised.
+    # [Without +type+]
+    #   Yield or return the entire responses hash.
+    #
+    #   When no block is given, the behavior is determined by
+    #   Config#responses_without_block:
+    #   >>>
+    #     [+:silence_deprecation_warning+ <em>(original behavior)</em>]
+    #       Returns the mutable responses hash (without any warnings).
+    #       <em>This is not thread-safe.</em>
+    #
+    #     [+:warn+ <em>(default since +v0.5+)</em>]
+    #       Prints a warning and returns the mutable responses hash.
+    #       <em>This is not thread-safe.</em>
+    #
+    #     [+:raise+ <em>(planned future default)</em>]
+    #       Raise an +ArgumentError+ with the deprecation warning.
     #
     # For example:
     #
     #   imap.select("inbox")
     #   p imap.responses("EXISTS", &:last)
     #   #=> 2
+    #   p imap.responses("UIDNEXT", &:last)
+    #   #=> 123456
     #   p imap.responses("UIDVALIDITY", &:last)
     #   #=> 968263756
+    #   p imap.responses {|responses|
+    #     {
+    #       exists:      responses.delete("EXISTS").last,
+    #       uidnext:     responses.delete("UIDNEXT").last,
+    #       uidvalidity: responses.delete("UIDVALIDITY").last,
+    #     }
+    #   }
+    #   #=> {:exists=>2, :uidnext=>123456, :uidvalidity=>968263756}
+    #   # "EXISTS", "UIDNEXT", and "UIDVALIDITY" have been removed:
+    #   p imap.responses(&:keys)
+    #   #=> ["FLAGS", "OK", "PERMANENTFLAGS", "RECENT", "HIGHESTMODSEQ"]
     #
+    # Related: #extract_responses, #clear_responses, #response_handlers, #greeting
+    #
+    # ===== Thread safety
     # >>>
     #   *Note:* Access to the responses hash is synchronized for thread-safety.
     #   The receiver thread and response_handlers cannot process new responses
     #   until the block completes.  Accessing either the response hash or its
-    #   response type arrays outside of the block is unsafe.
+    #   response type arrays outside of the block is unsafe.  They can be safely
+    #   updated inside the block.  Consider using #clear_responses or
+    #   #extract_responses instead.
     #
-    #   Calling without a block is unsafe and deprecated.  Future releases will
-    #   raise ArgumentError unless a block is given.
-    #   See Config#responses_without_block.
+    #   Net::IMAP will add and remove responses from the responses hash and its
+    #   array values, in the calling threads for commands and in the receiver
+    #   thread, but will not modify any responses after adding them to the
+    #   responses hash.
+    #
+    # ===== Clearing responses
     #
     # Previously unhandled responses are automatically cleared before entering a
     # mailbox with #select or #examine.  Long-lived connections can receive many
     # unhandled server responses, which must be pruned or they will continually
     # consume more memory.  Update or clear the responses hash or arrays inside
-    # the block, or use #clear_responses.
+    # the block, or remove responses with #extract_responses, #clear_responses,
+    # or #add_response_handler.
+    #
+    # ===== Missing responses
     #
     # Only non-+nil+ data is stored.  Many important response codes have no data
     # of their own, but are used as "tags" on the ResponseText object they are
@@ -2535,8 +2576,6 @@ module Net
     # ResponseCode#data on tagged responses.  Although some command methods do
     # return the TaggedResponse directly, #add_response_handler must be used to
     # handle all response codes.
-    #
-    # Related: #extract_responses, #clear_responses, #response_handlers, #greeting
     def responses(type = nil)
       if block_given?
         synchronize { yield(type ? @responses[type.to_s.upcase] : @responses) }

--- a/lib/net/imap/config.rb
+++ b/lib/net/imap/config.rb
@@ -7,10 +7,10 @@ require_relative "config/attr_type_coercion"
 module Net
   class IMAP
 
-    # Net::IMAP::Config stores configuration options for Net::IMAP clients.
-    # The global configuration can be seen at either Net::IMAP.config or
-    # Net::IMAP::Config.global, and the client-specific configuration can be
-    # seen at Net::IMAP#config.
+    # Net::IMAP::Config <em>(available since +v0.4.13+)</em> stores
+    # configuration options for Net::IMAP clients.  The global configuration can
+    # be seen at either Net::IMAP.config or Net::IMAP::Config.global, and the
+    # client-specific configuration can be seen at Net::IMAP#config.
     #
     # When creating a new client, all unhandled keyword arguments to
     # Net::IMAP.new are delegated to Config.new.  Every client has its own
@@ -128,7 +128,7 @@ module Net
       # The global config object.  Also available from Net::IMAP.config.
       def self.global; @global if defined?(@global) end
 
-      # A hash of hard-coded configurations, indexed by version number.
+      # A hash of hard-coded configurations, indexed by version number or name.
       def self.version_defaults; @version_defaults end
       @version_defaults = {}
 
@@ -172,9 +172,16 @@ module Net
       include AttrInheritance
       include AttrTypeCoercion
 
-      # The debug mode (boolean)
+      # The debug mode (boolean).  The default value is +false+.
       #
-      # The default value is +false+.
+      # When #debug is +true+:
+      # * Data sent to and received from the server will be logged.
+      # * ResponseParser will print warnings with extra detail for parse
+      #   errors.  _This may include recoverable errors._
+      # * ResponseParser makes extra assertions.
+      #
+      # *NOTE:* Versioned default configs inherit #debug from Config.global, and
+      # #load_defaults will not override #debug.
       attr_accessor :debug, type: :boolean
 
       # method: debug?
@@ -200,56 +207,62 @@ module Net
       # The default value is +5+ seconds.
       attr_accessor :idle_response_timeout, type: Integer
 
-      # :markup: markdown
-      #
       # Whether to use the +SASL-IR+ extension when the server and \SASL
-      # mechanism both support it.
+      # mechanism both support it.  Can be overridden by the +sasl_ir+ keyword
+      # parameter to Net::IMAP#authenticate.
       #
-      # See Net::IMAP#authenticate.
+      # <em>(Support for +SASL-IR+ was added in +v0.4.0+.)</em>
       #
-      # | Starting with version | The default value is                     |
-      # |-----------------------|------------------------------------------|
-      # | _original_            | +false+ <em>(extension unsupported)</em> |
-      # | v0.4                  | +true+  <em>(support added)</em>         |
+      # ==== Valid options
+      #
+      # [+false+ <em>(original behavior, before support was added)</em>]
+      #   Do not use +SASL-IR+, even when it is supported by the server and the
+      #   mechanism.
+      #
+      # [+true+ <em>(default since +v0.4+)</em>]
+      #   Use +SASL-IR+ when it is supported by the server and the mechanism.
       attr_accessor :sasl_ir, type: :boolean
 
-      # :markup: markdown
-      #
-      # Controls the behavior of Net::IMAP#login when the `LOGINDISABLED`
+      # Controls the behavior of Net::IMAP#login when the +LOGINDISABLED+
       # capability is present.  When enforced, Net::IMAP will raise a
-      # LoginDisabledError when that capability is present.  Valid values are:
+      # LoginDisabledError when that capability is present.
       #
-      # [+false+]
+      # <em>(Support for +LOGINDISABLED+ was added in +v0.5.0+.)</em>
+      #
+      # ==== Valid options
+      #
+      # [+false+ <em>(original behavior, before support was added)</em>]
       #   Send the +LOGIN+ command without checking for +LOGINDISABLED+.
       #
       # [+:when_capabilities_cached+]
       #   Enforce the requirement when Net::IMAP#capabilities_cached? is true,
       #   but do not send a +CAPABILITY+ command to discover the capabilities.
       #
-      # [+true+]
+      # [+true+ <em>(default since +v0.5+)</em>]
       #   Only send the +LOGIN+ command if the +LOGINDISABLED+ capability is not
       #   present.  When capabilities are unknown, Net::IMAP will automatically
       #   send a +CAPABILITY+ command first before sending +LOGIN+.
       #
-      # | Starting with version   | The default value is           |
-      # |-------------------------|--------------------------------|
-      # | _original_              | `false`                        |
-      # | v0.5                    | `true`                         |
       attr_accessor :enforce_logindisabled, type: [
         false, :when_capabilities_cached, true
       ]
 
-      # :markup: markdown
+      # Controls the behavior of Net::IMAP#responses when called without any
+      # arguments (+type+ or +block+).
       #
-      # Controls the behavior of Net::IMAP#responses when called without a
-      # block.  Valid options are `:warn`, `:raise`, or
-      # `:silence_deprecation_warning`.
+      # ==== Valid options
       #
-      # | Starting with version   | The default value is           |
-      # |-------------------------|--------------------------------|
-      # | v0.4.13                 | +:silence_deprecation_warning+ |
-      # | v0.5                    | +:warn+                        |
-      # | _eventually_            | +:raise+                       |
+      # [+:silence_deprecation_warning+ <em>(original behavior)</em>]
+      #   Returns the mutable responses hash (without any warnings).
+      #   <em>This is not thread-safe.</em>
+      #
+      # [+:warn+ <em>(default since +v0.5+)</em>]
+      #   Prints a warning and returns the mutable responses hash.
+      #   <em>This is not thread-safe.</em>
+      #
+      # [+:raise+ <em>(planned future default)</em>]
+      #   Raise an ArgumentError with the deprecation warning.
+      #
       attr_accessor :responses_without_block, type: [
         :silence_deprecation_warning, :warn, :raise,
       ]

--- a/lib/net/imap/config.rb
+++ b/lib/net/imap/config.rb
@@ -263,9 +263,18 @@ module Net
       # [+:raise+ <em>(planned future default)</em>]
       #   Raise an ArgumentError with the deprecation warning.
       #
+      # Note: #responses_without_args is an alias for #responses_without_block.
       attr_accessor :responses_without_block, type: [
-        :silence_deprecation_warning, :warn, :raise,
+        :silence_deprecation_warning, :warn, :frozen_dup, :raise,
       ]
+
+      alias responses_without_args  responses_without_block  # :nodoc:
+      alias responses_without_args= responses_without_block= # :nodoc:
+
+      ##
+      # :attr_accessor: responses_without_args
+      #
+      # Alias for responses_without_block
 
       # Creates a new config object and initialize its attribute with +attrs+.
       #

--- a/lib/net/imap/config.rb
+++ b/lib/net/imap/config.rb
@@ -260,6 +260,15 @@ module Net
       #   Prints a warning and returns the mutable responses hash.
       #   <em>This is not thread-safe.</em>
       #
+      # [+:frozen_dup+</em>]
+      #   Returns a frozen copy of the unhandled responses hash, with frozen
+      #   array values.
+      #
+      #   Note that calling IMAP#responses with a +type+ and without a block is
+      #   not configurable and always behaves like +:frozen_dup+.
+      #
+      #   <em>(+:frozen_dup+ config option was added in +v0.4.17+)</em>
+      #
       # [+:raise+ <em>(planned future default)</em>]
       #   Raise an ArgumentError with the deprecation warning.
       #

--- a/lib/net/imap/config.rb
+++ b/lib/net/imap/config.rb
@@ -260,7 +260,7 @@ module Net
       #   Prints a warning and returns the mutable responses hash.
       #   <em>This is not thread-safe.</em>
       #
-      # [+:frozen_dup+</em>]
+      # [+:frozen_dup+ <em>(planned default for +v0.6+)</em>]
       #   Returns a frozen copy of the unhandled responses hash, with frozen
       #   array values.
       #
@@ -269,7 +269,7 @@ module Net
       #
       #   <em>(+:frozen_dup+ config option was added in +v0.4.17+)</em>
       #
-      # [+:raise+ <em>(planned future default)</em>]
+      # [+:raise+]
       #   Raise an ArgumentError with the deprecation warning.
       #
       # Note: #responses_without_args is an alias for #responses_without_block.
@@ -388,12 +388,11 @@ module Net
 
       version_defaults[0.5] = Config[:current]
 
-      version_defaults[0.6] = Config[0.5]
-      version_defaults[:next] = Config[0.6]
-
-      version_defaults[:future]  = Config[0.6].dup.update(
-        responses_without_block: :raise,
+      version_defaults[0.6] = Config[0.5].dup.update(
+        responses_without_block: :frozen_dup,
       ).freeze
+      version_defaults[:next] = Config[0.6]
+      version_defaults[:future] = Config[:next]
 
       version_defaults.freeze
     end

--- a/test/lib/helper.rb
+++ b/test/lib/helper.rb
@@ -2,3 +2,16 @@ require "test/unit"
 require "core_assertions"
 
 Test::Unit::TestCase.include Test::Unit::CoreAssertions
+
+class Test::Unit::TestCase
+  def wait_for_response_count(imap, type:, count:,
+                              timeout: 0.5, interval: 0.001)
+    deadline = Time.now + timeout
+    loop do
+      current_count = imap.responses(type, &:size)
+      break :count    if count <= current_count
+      break :deadline if deadline < Time.now
+      sleep interval
+    end
+  end
+end

--- a/test/net/imap/test_config.rb
+++ b/test/net/imap/test_config.rb
@@ -190,7 +190,7 @@ class ConfigTest < Test::Unit::TestCase
     assert_same Config.default, Config.new(Config.default).parent
     assert_same Config.global,  Config.new(Config.global).parent
     assert_same Config[0.4],    Config.new(0.4).parent
-    assert_same Config[0.5],    Config.new(:next).parent
+    assert_same Config[0.6],    Config.new(:next).parent
     assert_equal true, Config.new({debug: true}, debug: false).parent.debug?
     assert_equal true, Config.new({debug: true}, debug: false).parent.frozen?
   end

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -1110,107 +1110,6 @@ EOF
     end
   end
 
-  test "#responses" do
-    with_fake_server do |server, imap|
-      # responses available before SELECT/EXAMINE
-      assert_equal(%w[IMAP4REV1 NAMESPACE MOVE IDLE UTF8=ACCEPT],
-                   imap.responses("CAPABILITY", &:last))
-      resp = imap.select "INBOX"
-      # responses are cleared after SELECT/EXAMINE
-      assert_equal(nil, imap.responses("CAPABILITY", &:last))
-      assert_equal([Net::IMAP::TaggedResponse, "RUBY0001", "OK"],
-                   [resp.class, resp.tag, resp.name])
-      assert_equal([172], imap.responses { _1["EXISTS"] })
-      assert_equal([3857529045], imap.responses("UIDVALIDITY") { _1 })
-      assert_equal(1, imap.responses("RECENT", &:last))
-      assert_raise(ArgumentError) do imap.responses("UIDNEXT") end
-      # Deprecated style, without a block:
-      imap.config.responses_without_block = :raise
-      assert_raise(ArgumentError) do imap.responses end
-      imap.config.responses_without_block = :warn
-      assert_raise(ArgumentError) do imap.responses("UIDNEXT") end
-      assert_warn(/Pass a block.*or.*clear_responses/i) do
-        assert_equal(%i[Answered Flagged Deleted Seen Draft],
-                     imap.responses["FLAGS"]&.last)
-      end
-      # TODO: assert_no_warn?
-      imap.config.responses_without_block = :silence_deprecation_warning
-      assert_raise(ArgumentError) do imap.responses("UIDNEXT") end
-      stderr = EnvUtil.verbose_warning {
-        assert_equal(%i[Answered Flagged Deleted Seen Draft],
-                     imap.responses["FLAGS"]&.last)
-      }
-      assert_empty stderr
-    end
-  end
-
-  test "#clear_responses" do
-    with_fake_server do |server, imap|
-      resp = imap.select "INBOX"
-      assert_equal([Net::IMAP::TaggedResponse, "RUBY0001", "OK"],
-                   [resp.class, resp.tag, resp.name])
-      # called with "type", clears and returns only that type
-      assert_equal([172],        imap.clear_responses("EXISTS"))
-      assert_equal([],           imap.clear_responses("EXISTS"))
-      assert_equal([1],          imap.clear_responses("RECENT"))
-      assert_equal([3857529045], imap.clear_responses("UIDVALIDITY"))
-      # called without "type", clears and returns all responses
-      responses = imap.clear_responses
-      assert_equal([],   responses["EXISTS"])
-      assert_equal([],   responses["RECENT"])
-      assert_equal([],   responses["UIDVALIDITY"])
-      assert_equal([12], responses["UNSEEN"])
-      assert_equal([4392], responses["UIDNEXT"])
-      assert_equal(5, responses["FLAGS"].last&.size)
-      assert_equal(3, responses["PERMANENTFLAGS"].last&.size)
-      assert_equal({}, imap.responses(&:itself))
-      assert_equal({}, imap.clear_responses)
-    end
-  end
-
-  test "#extract_responses" do
-    with_fake_server do |server, imap|
-      resp = imap.select "INBOX"
-      assert_equal([Net::IMAP::TaggedResponse, "RUBY0001", "OK"],
-                   [resp.class, resp.tag, resp.name])
-      # Need to send a string type and a block
-      assert_raise(ArgumentError) do imap.extract_responses { true } end
-      assert_raise(ArgumentError) do imap.extract_responses(nil) { true } end
-      assert_raise(ArgumentError) do imap.extract_responses("OK") end
-      # matching nothing
-      assert_equal([172], imap.responses("EXISTS", &:dup))
-      assert_equal([],    imap.extract_responses("EXISTS") { String === _1 })
-      assert_equal([172], imap.responses("EXISTS", &:dup))
-      # matching everything
-      assert_equal([172], imap.responses("EXISTS", &:dup))
-      assert_equal([172], imap.extract_responses("EXISTS", &:even?))
-      assert_equal([],    imap.responses("EXISTS", &:dup))
-      # matching some
-      server.unsolicited("101 FETCH (UID 1111 FLAGS (\\Seen))")
-      server.unsolicited("102 FETCH (UID 2222 FLAGS (\\Seen \\Flagged))")
-      server.unsolicited("103 FETCH (UID 3333 FLAGS (\\Deleted))")
-      wait_for_response_count(imap, type: "FETCH", count: 3)
-
-      result = imap.extract_responses("FETCH") { _1.flags.include?(:Flagged) }
-      assert_equal(
-        [
-          Net::IMAP::FetchData.new(
-            102, {"UID" => 2222, "FLAGS" => [:Seen, :Flagged]}
-          ),
-        ],
-        result,
-      )
-      assert_equal 2, imap.responses("FETCH", &:count)
-
-      result = imap.extract_responses("FETCH") { _1.flags.include?(:Deleted) }
-      assert_equal(
-        [Net::IMAP::FetchData.new(103, {"UID" => 3333, "FLAGS" => [:Deleted]})],
-        result
-      )
-      assert_equal 1, imap.responses("FETCH", &:count)
-    end
-  end
-
   test "#select with condstore" do
     with_fake_server do |server, imap|
       imap.select "inbox", condstore: true
@@ -1465,17 +1364,6 @@ EOF
 
   def server_addr
     Addrinfo.tcp("localhost", 0).ip_address
-  end
-
-  def wait_for_response_count(imap, type:, count:,
-                              timeout: 0.5, interval: 0.001)
-    deadline = Time.now + timeout
-    loop do
-      current_count = imap.responses(type, &:size)
-      break :count    if count <= current_count
-      break :deadline if deadline < Time.now
-      sleep interval
-    end
   end
 
 end

--- a/test/net/imap/test_imap_responses.rb
+++ b/test/net/imap/test_imap_responses.rb
@@ -99,7 +99,14 @@ class IMAPResponsesTest < Test::Unit::TestCase
   end
 
   def assert_responses_warn
-    assert_warn(/Pass a block.*or.*clear_responses/i) do
+    assert_warn(
+      /
+        (?=(?-x)Pass a type or block to #responses\b)
+        (?=.*config\.responses_without_block.*:silence_deprecation_warning\b)
+        (?=.*\#extract_responses\b)
+           .*\#clear_responses\b
+      /ix
+    ) do
       yield
     end
   end

--- a/test/net/imap/test_imap_responses.rb
+++ b/test/net/imap/test_imap_responses.rb
@@ -166,6 +166,15 @@ class IMAPResponsesTest < Test::Unit::TestCase
         assert_equal [], imap.responses["FAKE"]
       end
       assert_empty stderr
+      # opt-in to future behavior
+      imap.config.responses_without_block = :frozen_dup
+      stderr = EnvUtil.verbose_warning do
+        assert imap.responses.frozen?
+        assert imap.responses["CAPABILITY"].frozen?
+        assert_equal(%w[IMAP4REV1 NAMESPACE MOVE IDLE UTF8=ACCEPT],
+                     imap.responses["CAPABILITY"].last)
+      end
+      assert_empty stderr
     end
   end
 

--- a/test/net/imap/test_imap_responses.rb
+++ b/test/net/imap/test_imap_responses.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require "net/imap"
+require "test/unit"
+require_relative "fake_server"
+
+class IMAPResponsesTest < Test::Unit::TestCase
+  include Net::IMAP::FakeServer::TestHelper
+
+  def setup
+    Net::IMAP.config.reset
+    @do_not_reverse_lookup = Socket.do_not_reverse_lookup
+    Socket.do_not_reverse_lookup = true
+    @threads = []
+  end
+
+  def teardown
+    if !@threads.empty?
+      assert_join_threads(@threads)
+    end
+  ensure
+    Socket.do_not_reverse_lookup = @do_not_reverse_lookup
+  end
+
+  test "#responses" do
+    with_fake_server do |server, imap|
+      # responses available before SELECT/EXAMINE
+      assert_equal(%w[IMAP4REV1 NAMESPACE MOVE IDLE UTF8=ACCEPT],
+                   imap.responses("CAPABILITY", &:last))
+      resp = imap.select "INBOX"
+      # responses are cleared after SELECT/EXAMINE
+      assert_equal(nil, imap.responses("CAPABILITY", &:last))
+      assert_equal([Net::IMAP::TaggedResponse, "RUBY0001", "OK"],
+                   [resp.class, resp.tag, resp.name])
+      assert_equal([172], imap.responses { _1["EXISTS"] })
+      assert_equal([3857529045], imap.responses("UIDVALIDITY") { _1 })
+      assert_equal(1, imap.responses("RECENT", &:last))
+      assert_raise(ArgumentError) do imap.responses("UIDNEXT") end
+      # Deprecated style, without a block:
+      imap.config.responses_without_block = :raise
+      assert_raise(ArgumentError) do imap.responses end
+      imap.config.responses_without_block = :warn
+      assert_raise(ArgumentError) do imap.responses("UIDNEXT") end
+      assert_warn(/Pass a block.*or.*clear_responses/i) do
+        assert_equal(%i[Answered Flagged Deleted Seen Draft],
+                     imap.responses["FLAGS"]&.last)
+      end
+      # TODO: assert_no_warn?
+      imap.config.responses_without_block = :silence_deprecation_warning
+      assert_raise(ArgumentError) do imap.responses("UIDNEXT") end
+      stderr = EnvUtil.verbose_warning {
+        assert_equal(%i[Answered Flagged Deleted Seen Draft],
+                     imap.responses["FLAGS"]&.last)
+      }
+      assert_empty stderr
+    end
+  end
+
+  test "#clear_responses" do
+    with_fake_server do |server, imap|
+      resp = imap.select "INBOX"
+      assert_equal([Net::IMAP::TaggedResponse, "RUBY0001", "OK"],
+                   [resp.class, resp.tag, resp.name])
+      # called with "type", clears and returns only that type
+      assert_equal([172],        imap.clear_responses("EXISTS"))
+      assert_equal([],           imap.clear_responses("EXISTS"))
+      assert_equal([1],          imap.clear_responses("RECENT"))
+      assert_equal([3857529045], imap.clear_responses("UIDVALIDITY"))
+      # called without "type", clears and returns all responses
+      responses = imap.clear_responses
+      assert_equal([],   responses["EXISTS"])
+      assert_equal([],   responses["RECENT"])
+      assert_equal([],   responses["UIDVALIDITY"])
+      assert_equal([12], responses["UNSEEN"])
+      assert_equal([4392], responses["UIDNEXT"])
+      assert_equal(5, responses["FLAGS"].last&.size)
+      assert_equal(3, responses["PERMANENTFLAGS"].last&.size)
+      assert_equal({}, imap.responses(&:itself))
+      assert_equal({}, imap.clear_responses)
+    end
+  end
+
+  test "#extract_responses" do
+    with_fake_server do |server, imap|
+      resp = imap.select "INBOX"
+      assert_equal([Net::IMAP::TaggedResponse, "RUBY0001", "OK"],
+                   [resp.class, resp.tag, resp.name])
+      # Need to send a string type and a block
+      assert_raise(ArgumentError) do imap.extract_responses { true } end
+      assert_raise(ArgumentError) do imap.extract_responses(nil) { true } end
+      assert_raise(ArgumentError) do imap.extract_responses("OK") end
+      # matching nothing
+      assert_equal([172], imap.responses("EXISTS", &:dup))
+      assert_equal([],    imap.extract_responses("EXISTS") { String === _1 })
+      assert_equal([172], imap.responses("EXISTS", &:dup))
+      # matching everything
+      assert_equal([172], imap.responses("EXISTS", &:dup))
+      assert_equal([172], imap.extract_responses("EXISTS", &:even?))
+      assert_equal([],    imap.responses("EXISTS", &:dup))
+      # matching some
+      server.unsolicited("101 FETCH (UID 1111 FLAGS (\\Seen))")
+      server.unsolicited("102 FETCH (UID 2222 FLAGS (\\Seen \\Flagged))")
+      server.unsolicited("103 FETCH (UID 3333 FLAGS (\\Deleted))")
+      wait_for_response_count(imap, type: "FETCH", count: 3)
+
+      result = imap.extract_responses("FETCH") { _1.flags.include?(:Flagged) }
+      assert_equal(
+        [
+          Net::IMAP::FetchData.new(
+            102, {"UID" => 2222, "FLAGS" => [:Seen, :Flagged]}
+          ),
+        ],
+        result,
+      )
+      assert_equal 2, imap.responses("FETCH", &:count)
+
+      result = imap.extract_responses("FETCH") { _1.flags.include?(:Deleted) }
+      assert_equal(
+        [Net::IMAP::FetchData.new(103, {"UID" => 3333, "FLAGS" => [:Deleted]})],
+        result
+      )
+      assert_equal 1, imap.responses("FETCH", &:count)
+    end
+  end
+
+end


### PR DESCRIPTION
Add `:frozen_dup` option to `Config#responses_without_block`.  When set to `:frozen_dup`, `IMAP#responses` called without a type or a block will return a frozen duplicate or the responses hash.  The hash's array values will also be frozen dups.  None of the values in those arrays will be frozen, but writing to those should be uncommon.  (Net::IMAP itself will never update any response structs.)

Because `responses(type)` is relatively new and has always raised an exception, we can update it to _always_ return a frozen dup array without breaking backward compatibility.  This is done _regardless_ of the config option.  The config name (`config.responses_without_block`) is a little misleading now, but it's kept for backward compatibility.  `config.responses_without_args` was added as an alias.
