### PR TITLE
🐛 Use `Range#size` vs `Range#count` for `uid-set` limit

### DIFF
--- a/lib/net/imap/response_parser.rb
+++ b/lib/net/imap/response_parser.rb
@@ -1382,7 +1382,7 @@ module Net
         when T_NUMBER then [Integer(token.value)]
         when T_ATOM
           entries = uid_set__ranges(token.value)
-          if (count = entries.sum(&:count)) > MAX_UID_SET_SIZE
+          if (count = entries.sum(&:size)) > MAX_UID_SET_SIZE
             parse_error("uid-set is too large: %d > 10k", count)
           end
           entries.flat_map(&:to_a)

--- a/test/net/imap/test_imap_response_parser.rb
+++ b/test/net/imap/test_imap_response_parser.rb
@@ -445,6 +445,13 @@ EOF
         "A004 OK [copyUID 1 10000:20000,1 1:10001] Done\r\n"
       )
     end
+    Timeout.timeout(1) do
+      assert_raise Net::IMAP::ResponseParseError, /uid-set is too large/ do
+        parser.parse(
+          "A004 OK [copyUID 1 1:#{2**32 - 1} 1:#{2**32 - 1}] Done\r\n"
+        )
+      end
+    end
   end
 
 end


### PR DESCRIPTION
Prior to ruby 3.3, `Range#count` is handled by `Enumerable#count`, even for numeric ranges.  For large ranges, `Range#size` is _significantly_ faster.  On my system, ruby 3.2 took 54 seconds (at 100% CPU) to run `(1...2**32).count`.

Thanks to @xiaoge1001 for reporting this issue (Fixes #410).