### PR TITLE
✨ Add `SequenceSet#deconstruct`

### DIFF
--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -384,6 +384,10 @@ module Net
       # Related: #valid_string, #normalized_string, #to_s
       def string; @string ||= normalized_string if valid? end
 
+      # Returns an array with #normalized_string when valid and an empty array
+      # otherwise.
+      def deconstruct; valid? ? [normalized_string] : [] end
+
       # Assigns a new string to #string and resets #elements to match.  It
       # cannot be set to an empty string—assign +nil+ or use #clear instead.
       # The string is validated but not normalized.

--- a/test/net/imap/test_sequence_set.rb
+++ b/test/net/imap/test_sequence_set.rb
@@ -779,6 +779,18 @@ class IMAPSequenceSetTest < Test::Unit::TestCase
     assert_equal str, set.string
   end
 
+  test "#deconstruct" do |data|
+    set = SequenceSet.new(data[:input])
+    str = data[:normalize]
+    if str
+      assert_equal [str], set.deconstruct
+      set => SequenceSet[str]
+    else
+      assert_equal [], set.deconstruct
+      set => SequenceSet[]
+    end
+  end
+
   test "#normalized_string" do |data|
     set = SequenceSet.new(data[:input])
     assert_equal data[:normalize], set.normalized_string


### PR DESCRIPTION
Returns an array with `#normalized_string` when the sequence set is valid and an empty array otherwise.