### PR TITLE
🐛 Fix `SequenceSet#append` when its `@string` is nil

### DIFF
--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -684,8 +684,9 @@ module Net
         modifying!
         tuple = input_to_tuple object
         entry = tuple_to_str tuple
+        string unless empty? # write @string before tuple_add
         tuple_add tuple
-        @string = -(string ? "#{@string},#{entry}" : entry)
+        @string = -(@string ? "#{@string},#{entry}" : entry)
         self
       end
 

--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -56,18 +56,20 @@ module Net
     #     set = Net::IMAP::SequenceSet[1, 2, [3..7, 5], 6..10, 2048, 1024]
     #     set.valid_string  #=> "1:10,55,1024:2048"
     #
-    # == Normalized form
+    # == Ordered and Normalized sets
     #
-    # When a sequence set is created with a single String value, that #string
-    # representation is preserved.  SequenceSet's internal representation
-    # implicitly sorts all entries, de-duplicates numbers, and coalesces
-    # adjacent or overlapping ranges.  Most enumeration methods and offset-based
-    # methods use this normalized representation.  Most modification methods
-    # will convert #string to its normalized form.
+    # Sometimes the order of the set's members is significant, such as with the
+    # +ESORT+, <tt>CONTEXT=SORT</tt>, and +UIDPLUS+ extensions.  So, when a
+    # sequence set is created by the parser or with a single string value, that
+    # #string representation is preserved.
     #
-    # In some cases the order of the string representation is significant, such
-    # as the +ESORT+, <tt>CONTEXT=SORT</tt>, and +UIDPLUS+ extensions.  Use
-    # #entries or #each_entry to enumerate the set in its original order.  To
+    # Internally, SequenceSet stores a normalized representation which sorts all
+    # entries, de-duplicates numbers, and coalesces adjacent or overlapping
+    # ranges.  Most methods use this normalized representation to achieve
+    # <tt>O(lg n)</tt> porformance.  Use #entries or #each_entry to enumerate
+    # the set in its original order.
+    #
+    # Most modification methods convert #string to its normalized form.  To
     # preserve #string order while modifying a set, use #append, #string=, or
     # #replace.
     #
@@ -181,7 +183,7 @@ module Net
     # - #max: Returns the maximum number in the set.
     # - #minmax: Returns the minimum and maximum numbers in the set.
     #
-    # <i>Accessing value by offset:</i>
+    # <i>Accessing value by (normalized) offset:</i>
     # - #[] (aliased as #slice): Returns the number or consecutive subset at a
     #   given offset or range of offsets.
     # - #at: Returns the number at a given offset.
@@ -189,6 +191,7 @@ module Net
     #
     # <i>Set cardinality:</i>
     # - #count (aliased as #size): Returns the count of numbers in the set.
+    #   Duplicated numbers are not counted.
     # - #empty?: Returns whether the set has no members.  \IMAP syntax does not
     #   allow empty sequence sets.
     # - #valid?: Returns whether the set has any members.
@@ -838,8 +841,8 @@ module Net
       # <tt>*</tt> translates to an endless range.  Use #limit to translate both
       # cases to a maximum value.
       #
-      # If the original input was unordered or contains overlapping ranges, the
-      # returned ranges will be ordered and coalesced.
+      # The returned elements will be sorted and coalesced, even when the input
+      # #string is not.  <tt>*</tt> will sort last.  See #normalize.
       #
       #   Net::IMAP::SequenceSet["2,5:9,6,*,12:11"].elements
       #   #=> [2, 5..9, 11..12, :*]
@@ -857,7 +860,7 @@ module Net
       # translates to <tt>:*..</tt>.  Use #limit to set <tt>*</tt> to a maximum
       # value.
       #
-      # The returned ranges will be ordered and coalesced, even when the input
+      # The returned ranges will be sorted and coalesced, even when the input
       # #string is not.  <tt>*</tt> will sort last.  See #normalize.
       #
       #   Net::IMAP::SequenceSet["2,5:9,6,*,12:11"].ranges

--- a/test/net/imap/test_sequence_set.rb
+++ b/test/net/imap/test_sequence_set.rb
@@ -344,6 +344,14 @@ class IMAPSequenceSetTest < Test::Unit::TestCase
     assert_equal "1:6,4:9", SequenceSet.new("1:6").append("4:9").string
     assert_equal "1:4,5:*", SequenceSet.new("1:4").append(5..).string
     assert_equal "5:*,1:4", SequenceSet.new("5:*").append(1..4).string
+    # also works from empty
+    assert_equal "5,1",     SequenceSet.new.append(5).append(1).string
+    # also works when *previously* input was non-strings
+    assert_equal "*,1",     SequenceSet.new(:*).append(1).string
+    assert_equal "1,5",     SequenceSet.new(1).append("5").string
+    assert_equal "1:6,4:9", SequenceSet.new(1..6).append(4..9).string
+    assert_equal "1:4,5:*", SequenceSet.new(1..4).append(5..).string
+    assert_equal "5:*,1:4", SequenceSet.new(5..).append(1..4).string
   end
 
   test "#merge" do


### PR DESCRIPTION
When a SequenceSet is not normalized, it stores its string in `@string`.  When it is normalized, `@string` is still used as a cache for `@string`.

When `@string` isn't set, but the sequence set is not empty, `#append` would generate the normalized string _after_ adding the new numbers, and _then_ append the new numbers to the end of the string.  For example:

```ruby
SequenceSet.new.append(5).append(1).string
# in net-imap v0.5.5 => "1,5,1"
# with this bugfix   => "1,5"
```

This PR forces the string to be generated prior to adding the new numbers, so they can be appended to the end.