### PR TITLE
📦📚  Add release.yml for better release note generation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,26 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: Breaking Changes
+      labels: ["breaking-change"]
+    - title: Added
+      labels: ["enhancement"]
+    - title: Deprecated
+      labels: ["deprecation"]
+    - title: Fixed
+      labels: ["bug"]
+    - title: Documentation
+      labels: ["documentation"]
+    - title: Other Changes
+      labels: ["*"]
+      exclude:
+        labels:
+          - "tests-only"
+          - "dependencies"
+          - "workflows"
+        authors:
+          - "dependabot"
+    - title: Miscellaneous
+      labels: ["*"]


### PR DESCRIPTION
I noticed that rdoc and irb have a [release.yml].  This is slightly different from theirs.  It has all of the categories that I've been using for recent releases.  It does _not_ add emojis to the category titles, because that seems redundant when each individual PR has its own emoji. 😉

[release.yml]: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes