### PR TITLE
✨ New config option to return frozen dup from #responses [backport: #334]

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -2534,11 +2534,11 @@ module Net
     #       Prints a warning and returns the mutable responses hash.
     #       <em>This is not thread-safe.</em>
     #
-    #     [+:frozen_dup+</em>]
+    #     [+:frozen_dup+ <em>(planned default for +v0.6+)</em>]
     #       Returns a frozen copy of the unhandled responses hash, with frozen
     #       array values.
     #
-    #     [+:raise+ <em>(planned future default)</em>]
+    #     [+:raise+]
     #       Raise an +ArgumentError+ with the deprecation warning.
     #
     # For example:

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -2496,6 +2496,12 @@ module Net
       end
     end
 
+    RESPONSES_DEPRECATION_MSG =
+      "Pass a type or block to #responses, " \
+      "set config.responses_without_block to :silence_deprecation_warning, " \
+      "or use #extract_responses or #clear_responses."
+    private_constant :RESPONSES_DEPRECATION_MSG
+
     # :call-seq:
     #   responses       {|hash|  ...} -> block result
     #   responses(type) {|array| ...} -> block result
@@ -2590,9 +2596,9 @@ module Net
       else
         case config.responses_without_block
         when :raise
-          raise ArgumentError, "Pass a block or use #clear_responses"
+          raise ArgumentError, RESPONSES_DEPRECATION_MSG
         when :warn
-          warn("DEPRECATED: pass a block or use #clear_responses", uplevel: 1)
+          warn(RESPONSES_DEPRECATION_MSG, uplevel: 1)
         end
         @responses
       end

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -2503,17 +2503,21 @@ module Net
     private_constant :RESPONSES_DEPRECATION_MSG
 
     # :call-seq:
+    #   responses(type) -> frozen array
     #   responses       {|hash|  ...} -> block result
     #   responses(type) {|array| ...} -> block result
     #
-    # Yields unhandled server responses and returns the result of the block.
-    # Unhandled responses are stored in a hash, with arrays of
-    # <em>non-+nil+</em> UntaggedResponse#data keyed by UntaggedResponse#name
-    # and ResponseCode#data keyed by ResponseCode#name.
+    # Yields or returns unhandled server responses.  Unhandled responses are
+    # stored in a hash, with arrays of UntaggedResponse#data keyed by
+    # UntaggedResponse#name and <em>non-+nil+</em> untagged ResponseCode#data
+    # keyed by ResponseCode#name.
+    #
+    # When a block is given, yields unhandled responses and returns the block's
+    # result.  Without a block, returns the unhandled responses.
     #
     # [With +type+]
-    #   Yield only the array of responses for that +type+.
-    #   When no block is given, an +ArgumentError+ is raised.
+    #   Yield or return only the array of responses for that +type+.
+    #   When no block is given, the returned array is a frozen copy.
     # [Without +type+]
     #   Yield or return the entire responses hash.
     #
@@ -2534,7 +2538,7 @@ module Net
     # For example:
     #
     #   imap.select("inbox")
-    #   p imap.responses("EXISTS", &:last)
+    #   p imap.responses("EXISTS").last
     #   #=> 2
     #   p imap.responses("UIDNEXT", &:last)
     #   #=> 123456
@@ -2592,7 +2596,7 @@ module Net
       if block_given?
         synchronize { yield(type ? @responses[type.to_s.upcase] : @responses) }
       elsif type
-        raise ArgumentError, "Pass a block or use #clear_responses"
+        synchronize { @responses[type.to_s.upcase].dup.freeze }
       else
         case config.responses_without_block
         when :raise

--- a/lib/net/imap/config.rb
+++ b/lib/net/imap/config.rb
@@ -240,9 +240,18 @@ module Net
       # [+:raise+ <em>(planned future default)</em>]
       #   Raise an ArgumentError with the deprecation warning.
       #
+      # Note: #responses_without_args is an alias for #responses_without_block.
       attr_accessor :responses_without_block, type: [
-        :silence_deprecation_warning, :warn, :raise,
+        :silence_deprecation_warning, :warn, :frozen_dup, :raise,
       ]
+
+      alias responses_without_args  responses_without_block  # :nodoc:
+      alias responses_without_args= responses_without_block= # :nodoc:
+
+      ##
+      # :attr_accessor: responses_without_args
+      #
+      # Alias for responses_without_block
 
       # Creates a new config object and initialize its attribute with +attrs+.
       #

--- a/lib/net/imap/config.rb
+++ b/lib/net/imap/config.rb
@@ -237,7 +237,7 @@ module Net
       #   Prints a warning and returns the mutable responses hash.
       #   <em>This is not thread-safe.</em>
       #
-      # [+:frozen_dup+</em>]
+      # [+:frozen_dup+ <em>(planned default for +v0.6+)</em>]
       #   Returns a frozen copy of the unhandled responses hash, with frozen
       #   array values.
       #
@@ -246,7 +246,7 @@ module Net
       #
       #   <em>(+:frozen_dup+ config option was added in +v0.4.17+)</em>
       #
-      # [+:raise+ <em>(planned future default)</em>]
+      # [+:raise+]
       #   Raise an ArgumentError with the deprecation warning.
       #
       # Note: #responses_without_args is an alias for #responses_without_block.
@@ -363,9 +363,10 @@ module Net
       version_defaults[:current] = Config[0.4]
       version_defaults[:next]    = Config[0.5]
 
-      version_defaults[:future]  = Config[0.5].dup.update(
-        responses_without_block: :raise,
+      version_defaults[0.6]      = Config[0.5].dup.update(
+        responses_without_block: :frozen_dup,
       ).freeze
+      version_defaults[:future]  = Config[0.6]
 
       version_defaults.freeze
     end

--- a/lib/net/imap/config.rb
+++ b/lib/net/imap/config.rb
@@ -237,6 +237,15 @@ module Net
       #   Prints a warning and returns the mutable responses hash.
       #   <em>This is not thread-safe.</em>
       #
+      # [+:frozen_dup+</em>]
+      #   Returns a frozen copy of the unhandled responses hash, with frozen
+      #   array values.
+      #
+      #   Note that calling IMAP#responses with a +type+ and without a block is
+      #   not configurable and always behaves like +:frozen_dup+.
+      #
+      #   <em>(+:frozen_dup+ config option was added in +v0.4.17+)</em>
+      #
       # [+:raise+ <em>(planned future default)</em>]
       #   Raise an ArgumentError with the deprecation warning.
       #

--- a/test/lib/helper.rb
+++ b/test/lib/helper.rb
@@ -2,3 +2,16 @@ require "test/unit"
 require "core_assertions"
 
 Test::Unit::TestCase.include Test::Unit::CoreAssertions
+
+class Test::Unit::TestCase
+  def wait_for_response_count(imap, type:, count:,
+                              timeout: 0.5, interval: 0.001)
+    deadline = Time.now + timeout
+    loop do
+      current_count = imap.responses(type, &:size)
+      break :count    if count <= current_count
+      break :deadline if deadline < Time.now
+      sleep interval
+    end
+  end
+end

--- a/test/net/imap/test_config.rb
+++ b/test/net/imap/test_config.rb
@@ -191,6 +191,7 @@ class ConfigTest < Test::Unit::TestCase
     assert_same Config.global,  Config.new(Config.global).parent
     assert_same Config[0.4],    Config.new(0.4).parent
     assert_same Config[0.5],    Config.new(:next).parent
+    assert_same Config[0.6],    Config.new(:future).parent
     assert_equal true, Config.new({debug: true}, debug: false).parent.debug?
     assert_equal true, Config.new({debug: true}, debug: false).parent.frozen?
   end

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -1107,107 +1107,6 @@ EOF
     end
   end
 
-  test "#responses" do
-    with_fake_server do |server, imap|
-      # responses available before SELECT/EXAMINE
-      assert_equal(%w[IMAP4REV1 NAMESPACE MOVE IDLE UTF8=ACCEPT],
-                   imap.responses("CAPABILITY", &:last))
-      resp = imap.select "INBOX"
-      # responses are cleared after SELECT/EXAMINE
-      assert_equal(nil, imap.responses("CAPABILITY", &:last))
-      assert_equal([Net::IMAP::TaggedResponse, "RUBY0001", "OK"],
-                   [resp.class, resp.tag, resp.name])
-      assert_equal([172], imap.responses { _1["EXISTS"] })
-      assert_equal([3857529045], imap.responses("UIDVALIDITY") { _1 })
-      assert_equal(1, imap.responses("RECENT", &:last))
-      assert_raise(ArgumentError) do imap.responses("UIDNEXT") end
-      # Deprecated style, without a block:
-      imap.config.responses_without_block = :raise
-      assert_raise(ArgumentError) do imap.responses end
-      imap.config.responses_without_block = :warn
-      assert_raise(ArgumentError) do imap.responses("UIDNEXT") end
-      assert_warn(/Pass a block.*or.*clear_responses/i) do
-        assert_equal(%i[Answered Flagged Deleted Seen Draft],
-                     imap.responses["FLAGS"]&.last)
-      end
-      # TODO: assert_no_warn?
-      imap.config.responses_without_block = :silence_deprecation_warning
-      assert_raise(ArgumentError) do imap.responses("UIDNEXT") end
-      stderr = EnvUtil.verbose_warning {
-        assert_equal(%i[Answered Flagged Deleted Seen Draft],
-                     imap.responses["FLAGS"]&.last)
-      }
-      assert_empty stderr
-    end
-  end
-
-  test "#clear_responses" do
-    with_fake_server do |server, imap|
-      resp = imap.select "INBOX"
-      assert_equal([Net::IMAP::TaggedResponse, "RUBY0001", "OK"],
-                   [resp.class, resp.tag, resp.name])
-      # called with "type", clears and returns only that type
-      assert_equal([172],        imap.clear_responses("EXISTS"))
-      assert_equal([],           imap.clear_responses("EXISTS"))
-      assert_equal([1],          imap.clear_responses("RECENT"))
-      assert_equal([3857529045], imap.clear_responses("UIDVALIDITY"))
-      # called without "type", clears and returns all responses
-      responses = imap.clear_responses
-      assert_equal([],   responses["EXISTS"])
-      assert_equal([],   responses["RECENT"])
-      assert_equal([],   responses["UIDVALIDITY"])
-      assert_equal([12], responses["UNSEEN"])
-      assert_equal([4392], responses["UIDNEXT"])
-      assert_equal(5, responses["FLAGS"].last&.size)
-      assert_equal(3, responses["PERMANENTFLAGS"].last&.size)
-      assert_equal({}, imap.responses(&:itself))
-      assert_equal({}, imap.clear_responses)
-    end
-  end
-
-  test "#extract_responses" do
-    with_fake_server do |server, imap|
-      resp = imap.select "INBOX"
-      assert_equal([Net::IMAP::TaggedResponse, "RUBY0001", "OK"],
-                   [resp.class, resp.tag, resp.name])
-      # Need to send a string type and a block
-      assert_raise(ArgumentError) do imap.extract_responses { true } end
-      assert_raise(ArgumentError) do imap.extract_responses(nil) { true } end
-      assert_raise(ArgumentError) do imap.extract_responses("OK") end
-      # matching nothing
-      assert_equal([172], imap.responses("EXISTS", &:dup))
-      assert_equal([],    imap.extract_responses("EXISTS") { String === _1 })
-      assert_equal([172], imap.responses("EXISTS", &:dup))
-      # matching everything
-      assert_equal([172], imap.responses("EXISTS", &:dup))
-      assert_equal([172], imap.extract_responses("EXISTS", &:even?))
-      assert_equal([],    imap.responses("EXISTS", &:dup))
-      # matching some
-      server.unsolicited("101 FETCH (UID 1111 FLAGS (\\Seen))")
-      server.unsolicited("102 FETCH (UID 2222 FLAGS (\\Seen \\Flagged))")
-      server.unsolicited("103 FETCH (UID 3333 FLAGS (\\Deleted))")
-      wait_for_response_count(imap, type: "FETCH", count: 3)
-
-      result = imap.extract_responses("FETCH") { _1.flags.include?(:Flagged) }
-      assert_equal(
-        [
-          Net::IMAP::FetchData.new(
-            102, {"UID" => 2222, "FLAGS" => [:Seen, :Flagged]}
-          ),
-        ],
-        result,
-      )
-      assert_equal 2, imap.responses("FETCH", &:count)
-
-      result = imap.extract_responses("FETCH") { _1.flags.include?(:Deleted) }
-      assert_equal(
-        [Net::IMAP::FetchData.new(103, {"UID" => 3333, "FLAGS" => [:Deleted]})],
-        result
-      )
-      assert_equal 1, imap.responses("FETCH", &:count)
-    end
-  end
-
   test "#select with condstore" do
     with_fake_server do |server, imap|
       imap.select "inbox", condstore: true
@@ -1462,17 +1361,6 @@ EOF
 
   def server_addr
     Addrinfo.tcp("localhost", 0).ip_address
-  end
-
-  def wait_for_response_count(imap, type:, count:,
-                              timeout: 0.5, interval: 0.001)
-    deadline = Time.now + timeout
-    loop do
-      current_count = imap.responses(type, &:size)
-      break :count    if count <= current_count
-      break :deadline if deadline < Time.now
-      sleep interval
-    end
   end
 
 end

--- a/test/net/imap/test_imap_responses.rb
+++ b/test/net/imap/test_imap_responses.rb
@@ -99,7 +99,14 @@ class IMAPResponsesTest < Test::Unit::TestCase
   end
 
   def assert_responses_warn
-    assert_warn(/Pass a block.*or.*clear_responses/i) do
+    assert_warn(
+      /
+        (?=(?-x)Pass a type or block to #responses\b)
+        (?=.*config\.responses_without_block.*:silence_deprecation_warning\b)
+        (?=.*\#extract_responses\b)
+           .*\#clear_responses\b
+      /ix
+    ) do
       yield
     end
   end

--- a/test/net/imap/test_imap_responses.rb
+++ b/test/net/imap/test_imap_responses.rb
@@ -166,6 +166,15 @@ class IMAPResponsesTest < Test::Unit::TestCase
         assert_equal [], imap.responses["FAKE"]
       end
       assert_empty stderr
+      # opt-in to future behavior
+      imap.config.responses_without_block = :frozen_dup
+      stderr = EnvUtil.verbose_warning do
+        assert imap.responses.frozen?
+        assert imap.responses["CAPABILITY"].frozen?
+        assert_equal(%w[IMAP4REV1 NAMESPACE MOVE IDLE UTF8=ACCEPT],
+                     imap.responses["CAPABILITY"].last)
+      end
+      assert_empty stderr
     end
   end
 

--- a/test/net/imap/test_imap_responses.rb
+++ b/test/net/imap/test_imap_responses.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require "net/imap"
+require "test/unit"
+require_relative "fake_server"
+
+class IMAPResponsesTest < Test::Unit::TestCase
+  include Net::IMAP::FakeServer::TestHelper
+
+  def setup
+    Net::IMAP.config.reset
+    @do_not_reverse_lookup = Socket.do_not_reverse_lookup
+    Socket.do_not_reverse_lookup = true
+    @threads = []
+  end
+
+  def teardown
+    if !@threads.empty?
+      assert_join_threads(@threads)
+    end
+  ensure
+    Socket.do_not_reverse_lookup = @do_not_reverse_lookup
+  end
+
+  test "#responses" do
+    with_fake_server do |server, imap|
+      # responses available before SELECT/EXAMINE
+      assert_equal(%w[IMAP4REV1 NAMESPACE MOVE IDLE UTF8=ACCEPT],
+                   imap.responses("CAPABILITY", &:last))
+      resp = imap.select "INBOX"
+      # responses are cleared after SELECT/EXAMINE
+      assert_equal(nil, imap.responses("CAPABILITY", &:last))
+      assert_equal([Net::IMAP::TaggedResponse, "RUBY0001", "OK"],
+                   [resp.class, resp.tag, resp.name])
+      assert_equal([172], imap.responses { _1["EXISTS"] })
+      assert_equal([3857529045], imap.responses("UIDVALIDITY") { _1 })
+      assert_equal(1, imap.responses("RECENT", &:last))
+      assert_raise(ArgumentError) do imap.responses("UIDNEXT") end
+      # Deprecated style, without a block:
+      imap.config.responses_without_block = :raise
+      assert_raise(ArgumentError) do imap.responses end
+      imap.config.responses_without_block = :warn
+      assert_raise(ArgumentError) do imap.responses("UIDNEXT") end
+      assert_warn(/Pass a block.*or.*clear_responses/i) do
+        assert_equal(%i[Answered Flagged Deleted Seen Draft],
+                     imap.responses["FLAGS"]&.last)
+      end
+      # TODO: assert_no_warn?
+      imap.config.responses_without_block = :silence_deprecation_warning
+      assert_raise(ArgumentError) do imap.responses("UIDNEXT") end
+      stderr = EnvUtil.verbose_warning {
+        assert_equal(%i[Answered Flagged Deleted Seen Draft],
+                     imap.responses["FLAGS"]&.last)
+      }
+      assert_empty stderr
+    end
+  end
+
+  test "#clear_responses" do
+    with_fake_server do |server, imap|
+      resp = imap.select "INBOX"
+      assert_equal([Net::IMAP::TaggedResponse, "RUBY0001", "OK"],
+                   [resp.class, resp.tag, resp.name])
+      # called with "type", clears and returns only that type
+      assert_equal([172],        imap.clear_responses("EXISTS"))
+      assert_equal([],           imap.clear_responses("EXISTS"))
+      assert_equal([1],          imap.clear_responses("RECENT"))
+      assert_equal([3857529045], imap.clear_responses("UIDVALIDITY"))
+      # called without "type", clears and returns all responses
+      responses = imap.clear_responses
+      assert_equal([],   responses["EXISTS"])
+      assert_equal([],   responses["RECENT"])
+      assert_equal([],   responses["UIDVALIDITY"])
+      assert_equal([12], responses["UNSEEN"])
+      assert_equal([4392], responses["UIDNEXT"])
+      assert_equal(5, responses["FLAGS"].last&.size)
+      assert_equal(3, responses["PERMANENTFLAGS"].last&.size)
+      assert_equal({}, imap.responses(&:itself))
+      assert_equal({}, imap.clear_responses)
+    end
+  end
+
+  test "#extract_responses" do
+    with_fake_server do |server, imap|
+      resp = imap.select "INBOX"
+      assert_equal([Net::IMAP::TaggedResponse, "RUBY0001", "OK"],
+                   [resp.class, resp.tag, resp.name])
+      # Need to send a string type and a block
+      assert_raise(ArgumentError) do imap.extract_responses { true } end
+      assert_raise(ArgumentError) do imap.extract_responses(nil) { true } end
+      assert_raise(ArgumentError) do imap.extract_responses("OK") end
+      # matching nothing
+      assert_equal([172], imap.responses("EXISTS", &:dup))
+      assert_equal([],    imap.extract_responses("EXISTS") { String === _1 })
+      assert_equal([172], imap.responses("EXISTS", &:dup))
+      # matching everything
+      assert_equal([172], imap.responses("EXISTS", &:dup))
+      assert_equal([172], imap.extract_responses("EXISTS", &:even?))
+      assert_equal([],    imap.responses("EXISTS", &:dup))
+      # matching some
+      server.unsolicited("101 FETCH (UID 1111 FLAGS (\\Seen))")
+      server.unsolicited("102 FETCH (UID 2222 FLAGS (\\Seen \\Flagged))")
+      server.unsolicited("103 FETCH (UID 3333 FLAGS (\\Deleted))")
+      wait_for_response_count(imap, type: "FETCH", count: 3)
+
+      result = imap.extract_responses("FETCH") { _1.flags.include?(:Flagged) }
+      assert_equal(
+        [
+          Net::IMAP::FetchData.new(
+            102, {"UID" => 2222, "FLAGS" => [:Seen, :Flagged]}
+          ),
+        ],
+        result,
+      )
+      assert_equal 2, imap.responses("FETCH", &:count)
+
+      result = imap.extract_responses("FETCH") { _1.flags.include?(:Deleted) }
+      assert_equal(
+        [Net::IMAP::FetchData.new(103, {"UID" => 3333, "FLAGS" => [:Deleted]})],
+        result
+      )
+      assert_equal 1, imap.responses("FETCH", &:count)
+    end
+  end
+
+end


### PR DESCRIPTION
Backports #334 from `master` (0.5.0-dev).