### PR TITLE
♻️ Update versioned default configs (backports #412)

### DIFF
--- a/lib/net/imap/config.rb
+++ b/lib/net/imap/config.rb
@@ -408,9 +408,9 @@ module Net
 
       @global = default.new
 
-      version_defaults[0.4] = Config[default.send(:defaults_hash)]
+      version_defaults[:default] = Config[default.send(:defaults_hash)]
 
-      version_defaults[0] = Config[0.4].dup.update(
+      version_defaults[0] = Config[:default].dup.update(
         sasl_ir: false,
         parser_use_deprecated_uidplus_data: true,
         parser_max_deprecated_uidplus_data_size: 10_000,
@@ -420,24 +420,40 @@ module Net
       version_defaults[0.2] = Config[0]
       version_defaults[0.3] = Config[0]
 
+      version_defaults[0.4] = Config[0.3].dup.update(
+        sasl_ir: true,
+        parser_max_deprecated_uidplus_data_size: 1000,
+      ).freeze
+
       version_defaults[0.5] = Config[0.4].dup.update(
         responses_without_block: :warn,
         parser_use_deprecated_uidplus_data: :up_to_max_size,
         parser_max_deprecated_uidplus_data_size: 100,
       ).freeze
 
-      version_defaults[:default] = Config[0.4]
-      version_defaults[:current] = Config[0.4]
-      version_defaults[:next]    = Config[0.5]
-
       version_defaults[0.6]      = Config[0.5].dup.update(
         responses_without_block: :frozen_dup,
         parser_use_deprecated_uidplus_data: false,
         parser_max_deprecated_uidplus_data_size: 0,
       ).freeze
-      version_defaults[:future]  = Config[0.6]
+
+      version_defaults[0.7] = Config[0.6].dup.update(
+      ).freeze
+
+      current = VERSION.to_f
+      version_defaults[:original] = Config[0]
+      version_defaults[:current]  = Config[current]
+      version_defaults[:next]     = Config[current + 0.1]
+      version_defaults[:future]   = Config[0.7]
 
       version_defaults.freeze
+
+      if ($VERBOSE || $DEBUG) && self[:current].to_h != self[:default].to_h
+        warn "Misconfigured Net::IMAP::Config[:current] => %p,\n" \
+             " not equal to Net::IMAP::Config[:default] => %p" % [
+                self[:current].to_h, self[:default].to_h
+              ]
+      end
     end
   end
 end


### PR DESCRIPTION
This backports #412 to `v0.4-stable`, which should make it easier to cherry-pick other backported config changes to stable branches (with fewer merge conflicts).