### PR TITLE
🐛 Fix SequenceSet merging in another SequenceSet

### DIFF
--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -1341,8 +1341,8 @@ module Net
         modifying!
         min, max = tuple
         lower, lower_idx = tuple_gte_with_index(min - 1)
-        if    lower.nil?              then tuples << tuple
-        elsif (max + 1) < lower.first then tuples.insert(lower_idx, tuple)
+        if    lower.nil?              then tuples << [min, max]
+        elsif (max + 1) < lower.first then tuples.insert(lower_idx, [min, max])
         else  tuple_coalesce(lower, lower_idx, min, max)
         end
       end

--- a/test/net/imap/test_sequence_set.rb
+++ b/test/net/imap/test_sequence_set.rb
@@ -362,6 +362,11 @@ class IMAPSequenceSetTest < Test::Unit::TestCase
     assert_equal seqset["1:3,5,7:9"], seqset["1,3,5,7:8"].merge(seqset["2,8:9"])
     assert_equal seqset["1:*"],       seqset["5:*"].merge(1..4)
     assert_equal seqset["1:5"],       seqset["1,3,5"].merge(seqset["2,4"])
+    # when merging frozen SequenceSet
+    set = SequenceSet.new
+    set.merge SequenceSet[1, 3, 5]
+    set.merge SequenceSet[2..33]
+    assert_equal seqset[1..33], set
   end
 
   test "set - other" do


### PR DESCRIPTION
Most methods convert their inputs into an array of range tuples.  For efficiency, SequenceSet inputs just use the internal `@tuples` array directly.  Unfortunately, the internal tuple arrays were also reused, which could cause a variety of bugs.  Fortunately, the only bug I experienced was that adding a frozen SequenceSet would result in frozen tuples being added to a mutable set.  But this could also result in modifications to one SequenceSet affecting another SequenceSet!