### PR TITLE
♻️ Reorganize `Config.version_defaults` creation

### DIFF
--- a/lib/net/imap/config.rb
+++ b/lib/net/imap/config.rb
@@ -435,9 +435,8 @@ module Net
       @global = default.new
 
       version_defaults[:default] = Config[default.send(:defaults_hash)]
-      version_defaults[:current] = Config[:default]
 
-      version_defaults[0] = Config[:current].dup.update(
+      version_defaults[0] = Config[:default].dup.update(
         sasl_ir: false,
         responses_without_block: :silence_deprecation_warning,
         enforce_logindisabled: false,
@@ -454,17 +453,36 @@ module Net
         parser_max_deprecated_uidplus_data_size: 1000,
       ).freeze
 
-      version_defaults[0.5] = Config[:current]
+      version_defaults[0.5] = Config[0.4].dup.update(
+        enforce_logindisabled: true,
+        responses_without_block: :warn,
+        parser_use_deprecated_uidplus_data: :up_to_max_size,
+        parser_max_deprecated_uidplus_data_size: 100,
+      ).freeze
 
       version_defaults[0.6] = Config[0.5].dup.update(
         responses_without_block: :frozen_dup,
         parser_use_deprecated_uidplus_data: false,
         parser_max_deprecated_uidplus_data_size: 0,
       ).freeze
-      version_defaults[:next] = Config[0.6]
-      version_defaults[:future] = Config[:next]
+
+      version_defaults[0.7] = Config[0.6].dup.update(
+      ).freeze
+
+      current = VERSION.to_f
+      version_defaults[:original] = Config[0]
+      version_defaults[:current]  = Config[current]
+      version_defaults[:next]     = Config[current + 0.1]
+      version_defaults[:future]   = Config[current + 0.2]
 
       version_defaults.freeze
+
+      if ($VERBOSE || $DEBUG) && self[:current].to_h != self[:default].to_h
+        warn "Misconfigured Net::IMAP::Config[:current] => %p,\n" \
+             " not equal to Net::IMAP::Config[:default] => %p" % [
+                self[:current].to_h, self[:default].to_h
+              ]
+      end
     end
   end
 end

--- a/test/net/imap/test_config.rb
+++ b/test/net/imap/test_config.rb
@@ -5,6 +5,9 @@ require "test/unit"
 
 class ConfigTest < Test::Unit::TestCase
   Config = Net::IMAP::Config
+  THIS_VERSION   = Net::IMAP::VERSION.to_f
+  NEXT_VERSION   = THIS_VERSION + 0.1
+  FUTURE_VERSION = THIS_VERSION + 0.2
 
   setup do
     Config.global.reset
@@ -141,7 +144,23 @@ class ConfigTest < Test::Unit::TestCase
       assert_kind_of Config, config
       assert config.frozen?,            "#{name} isn't frozen"
       assert config.inherited?(:debug), "#{name} doesn't inherit debug"
+      keys = config.to_h.keys - [:debug]
+      keys.each do |key|
+        refute config.inherited?(key)
+      end
       assert_same Config.global, config.parent
+    end
+  end
+
+  test "Config[:default] and Config[:current] both hold default config" do
+    defaults = Config.default.to_h
+    assert_equal(defaults, Config[:default].to_h)
+    assert_equal(defaults, Config[:current].to_h)
+  end
+
+  test ".[] for all version_defaults" do
+    Config.version_defaults.each do |version, config|
+      assert_same Config[version], config
     end
   end
 
@@ -152,8 +171,9 @@ class ConfigTest < Test::Unit::TestCase
     assert_same original, Config[0.1]
     assert_same original, Config[0.2]
     assert_same original, Config[0.3]
-    assert_kind_of Config, Config[0.4]
-    assert_kind_of Config, Config[0.5]
+    ((0.4r..FUTURE_VERSION.to_r) % 0.1r).each do |version|
+      assert_kind_of Config, Config[version.to_f]
+    end
   end
 
   test ".[] range errors" do
@@ -169,10 +189,10 @@ class ConfigTest < Test::Unit::TestCase
   end
 
   test ".[] with symbol names" do
-    assert_same    Config[0.5],   Config[:current]
-    assert_same    Config[0.5],   Config[:default]
-    assert_same    Config[0.6],   Config[:next]
-    assert_kind_of Config,        Config[:future]
+    assert_equal   Config[THIS_VERSION].to_h, Config[:default].to_h
+    assert_same    Config[THIS_VERSION],      Config[:current]
+    assert_same    Config[NEXT_VERSION],      Config[:next]
+    assert_same    Config[FUTURE_VERSION],    Config[:future]
   end
 
   test ".[] with a hash" do
@@ -190,7 +210,7 @@ class ConfigTest < Test::Unit::TestCase
     assert_same Config.default, Config.new(Config.default).parent
     assert_same Config.global,  Config.new(Config.global).parent
     assert_same Config[0.4],    Config.new(0.4).parent
-    assert_same Config[0.6],    Config.new(:next).parent
+    assert_same Config[NEXT_VERSION], Config.new(:next).parent
     assert_equal true, Config.new({debug: true}, debug: false).parent.debug?
     assert_equal true, Config.new({debug: true}, debug: false).parent.frozen?
   end


### PR DESCRIPTION
This reorganizes the creation of `Config.version_defaults` to make it easier to cherry-pick backported config changes to stable branches, and to require fewer updates for new `x.y.0` releases:
* Sets `Config[0.5]` as a diff from the previous versioned default, just like the other versioned defaults.
* Sets `Config[:current] = Config[VERSION.to_f]`, so it will not need to be updated for any x.y.0 release.  Likewise, sets `Config[:next]` and `Config[:future]` to `Config[VERSION.to_f + 0.1]` or `+ 0.2`, so they which will only rarely need to be changed.
* Because `Config[:default]` and `Config[:current]` are now derived two different ways, both a warning and a test have been added to ensure they remain synchronized.
* A few other `Config.version_defaults` tests were added or updated.