### PR TITLE
🐛 Fix partial-range encoding of exclusive ranges

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3338,22 +3338,12 @@ module Net
         ]
       return_opts.map {|opt|
         case opt
-        when Symbol then opt.to_s
-        when Range  then partial_range_last_or_seqset(opt)
-        else             opt
+        when Symbol                 then opt.to_s
+        when PartialRange::Negative then PartialRange[opt]
+        when Range                  then SequenceSet[opt]
+        else                             opt
         end
       }
-    end
-
-    def partial_range_last_or_seqset(range)
-      case [range.begin, range.end]
-      in [Integer => first, Integer => last] if first.negative? && last.negative?
-        # partial-range-last [RFC9394]
-        first <= last or raise DataFormatError, "empty range: %p" % [range]
-        "#{first}:#{last}"
-      else
-        SequenceSet[range]
-      end
     end
 
     def search_internal(cmd, ...)

--- a/lib/net/imap/response_parser.rb
+++ b/lib/net/imap/response_parser.rb
@@ -321,6 +321,24 @@ module Net
         SEQUENCE_SET      = /#{SEQUENCE_SET_ITEM}(?:,#{SEQUENCE_SET_ITEM})*/n
         SEQUENCE_SET_STR  = /\A#{SEQUENCE_SET}\z/n
 
+        # partial-range-first = nz-number ":" nz-number
+        #     ;; Request to search from oldest (lowest UIDs) to
+        #     ;; more recent messages.
+        #     ;; A range 500:400 is the same as 400:500.
+        #     ;; This is similar to <seq-range> from [RFC3501]
+        #     ;; but cannot contain "*".
+        PARTIAL_RANGE_FIRST = /\A(#{NZ_NUMBER}):(#{NZ_NUMBER})\z/n
+
+        # partial-range-last  = MINUS nz-number ":" MINUS nz-number
+        #     ;; Request to search from newest (highest UIDs) to
+        #     ;; oldest messages.
+        #     ;; A range -500:-400 is the same as -400:-500.
+        PARTIAL_RANGE_LAST  = /\A(-#{NZ_NUMBER}):(-#{NZ_NUMBER})\z/n
+
+        # partial-range     = partial-range-first / partial-range-last
+        PARTIAL_RANGE       = Regexp.union(PARTIAL_RANGE_FIRST,
+                                           PARTIAL_RANGE_LAST)
+
         # RFC3501:
         #   literal          = "{" number "}" CRLF *CHAR8
         #                        ; Number represents the number of CHAR8s


### PR DESCRIPTION
Previously, `imap.uid_search "ALL", return: ["PARTIAL", 1...500]` would wrongly encode the range to "1:500", but it should encode as "1:499".

Maybe this could have been a one line bugfix: `first, last = range.minmax`.  But the rest was written to simplify support for the `PARTIAL` extension (#367).