### PR TITLE
🔥 Drop YAML.unsafe_load_file refinement (tests only)

### DIFF
--- a/test/net/imap/net_imap_test_helpers.rb
+++ b/test/net/imap/net_imap_test_helpers.rb
@@ -4,16 +4,6 @@ require "net/imap"
 require "test/unit"
 require "yaml"
 
-# Compatibility with older versions, e.g. the version comes with ruby 2.7
-module YAMLPolyfill
-  unless YAML.respond_to? :unsafe_load_file
-    refine YAML.singleton_class do
-      def unsafe_load_file(...) load_file(...) end
-    end
-  end
-end
-using YAMLPolyfill
-
 module NetIMAPTestHelpers
   module TestFixtureGenerators
 


### PR DESCRIPTION
This is obsolete.  The version of `yaml` that comes with the minimum ruby version now supports `unsafe_load_file`.