### PR TITLE
♻️  Refactor `Net::IMAP#get_response` (internal)

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3435,11 +3435,8 @@ module Net
       buff = String.new
       while true
         get_response_line(buff) or break
-        if /\{(\d+)\}\r\n\z/n =~ buff
-          get_response_literal(buff, $1.to_i) or break
-        else
-          break
-        end
+        break unless /\{(\d+)\}\r\n\z/n =~ buff
+        get_response_literal(buff, $1.to_i) or break
       end
       return nil if buff.length == 0
       $stderr.print(buff.gsub(/^/n, "S: ")) if config.debug?

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3445,10 +3445,8 @@ module Net
         end
       end
       return nil if buff.length == 0
-      if config.debug?
-        $stderr.print(buff.gsub(/^/n, "S: "))
-      end
-      return @parser.parse(buff)
+      $stderr.print(buff.gsub(/^/n, "S: ")) if config.debug?
+      @parser.parse(buff)
     end
 
     #############################

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3434,12 +3434,9 @@ module Net
     def get_response
       buff = String.new
       while true
-        s = @sock.gets(CRLF)
-        break unless s
-        buff.concat(s)
+        get_response_line(buff) or break
         if /\{(\d+)\}\r\n\z/n =~ buff
-          s = @sock.read($1.to_i)
-          buff.concat(s)
+          get_response_literal(buff, $1.to_i) or break
         else
           break
         end
@@ -3447,6 +3444,16 @@ module Net
       return nil if buff.length == 0
       $stderr.print(buff.gsub(/^/n, "S: ")) if config.debug?
       @parser.parse(buff)
+    end
+
+    def get_response_line(buff)
+      line = @sock.gets(CRLF) or return
+      buff << line
+    end
+
+    def get_response_literal(buff, literal_size)
+      literal = @sock.read(literal_size) or return
+      buff << literal
     end
 
     #############################

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3433,10 +3433,12 @@ module Net
 
     def get_response
       buff = String.new
-      while true
-        get_response_line(buff) or break
-        break unless /\{(\d+)\}\r\n\z/n =~ buff
-        get_response_literal(buff, $1.to_i) or break
+      catch :eof do
+        while true
+          get_response_line(buff)
+          break unless /\{(\d+)\}\r\n\z/n =~ buff
+          get_response_literal(buff, $1.to_i)
+        end
       end
       return nil if buff.length == 0
       $stderr.print(buff.gsub(/^/n, "S: ")) if config.debug?
@@ -3444,13 +3446,13 @@ module Net
     end
 
     def get_response_line(buff)
-      line = @sock.gets(CRLF) or return
+      line = @sock.gets(CRLF) or throw :eof
       buff << line
     end
 
     def get_response_literal(buff, literal_size)
       literal = String.new(capacity: literal_size)
-      @sock.read(literal_size, literal) or return
+      @sock.read(literal_size, literal) or throw :eof
       buff << literal
     end
 

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3437,7 +3437,7 @@ module Net
         s = @sock.gets(CRLF)
         break unless s
         buff.concat(s)
-        if /\{(\d+)\}\r\n/n =~ s
+        if /\{(\d+)\}\r\n\z/n =~ buff
           s = @sock.read($1.to_i)
           buff.concat(s)
         else

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3452,7 +3452,8 @@ module Net
     end
 
     def get_response_literal(buff, literal_size)
-      literal = @sock.read(literal_size) or return
+      literal = String.new(capacity: literal_size)
+      @sock.read(literal_size, literal) or return
       buff << literal
     end
 


### PR DESCRIPTION
IMO, this refactoring makes `Net::IMAP#get_response` much easier to understand.
Which will be useful, because I'm about to complicate it.  😉

Details in each commit.