### PR TITLE
♻️ Rational config versions

### DIFF
--- a/lib/net/imap/config.rb
+++ b/lib/net/imap/config.rb
@@ -439,44 +439,54 @@ module Net
 
       version_defaults[:default] = Config[default.send(:defaults_hash)]
 
-      version_defaults[0] = Config[:default].dup.update(
+      version_defaults[0r] = Config[:default].dup.update(
         sasl_ir: false,
         responses_without_block: :silence_deprecation_warning,
         enforce_logindisabled: false,
         parser_use_deprecated_uidplus_data: true,
         parser_max_deprecated_uidplus_data_size: 10_000,
       ).freeze
-      version_defaults[0.0] = Config[0]
-      version_defaults[0.1] = Config[0]
-      version_defaults[0.2] = Config[0]
-      version_defaults[0.3] = Config[0]
+      version_defaults[0.0r] = Config[0r]
+      version_defaults[0.1r] = Config[0r]
+      version_defaults[0.2r] = Config[0r]
+      version_defaults[0.3r] = Config[0r]
 
-      version_defaults[0.4] = Config[0.3].dup.update(
+      version_defaults[0.4r] = Config[0.3r].dup.update(
         sasl_ir: true,
         parser_max_deprecated_uidplus_data_size: 1000,
       ).freeze
 
-      version_defaults[0.5] = Config[0.4].dup.update(
+      version_defaults[0.5r] = Config[0.4r].dup.update(
         enforce_logindisabled: true,
         responses_without_block: :warn,
         parser_use_deprecated_uidplus_data: :up_to_max_size,
         parser_max_deprecated_uidplus_data_size: 100,
       ).freeze
 
-      version_defaults[0.6] = Config[0.5].dup.update(
+      version_defaults[0.6r] = Config[0.5r].dup.update(
         responses_without_block: :frozen_dup,
         parser_use_deprecated_uidplus_data: false,
         parser_max_deprecated_uidplus_data_size: 0,
       ).freeze
 
-      version_defaults[0.7] = Config[0.6].dup.update(
+      version_defaults[0.7r] = Config[0.6r].dup.update(
       ).freeze
 
-      current = VERSION.to_f
+      # Safe conversions one way only:
+      #   0.6r.to_f == 0.6  # => true
+      #   0.6 .to_r == 0.6r # => false
+      version_defaults.to_a.each do |k, v|
+        next unless k in Rational
+        version_defaults[k.to_f] = v
+        next unless k.to_i.to_r == k
+        version_defaults[k.to_i] = v
+      end
+
+      current = VERSION.to_r
       version_defaults[:original] = Config[0]
       version_defaults[:current]  = Config[current]
-      version_defaults[:next]     = Config[current + 0.1]
-      version_defaults[:future]   = Config[current + 0.2]
+      version_defaults[:next]     = Config[current + 0.1r]
+      version_defaults[:future]   = Config[current + 0.2r]
 
       version_defaults.freeze
 

--- a/test/net/imap/test_config.rb
+++ b/test/net/imap/test_config.rb
@@ -140,7 +140,7 @@ class ConfigTest < Test::Unit::TestCase
 
   test ".version_defaults are all frozen, and inherit debug from global" do
     Config.version_defaults.each do |name, config|
-      assert [0, Float, Symbol].any? { _1 === name }
+      assert [0, Float, Rational, Symbol].any? { _1 === name }
       assert_kind_of Config, config
       assert config.frozen?,            "#{name} isn't frozen"
       assert config.inherited?(:debug), "#{name} doesn't inherit debug"


### PR DESCRIPTION
Updates `Config.version_defaults` to use `Rational` internally, with aliases for `Float`.

Adds a `default_proc` to `Config.version_defaults` to enable more flexible lookups.  For example, we can now use something like `Config["0.4.11"]` (I do _not_ intend to store version defaults for `x.y.z` releases).  I had to add a special-case for zero, to avoid `Config["missing"] == Config[0r]`

Fixes #428.