### PR TITLE
Enabled windows-latest on GHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
         experimental: [false]
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -102,6 +102,8 @@ class IMAPTest < Test::Unit::TestCase
 
   if defined?(OpenSSL::SSL)
     def test_starttls_unknown_ca
+      omit "This test is not working with Windows" if RUBY_PLATFORM =~ /mswin|mingw/
+
       imap = nil
       assert_raise(OpenSSL::SSL::SSLError) do
         ex = nil


### PR DESCRIPTION
@nevans I'm working to enable to test with Windows at https://github.com/ruby/ruby/pull/12193

In `net-imap`, only `test_starttls_unknown_ca` is failing at that pull-request. I make to skip that test with Windows. And I added `windows-latest` to our CI. 