### PR TITLE
♻️ Parse `uid-set` as `sequence-set` without `*`

### DIFF
--- a/lib/net/imap/response_parser.rb
+++ b/lib/net/imap/response_parser.rb
@@ -2005,7 +2005,7 @@ module Net
       def resp_code_apnd__data
         validity = number; SP!
         dst_uids = uid_set # uniqueid ⊂ uid-set
-        UIDPlusData.new(validity, nil, dst_uids)
+        UIDPlus(validity, nil, dst_uids)
       end
 
       # already matched:  "COPYUID"
@@ -2015,6 +2015,12 @@ module Net
         validity = number;  SP!
         src_uids = uid_set; SP!
         dst_uids = uid_set
+        UIDPlus(validity, src_uids, dst_uids)
+      end
+
+      def UIDPlus(validity, src_uids, dst_uids)
+        src_uids &&= src_uids.each_ordered_number.to_a
+        dst_uids   = dst_uids.each_ordered_number.to_a
         UIDPlusData.new(validity, src_uids, dst_uids)
       end
 
@@ -2141,15 +2147,9 @@ module Net
       #      uniqueid        = nz-number
       #                          ; Strictly ascending
       def uid_set
-        token = match(T_NUMBER, T_ATOM)
-        case token.symbol
-        when T_NUMBER then [Integer(token.value)]
-        when T_ATOM
-          token.value.split(",").flat_map {|range|
-            range = range.split(":").map {|uniqueid| Integer(uniqueid) }
-            range.size == 1 ? range : Range.new(range.min, range.max).to_a
-          }
-        end
+        set = sequence_set
+        parse_error("uid-set cannot contain '*'") if set.include_star?
+        set
       end
 
       def nil_atom

--- a/test/net/imap/test_imap_response_parser.rb
+++ b/test/net/imap/test_imap_response_parser.rb
@@ -202,6 +202,15 @@ class IMAPResponseParserTest < Test::Unit::TestCase
     Net::IMAP.debug = debug
   end
 
+  test "APPENDUID with '*'" do
+    parser = Net::IMAP::ResponseParser.new
+    assert_raise_with_message Net::IMAP::ResponseParseError, /uid-set cannot contain '\*'/ do
+      parser.parse(
+        "A004 OK [appendUID 1 1:*] Done\r\n"
+      )
+    end
+  end
+
   test "COPYUID with backwards ranges" do
     parser = Net::IMAP::ResponseParser.new
     response = parser.parse(
@@ -221,6 +230,15 @@ class IMAPResponseParserTest < Test::Unit::TestCase
       },
       code.data.uid_mapping
     )
+  end
+
+  test "COPYUID with '*'" do
+    parser = Net::IMAP::ResponseParser.new
+    assert_raise_with_message Net::IMAP::ResponseParseError, /uid-set cannot contain '\*'/ do
+      parser.parse(
+        "A004 OK [copyUID 1 1:* 1:*] Done\r\n"
+      )
+    end
   end
 
 end


### PR DESCRIPTION
In addition to letting us delete some code, this is also a step towards replacing `UIDPlusData` with new (incompatible) data structures that store UID sets directly, rather than converted into arrays of integers.