### PR TITLE
✨ Enable parenthesized lists in search criteria

### DIFF
--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -1242,6 +1242,18 @@ EOF
                                                    [1..22, 30..-1]])
       cmd = server.commands.pop
       assert_equal ["UID SEARCH", "subject hello 1:22,30:*"], [cmd.name, cmd.args]
+
+      assert_equal search_result, imap.search(
+        "RETURN (COUNT) NOT (FLAGGED (OR SEEN ANSWERED))"
+      )
+      cmd = server.commands.pop
+      assert_equal "RETURN (COUNT) NOT (FLAGGED (OR SEEN ANSWERED))", cmd.args
+
+      assert_equal search_result, imap.search([
+        "RETURN", %w(MIN MAX COUNT), "NOT", ["FLAGGED", %w(OR SEEN ANSWERED)]
+      ])
+      cmd = server.commands.pop
+      assert_equal "RETURN (MIN MAX COUNT) NOT (FLAGGED (OR SEEN ANSWERED))", cmd.args
     end
   end
 


### PR DESCRIPTION
This affects `#search`, `#uid_search`, `#sort`, `#uid_sort`, `#thread`, and `#uid_thread#`.

Prior to this, sending a parenthesized list in the search criteria for any of these commands required the use of strings, which are converted to `RawData`, which has security implications with untrusted inputs.

With this change, arrays will only be converted into `SequenceSet` when _every_ element in the array is a valid `SequenceSet` input.  Otherwise, the array will be left alone, which allows us to send parenthesized lists without using strings and `RawData`.

For example, some searches this change enables:
* combining criteria to pass into `OR`, `NOT`, `FUZZY`, etc.
  * `search(["not", %w(flagged unread)])` converts to:
    `SEARCH not (flagged unread)`
* Adding return options (we should also add a `return` kwarg). 
  * `uid_search(["RETURN", ["PARTIAL", 1..50], "UID", 12345..67890]` converts to:
    `UID SEARCH RETURN (PARTIAL 1:50) UID 12345:67890`
  * _Note that `PARTIAL` supports negative ranges, which can't be coerced to SequenceSet.
    They'll need to be sent as strings, for now._
  * _Note that searches with return options should return `ESEARCH` results, which are currently unsupported.
    See #333._

This should be backward compatible: previously these inputs would simply raise an exception.