### PR TITLE
✅ Make FakeServer more robust against disconnect

### DIFF
--- a/test/net/imap/fake_server/command_reader.rb
+++ b/test/net/imap/fake_server/command_reader.rb
@@ -21,6 +21,7 @@ class Net::IMAP::FakeServer
         $2 or socket.print "+ Continue\r\n"
         buf << socket.read(Integer($1))
       end
+      throw :eof if buf.empty?
       @last_command = parse(buf)
     end
 

--- a/test/net/imap/fake_server/connection.rb
+++ b/test/net/imap/fake_server/connection.rb
@@ -23,7 +23,9 @@ class Net::IMAP::FakeServer
 
     def run
       writer.greeting
-      router << reader.get_command until state.logout?
+      catch(:eof) do
+        router << reader.get_command until state.logout?
+      end
     ensure
       close
     end

--- a/test/net/imap/fake_server/test_helper.rb
+++ b/test/net/imap/fake_server/test_helper.rb
@@ -14,7 +14,11 @@ module Net::IMAP::FakeServer::TestHelper
       end
       yield server
     ensure
-      server&.shutdown
+      begin
+        server&.shutdown
+      rescue IOError
+        raise unless ignore_io_error
+      end
     end
   end
 


### PR DESCRIPTION
When the client disconnects without a `LOGOUT`, that shouldn't cause a secondary error in the test output.  Most of the time, it's just a distraction.  In some cases, the test is intentionally triggering a bad disconnect, and the server's failure could break the test.