### PR TITLE
➕ Add "irb" to Gemfile to silence warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem "digest"
 gem "strscan"
 gem "base64"
 
+gem "irb"
 gem "rake"
 gem "rdoc"
 gem "test-unit"


### PR DESCRIPTION
This silences the warning seen when running `bin/console` in development.