### PR TITLE
✨ Track IMAP connection state

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -43,9 +43,15 @@ module Net
   # To work on the messages within a mailbox, the client must
   # first select that mailbox, using either #select or #examine
   # (for read-only access).  Once the client has successfully
-  # selected a mailbox, they enter the "_selected_" state, and that
+  # selected a mailbox, they enter the +selected+ state, and that
   # mailbox becomes the _current_ mailbox, on which mail-item
   # related commands implicitly operate.
+  #
+  # === Connection state
+  #
+  # Once an IMAP connection is established, the connection is in one of four
+  # states: <tt>not authenticated</tt>, +authenticated+, +selected+, and
+  # +logout+.  Most commands are valid only in certain states.
   #
   # === Sequence numbers and UIDs
   #
@@ -260,8 +266,9 @@ module Net
   #
   # - Net::IMAP.new: Creates a new \IMAP client which connects immediately and
   #   waits for a successful server greeting before the method returns.
+  # - #connection_state: Returns the connection state.
   # - #starttls: Asks the server to upgrade a clear-text connection to use TLS.
-  # - #logout: Tells the server to end the session. Enters the "_logout_" state.
+  # - #logout: Tells the server to end the session.  Enters the +logout+ state.
   # - #disconnect: Disconnects the connection (without sending #logout first).
   # - #disconnected?: True if the connection has been closed.
   #
@@ -317,37 +324,36 @@ module Net
   #   <em>In general, #capable? should be used rather than explicitly sending a
   #   +CAPABILITY+ command to the server.</em>
   # - #noop: Allows the server to send unsolicited untagged #responses.
-  # - #logout: Tells the server to end the session. Enters the "_logout_" state.
+  # - #logout: Tells the server to end the session. Enters the +logout+ state.
   #
   # ==== Not Authenticated state
   #
   # In addition to the commands for any state, the following commands are valid
-  # in the "<em>not authenticated</em>" state:
+  # in the +not_authenticated+ state:
   #
   # - #starttls: Upgrades a clear-text connection to use TLS.
   #
   #   <em>Requires the +STARTTLS+ capability.</em>
   # - #authenticate: Identifies the client to the server using the given
   #   {SASL mechanism}[https://www.iana.org/assignments/sasl-mechanisms/sasl-mechanisms.xhtml]
-  #   and credentials.  Enters the "_authenticated_" state.
+  #   and credentials.  Enters the +authenticated+ state.
   #
   #   <em>The server should list <tt>"AUTH=#{mechanism}"</tt> capabilities for
   #   supported mechanisms.</em>
   # - #login: Identifies the client to the server using a plain text password.
-  #   Using #authenticate is generally preferred.  Enters the "_authenticated_"
-  #   state.
+  #   Using #authenticate is preferred.  Enters the +authenticated+ state.
   #
   #   <em>The +LOGINDISABLED+ capability</em> <b>must NOT</b> <em>be listed.</em>
   #
   # ==== Authenticated state
   #
   # In addition to the commands for any state, the following commands are valid
-  # in the "_authenticated_" state:
+  # in the +authenticated+ state:
   #
   # - #enable: Enables backwards incompatible server extensions.
   #   <em>Requires the +ENABLE+ or +IMAP4rev2+ capability.</em>
-  # - #select:  Open a mailbox and enter the "_selected_" state.
-  # - #examine: Open a mailbox read-only, and enter the "_selected_" state.
+  # - #select:  Open a mailbox and enter the +selected+ state.
+  # - #examine: Open a mailbox read-only, and enter the +selected+ state.
   # - #create: Creates a new mailbox.
   # - #delete: Permanently remove a mailbox.
   # - #rename: Change the name of a mailbox.
@@ -369,12 +375,12 @@ module Net
   #
   # ==== Selected state
   #
-  # In addition to the commands for any state and the "_authenticated_"
-  # commands, the following commands are valid in the "_selected_" state:
+  # In addition to the commands for any state and the +authenticated+
+  # commands, the following commands are valid in the +selected+ state:
   #
-  # - #close: Closes the mailbox and returns to the "_authenticated_" state,
+  # - #close: Closes the mailbox and returns to the +authenticated+ state,
   #   expunging deleted messages, unless the mailbox was opened as read-only.
-  # - #unselect: Closes the mailbox and returns to the "_authenticated_" state,
+  # - #unselect: Closes the mailbox and returns to the +authenticated+ state,
   #   without expunging any messages.
   #   <em>Requires the +UNSELECT+ or +IMAP4rev2+ capability.</em>
   # - #expunge: Permanently removes messages which have the Deleted flag set.
@@ -395,7 +401,7 @@ module Net
   #
   # ==== Logout state
   #
-  # No \IMAP commands are valid in the "_logout_" state.  If the socket is still
+  # No \IMAP commands are valid in the +logout+ state.  If the socket is still
   # open, Net::IMAP will close it after receiving server confirmation.
   # Exceptions will be raised by \IMAP commands that have already started and
   # are waiting for a response, as well as any that are called after logout.
@@ -449,7 +455,7 @@ module Net
   # ==== RFC3691: +UNSELECT+
   # Folded into IMAP4rev2[https://www.rfc-editor.org/rfc/rfc9051] and also included
   # above with {Core IMAP commands}[rdoc-ref:Net::IMAP@Core+IMAP+commands].
-  # - #unselect: Closes the mailbox and returns to the "_authenticated_" state,
+  # - #unselect: Closes the mailbox and returns to the +authenticated+ state,
   #   without expunging any messages.
   #
   # ==== RFC4314: +ACL+

--- a/lib/net/imap/connection_state.rb
+++ b/lib/net/imap/connection_state.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Net
+  class IMAP
+    class ConnectionState < Net::IMAP::Data # :nodoc:
+      def self.define(symbol, *attrs)
+        symbol => Symbol
+        state = super(*attrs)
+        state.const_set :NAME, symbol
+        state
+      end
+
+      def symbol; self.class::NAME      end
+      def name;   self.class::NAME.name end
+      alias to_sym symbol
+
+      def deconstruct; [symbol, *super] end
+
+      def deconstruct_keys(names)
+        hash = super
+        hash[:symbol] = symbol if names.nil? || names.include?(:symbol)
+        hash[:name]   = name   if names.nil? || names.include?(:name)
+        hash
+      end
+
+      def to_h(&block)
+        hash = deconstruct_keys(nil)
+        block ? hash.to_h(&block) : hash
+      end
+
+      def not_authenticated?; to_sym == :not_authenticated end
+      def authenticated?;     to_sym == :authenticated     end
+      def selected?;          to_sym == :selected          end
+      def logout?;            to_sym == :logout            end
+
+      NotAuthenticated = define(:not_authenticated)
+      Authenticated    = define(:authenticated)
+      Selected         = define(:selected)
+      Logout           = define(:logout)
+
+      class << self
+        undef :define
+      end
+      freeze
+    end
+
+  end
+end

--- a/test/net/imap/test_imap_connection_state.rb
+++ b/test/net/imap/test_imap_connection_state.rb
@@ -1,0 +1,226 @@
+# frozen_string_literal: true
+
+require "net/imap"
+require "test/unit"
+require_relative "fake_server"
+
+class ConnectionStateTest < Test::Unit::TestCase
+  NotAuthenticated = Net::IMAP::ConnectionState::NotAuthenticated
+  Authenticated    = Net::IMAP::ConnectionState::Authenticated
+  Selected         = Net::IMAP::ConnectionState::Selected
+  Logout           = Net::IMAP::ConnectionState::Logout
+
+  test "#name" do
+    assert_equal "not_authenticated", NotAuthenticated[].name
+    assert_equal "authenticated",     Authenticated[]   .name
+    assert_equal "selected",          Selected[]        .name
+    assert_equal "logout",            Logout[]          .name
+  end
+
+
+  test "#to_sym" do
+    assert_equal :not_authenticated, NotAuthenticated[].to_sym
+    assert_equal :authenticated,     Authenticated[]   .to_sym
+    assert_equal :selected,          Selected[]        .to_sym
+    assert_equal :logout,            Logout[]          .to_sym
+  end
+
+  test "#deconstruct" do
+    assert_equal [:not_authenticated], NotAuthenticated[].deconstruct
+    assert_equal [:authenticated],     Authenticated[]   .deconstruct
+    assert_equal [:selected],          Selected[]        .deconstruct
+    assert_equal [:logout],            Logout[]          .deconstruct
+  end
+
+  test "#deconstruct_keys" do
+    assert_equal({symbol: :not_authenticated}, NotAuthenticated[].deconstruct_keys([:symbol]))
+    assert_equal({symbol: :authenticated},     Authenticated[]   .deconstruct_keys([:symbol]))
+    assert_equal({symbol: :selected},          Selected[]        .deconstruct_keys([:symbol]))
+    assert_equal({symbol: :logout},            Logout[]          .deconstruct_keys([:symbol]))
+    assert_equal({name: "not_authenticated"},  NotAuthenticated[].deconstruct_keys([:name]))
+    assert_equal({name: "authenticated"},      Authenticated[]   .deconstruct_keys([:name]))
+    assert_equal({name: "selected"},           Selected[]        .deconstruct_keys([:name]))
+    assert_equal({name: "logout"},             Logout[]          .deconstruct_keys([:name]))
+  end
+
+  test "#not_authenticated?" do
+    assert_equal true,  NotAuthenticated[].not_authenticated?
+    assert_equal false, Authenticated[]   .not_authenticated?
+    assert_equal false, Selected[]        .not_authenticated?
+    assert_equal false, Logout[]          .not_authenticated?
+  end
+
+  test "#authenticated?" do
+    assert_equal false, NotAuthenticated[].authenticated?
+    assert_equal true,  Authenticated[]   .authenticated?
+    assert_equal false, Selected[]        .authenticated?
+    assert_equal false, Logout[]          .authenticated?
+  end
+
+  test "#selected?" do
+    assert_equal false, NotAuthenticated[].selected?
+    assert_equal false, Authenticated[]   .selected?
+    assert_equal true,  Selected[]        .selected?
+    assert_equal false, Logout[]          .selected?
+  end
+
+  test "#logout?" do
+    assert_equal false, NotAuthenticated[].logout?
+    assert_equal false, Authenticated[]   .logout?
+    assert_equal false, Selected[]        .logout?
+    assert_equal true,  Logout[]          .logout?
+  end
+
+end
+
+class IMAPConnectionStateTest < Test::Unit::TestCase
+  include Net::IMAP::FakeServer::TestHelper
+
+  def setup
+    Net::IMAP.config.reset
+    @do_not_reverse_lookup = Socket.do_not_reverse_lookup
+    Socket.do_not_reverse_lookup = true
+    @threads = []
+  end
+
+  def teardown
+    if !@threads.empty?
+      assert_join_threads(@threads)
+    end
+  ensure
+    Socket.do_not_reverse_lookup = @do_not_reverse_lookup
+  end
+
+  test "#connection_state after AUTHENTICATE, SELECT, CLOSE successes" do
+    with_fake_server(preauth: false) do |server, imap|
+      # AUTHENTICATE, SELECT, CLOSE
+      assert_equal :not_authenticated, imap.connection_state.to_sym
+      imap.authenticate :plain, "test_user", "test-password"
+      assert_equal :authenticated, imap.connection_state.to_sym
+      imap.select "INBOX"
+      assert_equal :selected, imap.connection_state.to_sym
+      imap.close
+      assert_equal :authenticated, imap.connection_state.to_sym
+    end
+  end
+
+  test "#connection_state after LOGIN, EXAMINE, UNSELECT successes" do
+    with_fake_server(preauth: false, cleartext_login: true) do |server, imap|
+      assert_equal :not_authenticated, imap.connection_state.to_sym
+      imap.login "test_user", "test-password"
+      assert_equal :authenticated, imap.connection_state.to_sym
+      imap.examine "INBOX"
+      assert_equal :selected, imap.connection_state.to_sym
+      imap.unselect
+      assert_equal :authenticated, imap.connection_state.to_sym
+    end
+  end
+
+  test "#connection_state after PREAUTH" do
+    with_fake_server(preauth: true) do |server, imap|
+      assert_equal :authenticated, imap.connection_state.to_sym
+      imap.select "INBOX"
+      assert_equal :selected, imap.connection_state.to_sym
+      imap.unselect
+      assert_equal :authenticated, imap.connection_state.to_sym
+    end
+  end
+
+  test "#connection_state after [CLOSED] response code" do
+    with_fake_server(select: "INBOX") do |server, imap|
+      # NOOP doesn't _normally_ change the connection_state
+      assert_equal :selected, imap.connection_state.to_sym
+      server.on("NOOP", &:done_ok)
+      imap.noop
+      assert_equal :selected, imap.connection_state.to_sym
+
+      # using NOOP to trigger the response code
+      server.on("NOOP") do |resp|
+        resp.untagged "OK", "[CLOSED] server maintenance"
+        resp.done_ok
+      end
+      imap.noop
+      assert_equal :authenticated, imap.connection_state.to_sym
+    end
+  end
+
+  test "#connection_state after failed LOGIN or AUTHENTICATE" do
+    with_fake_server(preauth: false, cleartext_login: false) do |server, imap|
+      assert_raise(Net::IMAP::LoginDisabledError) do imap.login "foo", "bar" end
+      assert_equal :not_authenticated, imap.connection_state.to_sym
+
+      imap.config.enforce_logindisabled = false
+      server.on "LOGIN"        do |cmd| cmd.fail_no "nope" end
+      server.on "AUTHENTICATE" do |cmd| cmd.fail_no "nope" end
+
+      assert_raise(Net::IMAP::NoResponseError) do
+        imap.login "foo", "bar"
+      end
+      assert_equal :not_authenticated, imap.connection_state.to_sym
+
+      assert_raise(Net::IMAP::NoResponseError) do
+        imap.authenticate :plain, "foo", "bar"
+      end
+      assert_equal :not_authenticated, imap.connection_state.to_sym
+
+      server.on "LOGIN"        do |cmd| cmd.fail_bad "bad!" end
+      server.on "AUTHENTICATE" do |cmd| cmd.fail_bad "bad!" end
+
+      assert_raise(Net::IMAP::BadResponseError) do
+        imap.login "foo", "bar"
+      end
+      assert_equal :not_authenticated, imap.connection_state.to_sym
+
+      assert_raise(Net::IMAP::BadResponseError) do
+        imap.authenticate :plain, "foo", "bar"
+      end
+      assert_equal :not_authenticated, imap.connection_state.to_sym
+    end
+  end
+
+  test "#connection_state after failed SELECT or EXAMINE" do
+    with_fake_server(preauth: true) do |server, imap|
+      # good SELECT to enter the :selected state
+      imap.select "INBOX"
+      assert_equal :selected, imap.connection_state.to_sym
+      # bad SELECT enters the :authenticated state
+      assert_raise(Net::IMAP::NoResponseError) do
+        imap.select "doesn't exist"
+      end
+      assert_equal :authenticated, imap.connection_state.to_sym
+
+      # back into the :selected state
+      imap.examine "INBOX"
+      assert_equal :selected, imap.connection_state.to_sym
+      # bad EXAMINE enters the :authenticated state
+      assert_raise(Net::IMAP::NoResponseError) do
+        imap.examine "doesn't exist"
+      end
+      assert_equal :authenticated, imap.connection_state.to_sym
+    end
+  end
+
+  test "#connection_state after #logout" do
+    with_fake_server do |server, imap|
+      imap.logout
+      assert_equal :logout, imap.connection_state.to_sym
+      imap.disconnect # avoid `logout!` warning and wait for closed socket
+    end
+  end
+
+  test "#connection_state after #logout!" do
+    with_fake_server do |server, imap|
+      imap.logout!
+      assert_equal :logout, imap.connection_state.to_sym
+    end
+  end
+
+  test "#connection_state after #disconnect" do
+    with_fake_server(ignore_io_error: true) do
+      |server, imap|
+      imap.disconnect
+      assert_equal :logout, imap.connection_state.to_sym
+    end
+  end
+
+end


### PR DESCRIPTION
Tracking IMAP connection state has many uses.  But in this PR, we're only tracking the session state and exposing a `#connection_state` attribute reader.

For forward-compatibility, the only documented methods on the connection state objects are (currently) `#name` and `#to_sym`, which will return one of `not_authenticated`, `authenticated`, `selected`, or `logout`.

From RFC9051:
```
                   +----------------------+
                   |connection established|
                   +----------------------+
                              ||
                              \/
            +--------------------------------------+
            |          server greeting             |
            +--------------------------------------+
                      || (1)       || (2)        || (3)
                      \/           ||            ||
            +-----------------+    ||            ||
            |Not Authenticated|    ||            ||
            +-----------------+    ||            ||
             || (7)   || (4)       ||            ||
             ||       \/           \/            ||
             ||     +----------------+           ||
             ||     | Authenticated  |<=++       ||
             ||     +----------------+  ||       ||
             ||       || (7)   || (5)   || (6)   ||
             ||       ||       \/       ||       ||
             ||       ||    +--------+  ||       ||
             ||       ||    |Selected|==++       ||
             ||       ||    +--------+           ||
             ||       ||       || (7)            ||
             \/       \/       \/                \/
            +--------------------------------------+
            |               Logout                 |
            +--------------------------------------+
                              ||
                              \/
                +-------------------------------+
                |both sides close the connection|
                +-------------------------------+

Legend for the above diagram:

(1) connection without pre-authentication (OK greeting)
(2) pre-authenticated connection (PREAUTH greeting)
(3) rejected connection (BYE greeting)
(4) successful LOGIN or AUTHENTICATE command
(5) successful SELECT or EXAMINE command
(6) CLOSE or UNSELECT command, unsolicited CLOSED response code, or
    failed SELECT or EXAMINE command
(7) LOGOUT command, server shutdown, or connection closed
```

Before the server greeting, the state is `not_authenticated`.
After the connection closes, the state remains `logout`.