### PR TITLE
✅ Fix GH action for rubygems Trusted Publishing

### DIFF
--- a/.github/workflows/push_gem.yml
+++ b/.github/workflows/push_gem.yml
@@ -28,17 +28,17 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - uses: actions/checkout@v4
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@cacc9f1c0b3f4eb8a16a6bb0ed10897b43b9de49 # v1.176.0
+        uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
           ruby-version: ruby
 
       # Release
       - name: Publish to RubyGems
-        uses: rubygems/release-gem@612653d273a73bdae1df8453e090060bb4db5f31 # v1
+        uses: rubygems/release-gem@v1
 
       - name: Create GitHub release
         run: |


### PR DESCRIPTION
I'm not sure why dependabot didn't suggest upgrading these.  But we need to consider these actions as trustworthy, so I think that any security risk due to using a version branch (rather than a checksum) is offset by the hassle (and security risk!) of not automatically getting updates.

In particular, even if dependabot _did_ make PRs to upgrade these, it wouldn't have made a PR for the `v0.4-stable` branch.