### PR TITLE
Make simplecov-json as optional dependency

### DIFF
--- a/test/lib/helper.rb
+++ b/test/lib/helper.rb
@@ -1,11 +1,16 @@
 require "simplecov"
 
 # Cannot use ".simplecov" file: simplecov-json triggers a circular require.
-require "simplecov-json"
-SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new([
-  SimpleCov::Formatter::HTMLFormatter,
-  SimpleCov::Formatter::JSONFormatter,
-])
+begin
+  require "simplecov-json"
+  SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new([
+    SimpleCov::Formatter::HTMLFormatter,
+    SimpleCov::Formatter::JSONFormatter,
+  ])
+rescue LoadError
+  # for `make test-bundled-gems` in ruby-core repository.
+  # That task does not install C extension gem like json.
+end
 
 SimpleCov.start do
   command_name "Net::IMAP tests"


### PR DESCRIPTION
In `ruby/ruby` repository, we can't use `simplecov-json` for `make test-bundled-gems`.

https://github.com/ruby/ruby/actions/runs/11569147158/job/32202320346#step:14:163

I added workaround for that. I'm happy to release v0.5.1 with this. 