### PR TITLE
✨ Add support for `PARTIAL` extension (RFC9394)

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -2122,6 +2122,18 @@ module Net
     #    {[RFC4731]}[https://rfc-editor.org/rfc/rfc4731]
     #    {[RFC9051]}[https://rfc-editor.org/rfc/rfc9051]
     #
+    # [+PARTIAL+ _range_]
+    #    Returns ESearchResult#partial with a SequenceSet of a subset of
+    #    matching sequence numbers or UIDs, as selected by _range_.  As with
+    #    sequence numbers, the first result is +1+: <tt>1..500</tt> selects the
+    #    first 500 search results (in mailbox order), <tt>501..1000</tt> the
+    #    second 500, and so on.  _range_ may also be negative: <tt>-500..-1</tt>
+    #    selects the last 500 search results.
+    #
+    #    <em>Requires either the <tt>CONTEXT=SEARCH</tt> or +PARTIAL+ capabability.</em>
+    #    {[RFC5267]}[https://rfc-editor.org/rfc/rfc5267]
+    #    {[RFC9394]}[https://rfc-editor.org/rfc/rfc9394]
+    #
     # ===== +MODSEQ+ return data
     #
     # ESearchResult#modseq return data does not have a corresponding return

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -534,6 +534,11 @@ module Net
   #   See FetchData#emailid and FetchData#emailid.
   # - Updates #status with support for the +MAILBOXID+ status attribute.
   #
+  # ==== RFC9394: +PARTIAL+
+  # - Updates #search, #uid_search with the +PARTIAL+ return option which adds
+  #   ESearchResult#partial return data.
+  # - Updates #uid_fetch with the +partial+ modifier.
+  #
   # == References
   #
   # [{IMAP4rev1}[https://www.rfc-editor.org/rfc/rfc3501.html]]::
@@ -701,6 +706,11 @@ module Net
   #   Gondwana, B., Ed., "IMAP Extension for Object Identifiers",
   #   RFC 8474, DOI 10.17487/RFC8474, September 2018,
   #   <https://www.rfc-editor.org/info/rfc8474>.
+  # [PARTIAL[https://www.rfc-editor.org/info/rfc9394]]::
+  #   Melnikov, A., Achuthan, A., Nagulakonda, V., and L. Alves,
+  #   "IMAP PARTIAL Extension for Paged SEARCH and FETCH", RFC 9394,
+  #   DOI 10.17487/RFC9394, June 2023,
+  #   <https://www.rfc-editor.org/info/rfc9394>.
   #
   # === IANA registries
   # * {IMAP Capabilities}[http://www.iana.org/assignments/imap4-capabilities]

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -1971,8 +1971,9 @@ module Net
     # the server to return an ESearchResult instead of a SearchResult, but some
     # servers disobey this requirement.  <em>Requires an extended search
     # capability, such as +ESEARCH+ or +IMAP4rev2+.</em>
-    # See {"Argument translation"}[rdoc-ref:#search@Argument+translation]
-    # and {"Return options"}[rdoc-ref:#search@Return+options], below.
+    # See {"Argument translation"}[rdoc-ref:#search@Argument+translation] and
+    # {"Supported return options"}[rdoc-ref:#search@Supported+return+options],
+    # below.
     #
     # +charset+ is the name of the {registered character
     # set}[https://www.iana.org/assignments/character-sets/character-sets.xhtml]
@@ -2082,16 +2083,10 @@ module Net
     #   <em>*WARNING:* This is vulnerable to injection attacks when external
     #   inputs are used.</em>
     #
-    # ==== Return options
+    # ==== Supported return options
     #
     # For full definitions of the standard return options and return data, see
     # the relevant RFCs.
-    #
-    # ===== +ESEARCH+ or +IMAP4rev2+
-    #
-    # The following return options require either +ESEARCH+ or +IMAP4rev2+.
-    # See [{RFC4731 §3.1}[https://rfc-editor.org/rfc/rfc4731#section-3.1]] or
-    # [{IMAP4rev2 §6.4.4}[https://www.rfc-editor.org/rfc/rfc9051.html#section-6.4.4]].
     #
     # [+ALL+]
     #    Returns ESearchResult#all with a SequenceSet of all matching sequence
@@ -2099,16 +2094,35 @@ module Net
     #
     #    For compatibility with SearchResult, ESearchResult#to_a returns an
     #    Array of message sequence numbers or UIDs.
+    #
+    #    <em>Requires either the +ESEARCH+ or +IMAP4rev2+ capabability.</em>
+    #    {[RFC4731]}[https://rfc-editor.org/rfc/rfc4731]
+    #    {[RFC9051]}[https://rfc-editor.org/rfc/rfc9051]
+    #
     # [+COUNT+]
     #    Returns ESearchResult#count with the number of matching messages.
+    #
+    #    <em>Requires either the +ESEARCH+ or +IMAP4rev2+ capabability.</em>
+    #    {[RFC4731]}[https://rfc-editor.org/rfc/rfc4731]
+    #    {[RFC9051]}[https://rfc-editor.org/rfc/rfc9051]
+    #
     # [+MAX+]
     #    Returns ESearchResult#max with the highest matching sequence number or
     #    UID.
+    #
+    #    <em>Requires either the +ESEARCH+ or +IMAP4rev2+ capabability.</em>
+    #    {[RFC4731]}[https://rfc-editor.org/rfc/rfc4731]
+    #    {[RFC9051]}[https://rfc-editor.org/rfc/rfc9051]
+    #
     # [+MIN+]
     #    Returns ESearchResult#min with the lowest matching sequence number or
     #    UID.
     #
-    # ===== +CONDSTORE+
+    #    <em>Requires either the +ESEARCH+ or +IMAP4rev2+ capabability.</em>
+    #    {[RFC4731]}[https://rfc-editor.org/rfc/rfc4731]
+    #    {[RFC9051]}[https://rfc-editor.org/rfc/rfc9051]
+    #
+    # ===== +MODSEQ+ return data
     #
     # ESearchResult#modseq return data does not have a corresponding return
     # option.  Instead, it is returned if the +MODSEQ+ search key is used or
@@ -2120,8 +2134,8 @@ module Net
     #
     # {RFC4466 §2.6}[https://www.rfc-editor.org/rfc/rfc4466.html#section-2.6]
     # defines standard syntax for search extensions.  Net::IMAP allows sending
-    # unknown search return options and will parse unknown search extensions'
-    # return values into ExtensionData.  Please note that this is an
+    # unsupported search return options and will parse unsupported search
+    # extensions' return values into ExtensionData.  Please note that this is an
     # intentionally _unstable_ API.  Future releases may return different
     # (incompatible) objects, <em>without deprecation or warning</em>.
     #

--- a/rakelib/rfcs.rake
+++ b/rakelib/rfcs.rake
@@ -145,6 +145,7 @@ RFCS = {
   8514 => "IMAP SAVEDATE",
   8970 => "IMAP PREVIEW",
   9208 => "IMAP QUOTA, QUOTA=, QUOTASET",
+  9394 => "IMAP PARTIAL",
 
   # etc...
   3629 => "UTF8",

--- a/test/net/imap/fixtures/response_parser/rfc9394_partial.yml
+++ b/test/net/imap/fixtures/response_parser/rfc9394_partial.yml
@@ -1,0 +1,66 @@
+---
+:tests:
+
+  "RFC9394 PARTIAL 3.1. example 1":
+    comment: |
+      Neither RFC9394 nor RFC5267 contain any examples of a normal unelided
+      sequence-set result.  I've edited it to include a sequence-set here.
+    :response: "* ESEARCH (TAG \"A01\") UID PARTIAL (-1:-100 200:250,252:300)\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: ESEARCH
+      data: !ruby/object:Net::IMAP::ESearchResult
+        tag: A01
+        uid: true
+        data:
+        - - PARTIAL
+          - !ruby/object:Net::IMAP::ESearchResult::PartialResult
+            range: !ruby/range
+              begin: -100
+              end: -1
+              excl: false
+            results: !ruby/object:Net::IMAP::SequenceSet
+              string: 200:250,252:300
+              tuples:
+              - - 200
+                - 250
+              - - 252
+                - 300
+      raw_data: "* ESEARCH (TAG \"A01\") UID PARTIAL (-1:-100 200:250,252:300)\r\n"
+
+  "RFC9394 PARTIAL 3.1. example 2":
+    :response: "* ESEARCH (TAG \"A02\") UID PARTIAL (23500:24000 55500:56000)\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: ESEARCH
+      data: !ruby/object:Net::IMAP::ESearchResult
+        tag: A02
+        uid: true
+        data:
+        - - PARTIAL
+          - !ruby/object:Net::IMAP::ESearchResult::PartialResult
+            range: !ruby/range
+              begin: 23500
+              end: 24000
+              excl: false
+            results: !ruby/object:Net::IMAP::SequenceSet
+              string: 55500:56000
+              tuples:
+              - - 55500
+                - 56000
+      raw_data: "* ESEARCH (TAG \"A02\") UID PARTIAL (23500:24000 55500:56000)\r\n"
+
+  "RFC9394 PARTIAL 3.1. example 3":
+    :response: "* ESEARCH (TAG \"A04\") UID PARTIAL (24000:24500 NIL)\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: ESEARCH
+      data: !ruby/object:Net::IMAP::ESearchResult
+        tag: A04
+        uid: true
+        data:
+        - - PARTIAL
+          - !ruby/object:Net::IMAP::ESearchResult::PartialResult
+            range: !ruby/range
+              begin: 24000
+              end: 24500
+              excl: false
+            results:
+      raw_data: "* ESEARCH (TAG \"A04\") UID PARTIAL (24000:24500 NIL)\r\n"

--- a/test/net/imap/test_esearch_result.rb
+++ b/test/net/imap/test_esearch_result.rb
@@ -15,6 +15,10 @@ class ESearchResultTest < Test::Unit::TestCase
     assert_equal [], esearch.to_a
     esearch = ESearchResult.new(nil, false, [["ALL", SequenceSet["1,5:8"]]])
     assert_equal [1, 5, 6, 7, 8], esearch.to_a
+    esearch = ESearchResult.new(nil, false, [
+      ["PARTIAL", ESearchResult::PartialResult[1..5, "1,5:8"]]
+    ])
+    assert_equal [1, 5, 6, 7, 8], esearch.to_a
   end
 
   test "#tag" do
@@ -78,6 +82,19 @@ class ESearchResultTest < Test::Unit::TestCase
     assert_equal     12, esearch.count
     assert_equal seqset, esearch.all
     assert_equal  12345, esearch.modseq
+  end
+
+  test "#partial returns PARTIAL value (RFC9394: PARTIAL)" do
+    result = Net::IMAP::ResponseParser.new.parse(
+      "* ESEARCH (TAG \"A0006\") UID PARTIAL (-1:-100 200:250,252:300)\r\n"
+    ).data
+    assert_equal(ESearchResult, result.class)
+    assert_equal(
+      ESearchResult::PartialResult.new(
+        -100..-1, SequenceSet[200..250, 252..300]
+      ),
+      result.partial
+    )
   end
 
 end

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -1214,6 +1214,27 @@ EOF
     end
   end
 
+  test "#uid_fetch with partial" do
+    with_fake_server select: "inbox" do |server, imap|
+      server.on("UID FETCH", &:done_ok)
+      imap.uid_fetch 1.., "FAST", partial: 1..500
+      assert_equal("RUBY0002 UID FETCH 1:* FAST (PARTIAL 1:500)",
+                   server.commands.pop.raw.strip)
+      imap.uid_fetch 1.., "FAST", partial: 1...501
+      assert_equal("RUBY0003 UID FETCH 1:* FAST (PARTIAL 1:500)",
+                   server.commands.pop.raw.strip)
+      imap.uid_fetch 1.., "FAST", partial: -500..-1
+      assert_equal("RUBY0004 UID FETCH 1:* FAST (PARTIAL -500:-1)",
+                   server.commands.pop.raw.strip)
+      imap.uid_fetch 1.., "FAST", partial: -500...-1
+      assert_equal("RUBY0005 UID FETCH 1:* FAST (PARTIAL -500:-2)",
+                   server.commands.pop.raw.strip)
+      imap.uid_fetch 1.., "FAST", partial: 1..20, changedsince: 1234
+      assert_equal("RUBY0006 UID FETCH 1:* FAST (PARTIAL 1:20 CHANGEDSINCE 1234)",
+                   server.commands.pop.raw.strip)
+    end
+  end
+
   test "#store with unchangedsince" do
     with_fake_server select: "inbox" do |server, imap|
       server.on("STORE", &:done_ok)

--- a/test/net/imap/test_imap_response_parser.rb
+++ b/test/net/imap/test_imap_response_parser.rb
@@ -103,6 +103,9 @@ class IMAPResponseParserTest < Test::Unit::TestCase
   # RFC 9208: QUOTA extension
   generate_tests_from fixture_file: "rfc9208_quota_responses.yml"
 
+  # RFC 9394: PARTIAL extension
+  generate_tests_from fixture_file: "rfc9394_partial.yml"
+
   ############################################################################
   # Workarounds or unspecified extensions:
   generate_tests_from fixture_file: "quirky_behaviors.yml"


### PR DESCRIPTION
 - Updates `#search`, `#uid_search` with the `PARTIAL` return option which adds `ESearchResult#partial` return data.
 - Updates `#uid_fetch` with the `partial` modifier (kwarg).