### PR TITLE
✨ Coerce `Set`, `:*`, `#to_sequence_set` search args into sequence-set

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -1945,6 +1945,7 @@ module Net
     # * When +criteria+ is an array, each member is a +SEARCH+ command argument:
     #   * Any SequenceSet sends SequenceSet#valid_string.
     #     These types are converted to SequenceSet for validation and encoding:
+    #     * +Set+
     #     * +Range+
     #     * <tt>-1</tt> translates to <tt>*</tt>
     #     * nested +Array+
@@ -3204,7 +3205,7 @@ module Net
 
     def coerce_search_arg_to_seqset?(obj)
       case obj
-      when -1          then true
+      when Set, -1     then true
       when Range       then true
       when Array       then true
       else                  false

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -1944,8 +1944,10 @@ module Net
     #
     # * When +criteria+ is an array, each member is a +SEARCH+ command argument:
     #   * Any SequenceSet sends SequenceSet#valid_string.
-    #     +Range+, <tt>-1</tt>, and nested +Array+ elements are converted to
-    #     SequenceSet.
+    #     These types are converted to SequenceSet for validation and encoding:
+    #     * +Range+
+    #     * <tt>-1</tt> translates to <tt>*</tt>
+    #     * nested +Array+
     #   * Any +String+ is sent verbatim when it is a valid \IMAP atom,
     #     and encoded as an \IMAP quoted or literal string otherwise.
     #   * Any other +Integer+ (besides <tt>-1</tt>) will be sent as +#to_s+.

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3195,7 +3195,7 @@ module Net
       return RawData.new(criteria) if criteria.is_a?(String)
       criteria.map {|i|
         if coerce_search_arg_to_seqset?(i)
-          SequenceSet.new(i)
+          SequenceSet[i]
         else
           i
         end

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -1948,6 +1948,7 @@ module Net
     #     * +Set+
     #     * +Range+
     #     * <tt>-1</tt> and +:*+ -- both translate to <tt>*</tt>
+    #     * responds to +#to_sequence_set+
     #     * nested +Array+
     #   * Any +String+ is sent verbatim when it is a valid \IMAP atom,
     #     and encoded as an \IMAP quoted or literal string otherwise.
@@ -3208,7 +3209,7 @@ module Net
       when Set, -1, :* then true
       when Range       then true
       when Array       then true
-      else                  false
+      else                  obj.respond_to?(:to_sequence_set)
       end
     end
 

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3193,13 +3193,21 @@ module Net
 
     def normalize_searching_criteria(criteria)
       return RawData.new(criteria) if criteria.is_a?(String)
-      criteria.map do |i|
-        case i
-        when -1, Range, Array
+      criteria.map {|i|
+        if coerce_search_arg_to_seqset?(i)
           SequenceSet.new(i)
         else
           i
         end
+      }
+    end
+
+    def coerce_search_arg_to_seqset?(obj)
+      case obj
+      when -1          then true
+      when Range       then true
+      when Array       then true
+      else                  false
       end
     end
 

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -1947,7 +1947,7 @@ module Net
     #     These types are converted to SequenceSet for validation and encoding:
     #     * +Set+
     #     * +Range+
-    #     * <tt>-1</tt> translates to <tt>*</tt>
+    #     * <tt>-1</tt> and +:*+ -- both translate to <tt>*</tt>
     #     * nested +Array+
     #   * Any +String+ is sent verbatim when it is a valid \IMAP atom,
     #     and encoded as an \IMAP quoted or literal string otherwise.
@@ -3205,7 +3205,7 @@ module Net
 
     def coerce_search_arg_to_seqset?(obj)
       case obj
-      when Set, -1     then true
+      when Set, -1, :* then true
       when Range       then true
       when Array       then true
       else                  false

--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -282,10 +282,7 @@ module Net
 
       # valid inputs for "*"
       STARS     = [:*, ?*, -1].freeze
-      private_constant :STAR_INT, :STARS
-
-      COERCIBLE = ->{ _1.respond_to? :to_sequence_set }
-      private_constant :COERCIBLE
+      private_constant :STARS
 
       class << self
 

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -1224,6 +1224,9 @@ EOF
       imap.search(["SUBJECT", "1,*"])
       assert_equal 'SUBJECT "1,*"', server.commands.pop.args
 
+      imap.search(["subject", "hello", Set[1, 2, 3, 4, 5, 8, *(10..100)]])
+      assert_equal "subject hello 1:5,8,10:100", server.commands.pop.args
+
       server.on "UID SEARCH", &search_resp
       assert_equal search_result, imap.uid_search(["subject", "hello",
                                                    [1..22, 30..-1]])

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -1230,6 +1230,13 @@ EOF
       imap.search([:*])
       assert_equal "*", server.commands.pop.args
 
+      seqset_coercible = Object.new
+      def seqset_coercible.to_sequence_set
+        Net::IMAP::SequenceSet[1..9]
+      end
+      imap.search([seqset_coercible])
+      assert_equal "1:9", server.commands.pop.args
+
       server.on "UID SEARCH", &search_resp
       assert_equal search_result, imap.uid_search(["subject", "hello",
                                                    [1..22, 30..-1]])

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -1206,10 +1206,23 @@ EOF
       end
 
       server.on "SEARCH", &search_resp
-      assert_equal search_result, imap.search(["subject", "hello",
+      assert_equal search_result, imap.search(["subject", "hello world",
                                                [1..5, 8, 10..-1]])
       cmd = server.commands.pop
-      assert_equal ["SEARCH", "subject hello 1:5,8,10:*"], [cmd.name, cmd.args]
+      assert_equal(
+        ["SEARCH",'subject "hello world" 1:5,8,10:*'],
+        [cmd.name, cmd.args]
+      )
+
+      imap.search(["OR", 1..1000, -1, "UID", 12345..-1])
+      assert_equal "OR 1:1000 * UID 12345:*", server.commands.pop.args
+
+      imap.search([1..1000, "UID", 12345..])
+      assert_equal "1:1000 UID 12345:*", server.commands.pop.args
+
+      # Unfortunately, we can't send every sequence-set string directly
+      imap.search(["SUBJECT", "1,*"])
+      assert_equal 'SUBJECT "1,*"', server.commands.pop.args
 
       server.on "UID SEARCH", &search_resp
       assert_equal search_result, imap.uid_search(["subject", "hello",

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -1227,6 +1227,9 @@ EOF
       imap.search(["subject", "hello", Set[1, 2, 3, 4, 5, 8, *(10..100)]])
       assert_equal "subject hello 1:5,8,10:100", server.commands.pop.args
 
+      imap.search([:*])
+      assert_equal "*", server.commands.pop.args
+
       server.on "UID SEARCH", &search_resp
       assert_equal search_result, imap.uid_search(["subject", "hello",
                                                    [1..22, 30..-1]])


### PR DESCRIPTION
This was extracted from #345.  This adds types which will be converted into SequenceSet, so that PR can focus only on _not_ converting a few types to SequenceSet.