### PR TITLE
✅ Improvements to FakeServer (tests only)

### DIFF
--- a/test/net/imap/fake_server/command_router.rb
+++ b/test/net/imap/fake_server/command_router.rb
@@ -10,7 +10,9 @@ class Net::IMAP::FakeServer
       def on(*command_names, &handler)
         scope = self.is_a?(Module) ? self : singleton_class
         command_names.each do |command_name|
-          scope.define_method("handle_#{command_name.downcase}", &handler)
+          method_name = :"handle_#{command_name.downcase}"
+          scope.undef_method(method_name) if scope.method_defined?(method_name)
+          scope.define_method(method_name, &handler)
         end
       end
     end

--- a/test/net/imap/fake_server/socket.rb
+++ b/test/net/imap/fake_server/socket.rb
@@ -18,6 +18,7 @@ class Net::IMAP::FakeServer
     def tls?; !!@tls_socket end
     def closed?; @closed end
 
+    def eof?;      socket.eof?       end
     def gets(...)  socket.gets(...)  end
     def read(...)  socket.read(...)  end
     def print(...) socket.print(...) end

--- a/test/net/imap/fake_server/test_helper.rb
+++ b/test/net/imap/fake_server/test_helper.rb
@@ -4,10 +4,14 @@ require_relative "../fake_server"
 
 module Net::IMAP::FakeServer::TestHelper
 
-  def run_fake_server_in_thread(ignore_io_error: false, timeout: 10, **opts)
+  def run_fake_server_in_thread(ignore_io_error: false,
+                                report_on_exception: true,
+                                timeout: 10, **opts)
     Timeout.timeout(timeout) do
       server = Net::IMAP::FakeServer.new(timeout: timeout, **opts)
       @threads << Thread.new do
+        Thread.current.abort_on_exception  = false
+        Thread.current.report_on_exception = report_on_exception
         server.run
       rescue IOError
         raise unless ignore_io_error


### PR DESCRIPTION
Most importantly, transforming basic command parse error into IOError after EOF, enabling `with_fake_server(ignore_io_error: true)` to be usable for more test cases.