### PR TITLE
✨ SequenceSet ordered entries methods (backports to v0.4-stable)

### DIFF
--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -60,18 +60,20 @@ module Net
     #     set = Net::IMAP::SequenceSet[1, 2, [3..7, 5], 6..10, 2048, 1024]
     #     set.valid_string  #=> "1:10,55,1024:2048"
     #
-    # == Normalized form
+    # == Ordered and Normalized sets
     #
-    # When a sequence set is created with a single String value, that #string
-    # representation is preserved.  SequenceSet's internal representation
-    # implicitly sorts all entries, de-duplicates numbers, and coalesces
-    # adjacent or overlapping ranges.  Most enumeration methods and offset-based
-    # methods use this normalized representation.  Most modification methods
-    # will convert #string to its normalized form.
+    # Sometimes the order of the set's members is significant, such as with the
+    # +ESORT+, <tt>CONTEXT=SORT</tt>, and +UIDPLUS+ extensions.  So, when a
+    # sequence set is created by the parser or with a single string value, that
+    # #string representation is preserved.
     #
-    # In some cases the order of the string representation is significant, such
-    # as the +ESORT+, <tt>CONTEXT=SORT</tt>, and +UIDPLUS+ extensions.  Use
-    # #entries or #each_entry to enumerate the set in its original order.  To
+    # Internally, SequenceSet stores a normalized representation which sorts all
+    # entries, de-duplicates numbers, and coalesces adjacent or overlapping
+    # ranges.  Most methods use this normalized representation to achieve
+    # <tt>O(lg n)</tt> porformance.  Use #entries or #each_entry to enumerate
+    # the set in its original order.
+    #
+    # Most modification methods convert #string to its normalized form.  To
     # preserve #string order while modifying a set, use #append, #string=, or
     # #replace.
     #
@@ -185,7 +187,7 @@ module Net
     # - #max: Returns the maximum number in the set.
     # - #minmax: Returns the minimum and maximum numbers in the set.
     #
-    # <i>Accessing value by offset:</i>
+    # <i>Accessing value by (normalized) offset:</i>
     # - #[] (aliased as #slice): Returns the number or consecutive subset at a
     #   given offset or range of offsets.
     # - #at: Returns the number at a given offset.
@@ -193,6 +195,7 @@ module Net
     #
     # <i>Set cardinality:</i>
     # - #count (aliased as #size): Returns the count of numbers in the set.
+    #   Duplicated numbers are not counted.
     # - #empty?: Returns whether the set has no members.  \IMAP syntax does not
     #   allow empty sequence sets.
     # - #valid?: Returns whether the set has any members.
@@ -843,8 +846,8 @@ module Net
       # <tt>*</tt> translates to an endless range.  Use #limit to translate both
       # cases to a maximum value.
       #
-      # If the original input was unordered or contains overlapping ranges, the
-      # returned ranges will be ordered and coalesced.
+      # The returned elements will be sorted and coalesced, even when the input
+      # #string is not.  <tt>*</tt> will sort last.  See #normalize.
       #
       #   Net::IMAP::SequenceSet["2,5:9,6,*,12:11"].elements
       #   #=> [2, 5..9, 11..12, :*]
@@ -862,7 +865,7 @@ module Net
       # translates to <tt>:*..</tt>.  Use #limit to set <tt>*</tt> to a maximum
       # value.
       #
-      # The returned ranges will be ordered and coalesced, even when the input
+      # The returned ranges will be sorted and coalesced, even when the input
       # #string is not.  <tt>*</tt> will sort last.  See #normalize.
       #
       #   Net::IMAP::SequenceSet["2,5:9,6,*,12:11"].ranges

--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -187,11 +187,11 @@ module Net
     # - #max: Returns the maximum number in the set.
     # - #minmax: Returns the minimum and maximum numbers in the set.
     #
-    # <i>Accessing value by (normalized) offset:</i>
+    # <i>Accessing value by offset in sorted set:</i>
     # - #[] (aliased as #slice): Returns the number or consecutive subset at a
-    #   given offset or range of offsets.
-    # - #at: Returns the number at a given offset.
-    # - #find_index: Returns the given number's offset in the set
+    #   given offset or range of offsets in the sorted set.
+    # - #at: Returns the number at a given offset in the sorted set.
+    # - #find_index: Returns the given number's offset in the sorted set.
     #
     # <i>Set cardinality:</i>
     # - #count (aliased as #size): Returns the count of numbers in the set.
@@ -1087,10 +1087,10 @@ module Net
         count_with_duplicates != count
       end
 
-      # Returns the index of +number+ in the set, or +nil+ if +number+ isn't in
-      # the set.
+      # Returns the (sorted and deduplicated) index of +number+ in the set, or
+      # +nil+ if +number+ isn't in the set.
       #
-      # Related: #[]
+      # Related: #[], #at
       def find_index(number)
         number = to_tuple_int number
         each_tuple_with_index do |min, max, idx_min|
@@ -1124,8 +1124,11 @@ module Net
 
       # :call-seq: at(index) -> integer or nil
       #
-      # Returns a number from +self+, without modifying the set.  Behaves the
-      # same as #[], except that #at only allows a single integer argument.
+      # Returns the number at the given +index+ in the sorted set, without
+      # modifying the set.
+      #
+      # +index+ is interpreted the same as in #[], except that #at only allows a
+      # single integer argument.
       #
       # Related: #[], #slice
       def at(index)
@@ -1150,17 +1153,18 @@ module Net
       #    seqset[range]         -> sequence set or nil
       #    slice(range)          -> sequence set or nil
       #
-      # Returns a number or a subset from +self+, without modifying the set.
+      # Returns a number or a subset from the _sorted_ set, without modifying
+      # the set.
       #
       # When an Integer argument +index+ is given, the number at offset +index+
-      # is returned:
+      # in the sorted set is returned:
       #
       #     set = Net::IMAP::SequenceSet["10:15,20:23,26"]
       #     set[0]   #=> 10
       #     set[5]   #=> 15
       #     set[10]  #=> 26
       #
-      # If +index+ is negative, it counts relative to the end of +self+:
+      # If +index+ is negative, it counts relative to the end of the sorted set:
       #     set = Net::IMAP::SequenceSet["10:15,20:23,26"]
       #     set[-1]  #=> 26
       #     set[-3]  #=> 22
@@ -1172,13 +1176,14 @@ module Net
       #     set[11]  #=> nil
       #     set[-12] #=> nil
       #
-      # The result is based on the normalized set—sorted and de-duplicated—not
-      # on the assigned value of #string.
+      # The result is based on the sorted and de-duplicated set, not on the
+      # ordered #entries in #string.
       #
       #     set = Net::IMAP::SequenceSet["12,20:23,11:16,21"]
       #     set[0]   #=> 11
       #     set[-1]  #=> 23
       #
+      # Related: #at
       def [](index, length = nil)
         if    length              then slice_length(index, length)
         elsif index.is_a?(Range)  then slice_range(index)

--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -166,7 +166,7 @@ module Net
     # - #===:
     #   Returns whether a given object is fully contained within +self+, or
     #   +nil+ if the object cannot be converted to a compatible type.
-    # - #cover? (aliased as #===):
+    # - #cover?:
     #   Returns whether a given object is fully contained within +self+.
     # - #intersect? (aliased as #overlap?):
     #   Returns whether +self+ and a given object have any common elements.

--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -204,14 +204,11 @@ module Net
     #
     # === Methods for Iterating
     #
+    # <i>Normalized (sorted and coalesced):</i>
     # - #each_element: Yields each number and range in the set, sorted and
     #   coalesced, and returns +self+.
     # - #elements (aliased as #to_a): Returns an Array of every number and range
     #   in the set, sorted and coalesced.
-    # - #each_entry: Yields each number and range in the set, unsorted and
-    #   without deduplicating numbers or coalescing ranges, and returns +self+.
-    # - #entries: Returns an Array of every number and range in the set,
-    #   unsorted and without deduplicating numbers or coalescing ranges.
     # - #each_range:
     #   Yields each element in the set as a Range and returns +self+.
     # - #ranges: Returns an Array of every element in the set, converting
@@ -220,6 +217,12 @@ module Net
     # - #numbers: Returns an Array with every number in the set, expanding
     #   ranges into all of their contained numbers.
     # - #to_set: Returns a Set containing all of the #numbers in the set.
+    #
+    # <i>Order preserving:</i>
+    # - #each_entry: Yields each number and range in the set, unsorted and
+    #   without deduplicating numbers or coalescing ranges, and returns +self+.
+    # - #entries: Returns an Array of every number and range in the set,
+    #   unsorted and without deduplicating numbers or coalescing ranges.
     #
     # === Methods for \Set Operations
     # These methods do not modify +self+.
@@ -240,19 +243,29 @@ module Net
     # === Methods for Assigning
     # These methods add or replace elements in +self+.
     #
+    # <i>Normalized (sorted and coalesced):</i>
+    #
+    # These methods always update #string to be fully sorted and coalesced.
+    #
     # - #add (aliased as #<<): Adds a given object to the set; returns +self+.
     # - #add?: If the given object is not an element in the set, adds it and
     #   returns +self+; otherwise, returns +nil+.
     # - #merge: Merges multiple elements into the set; returns +self+.
+    # - #complement!: Replaces the contents of the set with its own #complement.
+    #
+    # <i>Order preserving:</i>
+    #
+    # These methods _may_ cause #string to not be sorted or coalesced.
+    #
     # - #append: Adds a given object to the set, appending it to the existing
     #   string, and returns +self+.
     # - #string=: Assigns a new #string value and replaces #elements to match.
     # - #replace: Replaces the contents of the set with the contents
     #   of a given object.
-    # - #complement!: Replaces the contents of the set with its own #complement.
     #
     # === Methods for Deleting
-    # These methods remove elements from +self+.
+    # These methods remove elements from +self+, and update #string to be fully
+    # sorted and coalesced.
     #
     # - #clear: Removes all elements in the set; returns +self+.
     # - #delete: Removes a given object from the set; returns +self+.

--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -194,6 +194,7 @@ module Net
     # - #find_index: Returns the given number's offset in the sorted set.
     #
     # <i>Accessing value by offset in ordered entries</i>
+    # - #ordered_at: Returns the number at a given offset in the ordered entries.
     # - #find_ordered_index: Returns the index of the given number's first
     #   occurrence in entries.
     #
@@ -1149,15 +1150,32 @@ module Net
       # +index+ is interpreted the same as in #[], except that #at only allows a
       # single integer argument.
       #
-      # Related: #[], #slice
+      # Related: #[], #slice, #ordered_at
       def at(index)
+        lookup_number_by_tuple_index(tuples, index)
+      end
+
+      # :call-seq: ordered_at(index) -> integer or nil
+      #
+      # Returns the number at the given +index+ in the ordered #entries, without
+      # modifying the set.
+      #
+      # +index+ is interpreted the same as in #at (and #[]), except that
+      # #ordered_at applies to the ordered #entries, not the sorted set.
+      #
+      # Related: #[], #slice, #ordered_at
+      def ordered_at(index)
+        lookup_number_by_tuple_index(each_entry_tuple, index)
+      end
+
+      private def lookup_number_by_tuple_index(tuples, index)
         index = Integer(index.to_int)
         if index.negative?
-          reverse_each_tuple_with_index(@tuples) do |min, max, idx_min, idx_max|
+          reverse_each_tuple_with_index(tuples) do |min, max, idx_min, idx_max|
             idx_min <= index and return from_tuple_int(min + (index - idx_min))
           end
         else
-          each_tuple_with_index(@tuples) do |min, _, idx_min, idx_max|
+          each_tuple_with_index(tuples) do |min, _, idx_min, idx_max|
             index <= idx_max and return from_tuple_int(min + (index - idx_min))
           end
         end

--- a/test/net/imap/test_sequence_set.rb
+++ b/test/net/imap/test_sequence_set.rb
@@ -164,6 +164,21 @@ class IMAPSequenceSetTest < Test::Unit::TestCase
     assert_raise DataFormatError do SequenceSet.try_convert(obj) end
   end
 
+  test "#at(non-negative index)" do
+    assert_nil        SequenceSet.empty.at(0)
+    assert_equal   1, SequenceSet[1..].at(0)
+    assert_equal   1, SequenceSet.full.at(0)
+    assert_equal 111, SequenceSet.full.at(110)
+    assert_equal   4, SequenceSet[2,4,6,8].at(1)
+    assert_equal   8, SequenceSet[2,4,6,8].at(3)
+    assert_equal   6, SequenceSet[4..6].at(2)
+    assert_nil        SequenceSet[4..6].at(3)
+    assert_equal 205, SequenceSet["101:110,201:210,301:310"].at(14)
+    assert_equal 310, SequenceSet["101:110,201:210,301:310"].at(29)
+    assert_nil        SequenceSet["101:110,201:210,301:310"].at(44)
+    assert_equal  :*, SequenceSet["1:10,*"].at(10)
+  end
+
   test "#[non-negative index]" do
     assert_nil        SequenceSet.empty[0]
     assert_equal   1, SequenceSet[1..][0]
@@ -179,18 +194,32 @@ class IMAPSequenceSetTest < Test::Unit::TestCase
     assert_equal  :*, SequenceSet["1:10,*"][10]
   end
 
+  test "#at(negative index)" do
+    assert_nil        SequenceSet.empty.at(-1)
+    assert_equal  :*, SequenceSet[1..].at(-1)
+    assert_equal   1, SequenceSet.full.at(-(2**32))
+    assert_equal 111, SequenceSet[1..111].at(-1)
+    assert_equal   6, SequenceSet[2,4,6,8].at(-2)
+    assert_equal   2, SequenceSet[2,4,6,8].at(-4)
+    assert_equal   4, SequenceSet[4..6].at(-3)
+    assert_nil        SequenceSet[4..6].at(-4)
+    assert_equal 207, SequenceSet["101:110,201:210,301:310"].at(-14)
+    assert_equal 102, SequenceSet["101:110,201:210,301:310"].at(-29)
+    assert_nil        SequenceSet["101:110,201:210,301:310"].at(-44)
+  end
+
   test "#[negative index]" do
-    assert_nil        SequenceSet.empty[0]
+    assert_nil        SequenceSet.empty[-1]
     assert_equal  :*, SequenceSet[1..][-1]
     assert_equal   1, SequenceSet.full[-(2**32)]
     assert_equal 111, SequenceSet[1..111][-1]
-    assert_equal   4, SequenceSet[2,4,6,8][1]
-    assert_equal   8, SequenceSet[2,4,6,8][3]
-    assert_equal   6, SequenceSet[4..6][2]
-    assert_nil        SequenceSet[4..6][3]
-    assert_equal 205, SequenceSet["101:110,201:210,301:310"][14]
-    assert_equal 310, SequenceSet["101:110,201:210,301:310"][29]
-    assert_nil        SequenceSet["101:110,201:210,301:310"][44]
+    assert_equal   6, SequenceSet[2,4,6,8][-2]
+    assert_equal   2, SequenceSet[2,4,6,8][-4]
+    assert_equal   4, SequenceSet[4..6][-3]
+    assert_nil        SequenceSet[4..6][-4]
+    assert_equal 207, SequenceSet["101:110,201:210,301:310"][-14]
+    assert_equal 102, SequenceSet["101:110,201:210,301:310"][-29]
+    assert_nil        SequenceSet["101:110,201:210,301:310"][-44]
   end
 
   test "#[start, length]" do

--- a/test/net/imap/test_sequence_set.rb
+++ b/test/net/imap/test_sequence_set.rb
@@ -782,8 +782,40 @@ class IMAPSequenceSetTest < Test::Unit::TestCase
     assert_equal data[:entries], seqset.each_entry.to_a
   end
 
+  test "#each_range" do |data|
+    seqset = SequenceSet.new(data[:input])
+    array = []
+    assert_equal seqset, seqset.each_range { array << _1 }
+    assert_equal data[:ranges], array
+    assert_equal data[:ranges], seqset.each_range.to_a
+  end
+
   test "#ranges" do |data|
     assert_equal data[:ranges], SequenceSet.new(data[:input]).ranges
+  end
+
+  test "#each_number" do |data|
+    seqset   = SequenceSet.new(data[:input])
+    expected = data[:numbers]
+    enum     = seqset.each_number
+    if expected.is_a?(Class) && expected < Exception
+      assert_raise expected do enum.to_a end
+      assert_raise expected do enum.each do fail "shouldn't get here" end end
+    else
+      array = []
+      assert_equal seqset, seqset.each_number { array << _1 }
+      assert_equal expected, array
+      assert_equal expected, seqset.each_number.to_a
+    end
+  end
+
+  test "#numbers" do |data|
+    expected = data[:numbers]
+    if expected.is_a?(Class) && expected < Exception
+      assert_raise expected do SequenceSet.new(data[:input]).numbers end
+    else
+      assert_equal expected, SequenceSet.new(data[:input]).numbers
+    end
   end
 
   test "#string" do |data|
@@ -833,15 +865,6 @@ class IMAPSequenceSetTest < Test::Unit::TestCase
     set = SequenceSet.new(data[:input])
     assert_equal(data[:complement], set.complement.to_s)
     assert_equal(data[:complement], (~set).to_s)
-  end
-
-  test "#numbers" do |data|
-    expected = data[:numbers]
-    if expected.is_a?(Class) && expected < Exception
-      assert_raise expected do SequenceSet.new(data[:input]).numbers end
-    else
-      assert_equal expected, SequenceSet.new(data[:input]).numbers
-    end
   end
 
   test "SequenceSet[input]" do |input|

--- a/test/net/imap/test_sequence_set.rb
+++ b/test/net/imap/test_sequence_set.rb
@@ -222,6 +222,38 @@ class IMAPSequenceSetTest < Test::Unit::TestCase
     assert_nil        SequenceSet["101:110,201:210,301:310"][-44]
   end
 
+  test "#ordered_at(non-negative index)" do
+    assert_nil        SequenceSet.empty.ordered_at(0)
+    assert_equal   1, SequenceSet.full.ordered_at(0)
+    assert_equal 111, SequenceSet.full.ordered_at(110)
+    assert_equal   1, SequenceSet["1:*"].ordered_at(0)
+    assert_equal  :*, SequenceSet["*,1"].ordered_at(0)
+    assert_equal   4, SequenceSet["6,4,8,2"].ordered_at(1)
+    assert_equal   2, SequenceSet["6,4,8,2"].ordered_at(3)
+    assert_equal   6, SequenceSet["9:11,4:6,1:3"].ordered_at(5)
+    assert_nil        SequenceSet["9:11,4:6,1:3"].ordered_at(9)
+    assert_equal 105, SequenceSet["201:210,101:110,301:310"].ordered_at(14)
+    assert_equal 310, SequenceSet["201:210,101:110,301:310"].ordered_at(29)
+    assert_nil        SequenceSet["201:210,101:110,301:310"].ordered_at(30)
+    assert_equal  :*, SequenceSet["1:10,*"].ordered_at(10)
+  end
+
+  test "#ordered_at(negative index)" do
+    assert_nil        SequenceSet.empty.ordered_at(-1)
+    assert_equal  :*, SequenceSet["1:*"].ordered_at(-1)
+    assert_equal   1, SequenceSet.full.ordered_at(-(2**32))
+    assert_equal  :*, SequenceSet["*,1"].ordered_at(0)
+    assert_equal   8, SequenceSet["6,4,8,2"].ordered_at(-2)
+    assert_equal   6, SequenceSet["6,4,8,2"].ordered_at(-4)
+    assert_equal   4, SequenceSet["9:11,4:6,1:3"].ordered_at(-6)
+    assert_equal  10, SequenceSet["9:11,4:6,1:3"].ordered_at(-8)
+    assert_nil        SequenceSet["9:11,4:6,1:3"].ordered_at(-12)
+    assert_equal 107, SequenceSet["201:210,101:110,301:310"].ordered_at(-14)
+    assert_equal 201, SequenceSet["201:210,101:110,301:310"].ordered_at(-30)
+    assert_nil        SequenceSet["201:210,101:110,301:310"].ordered_at(-31)
+    assert_equal  :*, SequenceSet["1:10,*"].ordered_at(10)
+  end
+
   test "#[start, length]" do
     assert_equal SequenceSet[10..99], SequenceSet.full[9, 90]
     assert_equal 90, SequenceSet.full[9, 90].count

--- a/test/net/imap/test_sequence_set.rb
+++ b/test/net/imap/test_sequence_set.rb
@@ -680,6 +680,7 @@ class IMAPSequenceSetTest < Test::Unit::TestCase
     entries:    [46, 6..7, 15, 1..3],
     ranges:     [1..3, 6..7, 15..15, 46..46],
     numbers:    [1, 2, 3, 6, 7, 15, 46],
+    ordered:    [46, 6, 7, 15, 1, 2, 3],
     to_s:       "46,7:6,15,3:1",
     normalize:  "1:3,6:7,15,46",
     count:      7,
@@ -704,6 +705,7 @@ class IMAPSequenceSetTest < Test::Unit::TestCase
     entries:    [1..5, 3..7, 9..10, 10..11],
     ranges:     [1..7, 9..11],
     numbers:    [1, 2, 3, 4, 5, 6, 7,  9, 10, 11],
+    ordered:    [1,2,3,4,5,  3,4,5,6,7,  9,10,  10,11],
     to_s:       "1:5,3:7,10:9,10:11",
     normalize:  "1:7,9:11",
     count:      10,
@@ -717,6 +719,7 @@ class IMAPSequenceSetTest < Test::Unit::TestCase
     entries:    [1..5, 3..4, 9..11, 10],
     ranges:     [1..5, 9..11],
     numbers:    [1, 2, 3, 4, 5, 9, 10, 11],
+    ordered:    [1,2,3,4,5,  3,4,  9,10,11,  10],
     to_s:       "1:5,3:4,9:11,10",
     normalize:  "1:5,9:11",
     count:      8,
@@ -814,6 +817,21 @@ class IMAPSequenceSetTest < Test::Unit::TestCase
       assert_raise expected do enum.each do fail "shouldn't get here" end end
     else
       assert_seqset_enum expected, seqset, :each_number
+    end
+  end
+
+  test "#each_ordered_number" do |data|
+    seqset   = SequenceSet.new(data[:input])
+    expected = data[:ordered] || data[:numbers]
+    if expected.is_a?(Class) && expected < Exception
+      assert_raise expected do
+        seqset.each_ordered_number do fail "shouldn't get here" end
+      end
+      enum = seqset.each_ordered_number
+      assert_raise expected do enum.to_a end
+      assert_raise expected do enum.each do fail "shouldn't get here" end end
+    else
+      assert_seqset_enum expected, seqset, :each_ordered_number
     end
   end
 

--- a/test/net/imap/test_sequence_set.rb
+++ b/test/net/imap/test_sequence_set.rb
@@ -727,6 +727,19 @@ class IMAPSequenceSetTest < Test::Unit::TestCase
     complement: "6:8,12:*",
   }, keep: true
 
+  data "multiple *", {
+    input:      "2:*,3:*,*",
+    elements:   [2..],
+    entries:    [2.., 3.., :*],
+    ranges:     [2..],
+    numbers:    RangeError,
+    to_s:       "2:*,3:*,*",
+    normalize:  "2:*",
+    count:      2**32 - 2,
+    count_dups: 2**32 - 2,
+    complement: "1",
+  }, keep: true
+
   data "array", {
     input:      ["1:5,3:4", 9..11, "10", 99, :*],
     elements:   [1..5, 9..11, 99, :*],

--- a/test/net/imap/test_sequence_set.rb
+++ b/test/net/imap/test_sequence_set.rb
@@ -248,6 +248,44 @@ class IMAPSequenceSetTest < Test::Unit::TestCase
     assert_equal 2**32 - 1, SequenceSet.full.find_index(:*)
   end
 
+  test "#find_ordered_index" do
+    assert_equal         9, SequenceSet.full.find_ordered_index(10)
+    assert_equal        99, SequenceSet.full.find_ordered_index(100)
+    assert_equal 2**32 - 1, SequenceSet.full.find_ordered_index(:*)
+    assert_nil SequenceSet.empty.find_index(1)
+    set = SequenceSet["9,8,7,6,5,4,3,2,1"]
+    assert_equal 0, set.find_ordered_index(9)
+    assert_equal 1, set.find_ordered_index(8)
+    assert_equal 2, set.find_ordered_index(7)
+    assert_equal 3, set.find_ordered_index(6)
+    assert_equal 4, set.find_ordered_index(5)
+    assert_equal 5, set.find_ordered_index(4)
+    assert_equal 6, set.find_ordered_index(3)
+    assert_equal 7, set.find_ordered_index(2)
+    assert_equal 8, set.find_ordered_index(1)
+    assert_nil      set.find_ordered_index(10)
+    set = SequenceSet["7:9,5:6"]
+    assert_equal 0, set.find_ordered_index(7)
+    assert_equal 1, set.find_ordered_index(8)
+    assert_equal 2, set.find_ordered_index(9)
+    assert_equal 3, set.find_ordered_index(5)
+    assert_equal 4, set.find_ordered_index(6)
+    assert_nil   set.find_ordered_index(4)
+    set = SequenceSet["1000:1111,1:100"]
+    assert_equal   0, set.find_ordered_index(1000)
+    assert_equal 100, set.find_ordered_index(1100)
+    assert_equal 112, set.find_ordered_index(1)
+    assert_equal 121, set.find_ordered_index(10)
+    set = SequenceSet["1,1,1,1,51,50,4,11"]
+    assert_equal   0, set.find_ordered_index(1)
+    assert_equal   4, set.find_ordered_index(51)
+    assert_equal   5, set.find_ordered_index(50)
+    assert_equal   6, set.find_ordered_index(4)
+    assert_equal   7, set.find_ordered_index(11)
+    assert_equal   1, SequenceSet["1,*"].find_ordered_index(-1)
+    assert_equal   0, SequenceSet["*,1"].find_ordered_index(-1)
+  end
+
   test "#limit" do
     set = SequenceSet["1:100,500"]
     assert_equal [1..99],               set.limit(max: 99).ranges

--- a/test/net/imap/test_sequence_set.rb
+++ b/test/net/imap/test_sequence_set.rb
@@ -707,6 +707,7 @@ class IMAPSequenceSetTest < Test::Unit::TestCase
     to_s:       "1:5,3:7,10:9,10:11",
     normalize:  "1:7,9:11",
     count:      10,
+    count_dups:  4,
     complement: "8,12:*",
   }, keep: true
 
@@ -719,6 +720,7 @@ class IMAPSequenceSetTest < Test::Unit::TestCase
     to_s:       "1:5,3:4,9:11,10",
     normalize:  "1:5,9:11",
     count:      8,
+    count_dups: 3,
     complement: "6:8,12:*",
   }, keep: true
 
@@ -849,6 +851,25 @@ class IMAPSequenceSetTest < Test::Unit::TestCase
 
   test "#count" do |data|
     assert_equal data[:count], SequenceSet.new(data[:input]).count
+  end
+
+  test "#count_with_duplicates" do |data|
+    dups = data[:count_dups] || 0
+    count = data[:count] + dups
+    seqset = SequenceSet.new(data[:input])
+    assert_equal count, seqset.count_with_duplicates
+  end
+
+  test "#count_duplicates" do |data|
+    dups = data[:count_dups] || 0
+    seqset = SequenceSet.new(data[:input])
+    assert_equal dups, seqset.count_duplicates
+  end
+
+  test "#has_duplicates?" do |data|
+    has_dups = !(data[:count_dups] || 0).zero?
+    seqset = SequenceSet.new(data[:input])
+    assert_equal has_dups, seqset.has_duplicates?
   end
 
   test "#valid_string" do |data|


### PR DESCRIPTION
Backports all of the following PRs to `v0.4-stable`:
* _rdoc only:_ #376
  _The code changes were backported already._
* #379 
* #383 
* #384 
* #385 
* #386 
* #387 
* #396 
* #397 

With only a few simple exceptions (relating to differences in rdoc, versioned defaults in `config.rb`, and the autoloads in `response_data.rb`) cherry-picking went smoothly and without conflicts.

This adds the following new methods to `Net::IMAP::SequenceSet`:
* `#count_with_duplicates`: The ordered entries version of `#count`.
* `#count_duplicates`: The difference between `#count` and `#count_with_duplicates`.
* `#has_duplicates?`: Returns whether `#count_duplicates` is positive.
* `#each_ordered_number`: The ordered entries version of `#each_number`.
* `#find_ordered_index`: The ordered entries version of `#find_index`.
* `#ordered_at`: The ordered entries version of `#at`.