### PR TITLE
Removed needless workaround

### DIFF
--- a/test/lib/helper.rb
+++ b/test/lib/helper.rb
@@ -1,16 +1,11 @@
 require "simplecov"
 
 # Cannot use ".simplecov" file: simplecov-json triggers a circular require.
-begin
-  require "simplecov-json"
-  SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new([
-    SimpleCov::Formatter::HTMLFormatter,
-    SimpleCov::Formatter::JSONFormatter,
-  ])
-rescue LoadError
-  # for `make test-bundled-gems` in ruby-core repository.
-  # That task does not install C extension gem like json.
-end
+require "simplecov-json"
+SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new([
+  SimpleCov::Formatter::HTMLFormatter,
+  SimpleCov::Formatter::JSONFormatter,
+])
 
 SimpleCov.start do
   command_name "Net::IMAP tests"


### PR DESCRIPTION
@nobu resolved installation issue for `simplecov-json` at https://github.com/ruby/ruby/pull/11969

We don't need this workaround now.
