### PR TITLE
♻️ Refactor Config attr type coercion

### DIFF
--- a/lib/net/imap/config.rb
+++ b/lib/net/imap/config.rb
@@ -245,7 +245,7 @@ module Net
       #   present.  When capabilities are unknown, Net::IMAP will automatically
       #   send a +CAPABILITY+ command first before sending +LOGIN+.
       #
-      attr_accessor :enforce_logindisabled, type: [
+      attr_accessor :enforce_logindisabled, type: Enum[
         false, :when_capabilities_cached, true
       ]
 
@@ -275,7 +275,7 @@ module Net
       #   Raise an ArgumentError with the deprecation warning.
       #
       # Note: #responses_without_args is an alias for #responses_without_block.
-      attr_accessor :responses_without_block, type: [
+      attr_accessor :responses_without_block, type: Enum[
         :silence_deprecation_warning, :warn, :frozen_dup, :raise,
       ]
 
@@ -320,7 +320,7 @@ module Net
       #
       # [+false+ <em>(planned default for +v0.6+)</em>]
       #    ResponseParser _only_ uses AppendUIDData and CopyUIDData.
-      attr_accessor :parser_use_deprecated_uidplus_data, type: [
+      attr_accessor :parser_use_deprecated_uidplus_data, type: Enum[
         true, :up_to_max_size, false
       ]
 

--- a/lib/net/imap/config/attr_type_coercion.rb
+++ b/lib/net/imap/config/attr_type_coercion.rb
@@ -26,34 +26,24 @@ module Net
         end
         private_class_method :included
 
+        Types = Hash.new do |h, type| type => Proc | nil; type end
+        Types[:boolean] = Boolean = -> {!!_1}
+        Types[Integer]  = ->{Integer(_1)}
+
         def self.attr_accessor(attr, type: nil)
-          return unless type
-          if    :boolean == type then boolean attr
-          elsif Integer  == type then integer attr
-          elsif Array   === type then enum    attr, type
-          else raise ArgumentError, "unknown type coercion %p" % [type]
-          end
+          type = Types[type] or return
+          define_method :"#{attr}=" do |val| super type[val] end
+          define_method :"#{attr}?" do send attr end if type == Boolean
         end
 
-        def self.boolean(attr)
-          define_method :"#{attr}=" do |val| super !!val end
-          define_method :"#{attr}?" do send attr end
-        end
-
-        def self.integer(attr)
-          define_method :"#{attr}=" do |val| super Integer val end
-        end
-
-        def self.enum(attr, enum)
+        Enum = ->(*enum) {
           enum = enum.dup.freeze
           expected = -"one of #{enum.map(&:inspect).join(", ")}"
-          define_method :"#{attr}=" do |val|
-            unless enum.include?(val)
-              raise ArgumentError, "expected %s, got %p" % [expected, val]
-            end
-            super val
-          end
-        end
+          ->val {
+            return val if enum.include?(val)
+            raise ArgumentError, "expected %s, got %p" % [expected, val]
+          }
+        }
 
       end
     end


### PR DESCRIPTION
Switching to a "Types" registry, which holds a proc for each coercion.  Also added some safeguards to ensure these procs are ractor shareable.