### PR TITLE
🐛 Ensure `set` is loaded in ruby 3.1

### DIFF
--- a/benchmarks/table-regexps.yml
+++ b/benchmarks/table-regexps.yml
@@ -1,6 +1,6 @@
 prelude: |
   require "json"
-  require "set"
+  require "set" unless defined?(::Set)
 
   all_codepoints = (0..0x10ffff).map{_1.chr("UTF-8") rescue nil}.compact
 

--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "set" unless defined?(::Set)
+
 module Net
   class IMAP
 

--- a/rakelib/string_prep_tables_generator.rb
+++ b/rakelib/string_prep_tables_generator.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "set" unless defined?(::Set)
+
 # Generator for stringprep regexps.
 #
 # Combines Unicode character classes with generated tables.  Generated regexps

--- a/test/net/imap/test_sequence_set.rb
+++ b/test/net/imap/test_sequence_set.rb
@@ -2,7 +2,6 @@
 
 require "net/imap"
 require "test/unit"
-require "set"
 
 class IMAPSequenceSetTest < Test::Unit::TestCase
   # alias for convenience

--- a/test/net/imap/test_stringprep_tables.rb
+++ b/test/net/imap/test_stringprep_tables.rb
@@ -3,7 +3,6 @@
 require "net/imap"
 require "test/unit"
 require "json"
-require "set"
 
 require_relative "../../../rakelib/string_prep_tables_generator"
 


### PR DESCRIPTION
`set` doesn't need to be explicitly loaded in ruby 3.2+.  Previously, we loaded it in the tests, so they passed.  But running the actual code that uses Set could raise an exception.