### PR TITLE
✅ Fix GH action for rubygems Trusted Publishing (backport: #340)

### DIFF
--- a/.github/workflows/push_gem.yml
+++ b/.github/workflows/push_gem.yml
@@ -28,17 +28,17 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - uses: actions/checkout@v4
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@cacc9f1c0b3f4eb8a16a6bb0ed10897b43b9de49 # v1.176.0
+        uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
           ruby-version: ruby
 
       # Release
       - name: Publish to RubyGems
-        uses: rubygems/release-gem@612653d273a73bdae1df8453e090060bb4db5f31 # v1
+        uses: rubygems/release-gem@v1
 
       - name: Create GitHub release
         run: |

--- a/.github/workflows/push_gem.yml
+++ b/.github/workflows/push_gem.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       # Set up
       - name: Harden Runner
-        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
         with:
           egress-policy: audit
 


### PR DESCRIPTION
This backports #340 from `master` (v0.5.0-dev).