### PR TITLE
🔧 ResponseParser config is mutable and non-global (backports #381)

### DIFF
--- a/lib/net/imap/response_parser.rb
+++ b/lib/net/imap/response_parser.rb
@@ -13,13 +13,17 @@ module Net
 
       attr_reader :config
 
-      # :call-seq: Net::IMAP::ResponseParser.new -> Net::IMAP::ResponseParser
+      # Creates a new ResponseParser.
+      #
+      # When +config+ is frozen or global, the parser #config inherits from it.
+      # Otherwise, +config+ will be used directly.
       def initialize(config: Config.global)
         @str = nil
         @pos = nil
         @lex_state = nil
         @token = nil
         @config = Config[config]
+        @config = @config.new if @config == Config.global || @config.frozen?
       end
 
       # :call-seq:

--- a/test/net/imap/test_imap_response_parser.rb
+++ b/test/net/imap/test_imap_response_parser.rb
@@ -109,6 +109,41 @@ class IMAPResponseParserTest < Test::Unit::TestCase
   # response data, should still use normal tests, below
   ############################################################################
 
+  test "default config inherits from Config.global" do
+    parser = Net::IMAP::ResponseParser.new
+    refute parser.config.frozen?
+    refute_equal Net::IMAP::Config.global, parser.config
+    assert_same  Net::IMAP::Config.global, parser.config.parent
+  end
+
+  test "config can be passed in to #initialize" do
+    config = Net::IMAP::Config.global.new
+    parser = Net::IMAP::ResponseParser.new config: config
+    assert_same config, parser.config
+  end
+
+  test "passing in global config inherits from Config.global" do
+    parser = Net::IMAP::ResponseParser.new config: Net::IMAP::Config.global
+    refute parser.config.frozen?
+    refute_equal Net::IMAP::Config.global, parser.config
+    assert_same  Net::IMAP::Config.global, parser.config.parent
+  end
+
+  test "config will inherits from passed in frozen config" do
+    parser = Net::IMAP::ResponseParser.new config: {debug: true}
+    refute_equal Net::IMAP::Config.global, parser.config.parent
+    refute parser.config.frozen?
+
+    assert parser.config.parent.frozen?
+    assert parser.config.debug?
+    assert parser.config.inherited?(:debug)
+
+    config = Net::IMAP::Config[debug: true]
+    parser = Net::IMAP::ResponseParser.new(config: config)
+    refute_equal Net::IMAP::Config.global, parser.config.parent
+    assert_same  config, parser.config.parent
+  end
+
   # Strangly, there are no example responses for BINARY[section] in either
   # RFC3516 or RFC9051!  The closest I found was RFC5259, and those examples
   # aren't FETCH responses.


### PR DESCRIPTION
* Backports #381 to `v0.4-stable`