### PR TITLE
📚 Document COPYUID in tagged vs untagged responses

### DIFF
--- a/lib/net/imap/uidplus_data.rb
+++ b/lib/net/imap/uidplus_data.rb
@@ -6,12 +6,20 @@ module Net
     # UIDPlusData represents the ResponseCode#data that accompanies the
     # +APPENDUID+ and +COPYUID+ {response codes}[rdoc-ref:ResponseCode].
     #
-    # A server that supports +UIDPLUS+ should send a UIDPlusData object inside
-    # every TaggedResponse returned by the append[rdoc-ref:Net::IMAP#append],
-    # copy[rdoc-ref:Net::IMAP#copy], move[rdoc-ref:Net::IMAP#move], {uid
-    # copy}[rdoc-ref:Net::IMAP#uid_copy], and {uid
-    # move}[rdoc-ref:Net::IMAP#uid_move] commands---unless the destination
-    # mailbox reports +UIDNOTSTICKY+.
+    # A server that supports +UIDPLUS+ should send UIDPlusData in response to
+    # the append[rdoc-ref:Net::IMAP#append], copy[rdoc-ref:Net::IMAP#copy],
+    # move[rdoc-ref:Net::IMAP#move], {uid copy}[rdoc-ref:Net::IMAP#uid_copy],
+    # and {uid move}[rdoc-ref:Net::IMAP#uid_move] commands---unless the
+    # destination mailbox reports +UIDNOTSTICKY+.
+    #
+    # Note that append[rdoc-ref:Net::IMAP#append], copy[rdoc-ref:Net::IMAP#copy]
+    # and {uid_copy}[rdoc-ref:Net::IMAP#uid_copy] return UIDPlusData in their
+    # TaggedResponse.  But move[rdoc-ref:Net::IMAP#copy] and
+    # {uid_move}[rdoc-ref:Net::IMAP#uid_move] _should_ send UIDPlusData in an
+    # UntaggedResponse response before sending their TaggedResponse.  However
+    # some servers do send UIDPlusData in the TaggedResponse for +MOVE+
+    # commands---this complies with the older +UIDPLUS+ specification but is
+    # discouraged by the +MOVE+ extension and disallowed by +IMAP4rev2+.
     #
     # == Required capability
     # Requires either +UIDPLUS+ [RFC4315[https://www.rfc-editor.org/rfc/rfc4315]]


### PR DESCRIPTION
`COPYUID` was originally (in the `UIDPLUS` extension) only allowed to be sent in the tagged response to the command which copied the messages.

Because the move commands atomically combine copy with expunge, the `MOVE` extension changed that for move commands, to recommend sending it as an untagged response prior to the tagged response for the move.  This way, `EXPUNGE` responses could also be sent prior to the completion of the `MOVE`.  `IMAP4rev2` updates that recommendation to a requirement.

However, some of the biggest email providers (most notably, GMail) follow the original `UIDPLUS` extension's requirement and still send the `COPYUID` response with the tagged response, even for move commands.