### PR TITLE
🥅 Raise ArgumentError on multiple search charset args

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3151,6 +3151,10 @@ module Net
     end
 
     def search_args(keys, charset = nil)
+      # NOTE: not handling combined RETURN and CHARSET for raw strings
+      if charset && keys in /\ACHARSET\b/i | Array[/\ACHARSET\z/i, *]
+        raise ArgumentError, "multiple charset arguments"
+      end
       args = normalize_searching_criteria(keys)
       args.prepend("CHARSET", charset)     if charset
       args

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3150,9 +3150,14 @@ module Net
       end
     end
 
-    def search_internal(cmd, keys, charset = nil)
-      keys = normalize_searching_criteria(keys)
-      args = charset ? ["CHARSET", charset, *keys] : keys
+    def search_args(keys, charset = nil)
+      args = normalize_searching_criteria(keys)
+      args.prepend("CHARSET", charset)     if charset
+      args
+    end
+
+    def search_internal(cmd, ...)
+      args = search_args(...)
       synchronize do
         send_command(cmd, *args)
         search_result = clear_responses("SEARCH").last
@@ -3223,7 +3228,7 @@ module Net
     end
 
     def normalize_searching_criteria(criteria)
-      return RawData.new(criteria) if criteria.is_a?(String)
+      return [RawData.new(criteria)] if criteria.is_a?(String)
       criteria.map {|i|
         if coerce_search_arg_to_seqset?(i)
           SequenceSet[i]

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -1229,6 +1229,12 @@ EOF
       imap.search(["subject", "hello", Set[1, 2, 3, 4, 5, 8, *(10..100)]])
       assert_equal "subject hello 1:5,8,10:100", server.commands.pop.args
 
+      imap.search('SUBJECT "Hello world"', "UTF-8")
+      assert_equal 'CHARSET UTF-8 SUBJECT "Hello world"', server.commands.pop.args
+
+      imap.search('CHARSET UTF-8 SUBJECT "Hello world"')
+      assert_equal 'CHARSET UTF-8 SUBJECT "Hello world"', server.commands.pop.args
+
       imap.search([:*])
       assert_equal "*", server.commands.pop.args
 

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -1265,6 +1265,24 @@ EOF
     end
   end
 
+  test("#search/#uid_search with invalid arguments") do
+    with_fake_server do |server, imap|
+      server.on "SEARCH"     do |cmd| cmd.fail_no "should fail before this" end
+      server.on "UID SEARCH" do |cmd| cmd.fail_no "should fail before this" end
+
+      assert_raise(ArgumentError) do
+        imap.search(["charset", "foo", "ALL"], "bar")
+      end
+      assert_raise(ArgumentError) do
+        imap.search("charset foo ALL", "bar")
+      end
+      # Parsing return opts is too complicated, for now.
+      # assert_raise(ArgumentError) do
+      #   imap.search("return () charset foo ALL", "bar")
+      # end
+    end
+  end
+
   test("missing server SEARCH response") do
     with_fake_server do |server, imap|
       server.on "SEARCH",     &:done_ok


### PR DESCRIPTION
Extracted from #333.

Eventually, I'd like to deprecate the `charset` optional arg to `#search` (etc) and replace it with a kwarg or embedding it inside the command args array.  This is only a tiny step in that direction.  (It won't be deprecated any time soon.)