### PR TITLE
✨ Return empty SearchResult for no search result

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3155,7 +3155,13 @@ module Net
       args = charset ? ["CHARSET", charset, *keys] : keys
       synchronize do
         send_command(cmd, *args)
-        clear_responses("SEARCH").last || []
+        search_result = clear_responses("SEARCH").last
+        if search_result
+          search_result
+        else
+          # warn NO_SEARCH_RESPONSE
+          SearchResult[]
+        end
       end
     end
 

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -1264,9 +1264,11 @@ EOF
       server.on "SEARCH",     &:done_ok
       server.on "UID SEARCH", &:done_ok
       found = imap.search ["subject", "hello"]
-      assert_equal [], found
+      assert_instance_of Net::IMAP::SearchResult, found
+      assert_empty found
       found = imap.uid_search ["subject", "hello"]
-      assert_equal [], found
+      assert_instance_of Net::IMAP::SearchResult, found
+      assert_empty found
     end
   end
 


### PR DESCRIPTION
Previously this was an empty array, but that's incompatible: it's missing `#modseq`.