### PR TITLE
📚 Fix rdoc issues

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -6,9 +6,7 @@
 
 main .method-detail {
   display: grid;
-  grid-template-areas:   "header         controls"
-                         "description description";
-  grid-template-columns: 1fr           min-content;
+  grid-template-columns: 1fr auto;
   justify-content: space-between;
 }
 
@@ -20,19 +18,16 @@ main .method-header, main .method-controls {
 }
 
 main .method-header {
-  grid-area: "header";
   border-right: none;
   border-radius: 4px 0 0 4px;
 }
 
 main .method-controls {
-  grid-area: "controls";
   border-left: none;
   border-radius: 0 4px 4px 0;
 }
 
 main .method-description, main .aliases {
-  grid-area: "description";
   grid-column: 1 / span 2;
   padding-left: 1em;
 }

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -1942,7 +1942,7 @@ module Net
     # and returns either a SearchResult or an ESearchResult.  SearchResult
     # inherits from Array (for backward compatibility) but adds
     # SearchResult#modseq when the +CONDSTORE+ capability has been enabled.
-    # ESearchResult also implements to_a{rdoc-ref:ESearchResult#to_a}, for
+    # ESearchResult also implements {#to_a}[rdoc-ref:ESearchResult#to_a], for
     # compatibility with SearchResult.
     #
     # +criteria+ is one or more search keys and their arguments, which may be


### PR DESCRIPTION
* Fix rdoc method "> Source" style (`min-content` squeezed the disclosure icon to a different line).
* Fix rdoc-ref link syntax (linking `#search` to `ESearchResult#to_a`).