### PR TITLE
♻️ Rational config version (backport #429 to v0.4)

### DIFF
--- a/lib/net/imap/config.rb
+++ b/lib/net/imap/config.rb
@@ -129,8 +129,25 @@ module Net
       def self.global; @global if defined?(@global) end
 
       # A hash of hard-coded configurations, indexed by version number or name.
+      # Values can be accessed with any object that responds to +to_sym+ or
+      # +to_r+/+to_f+ with a non-zero number.
+      #
+      # Config::[] gets named or numbered versions from this hash.
+      #
+      # For example:
+      #     Net::IMAP::Config.version_defaults[0.5] == Net::IMAP::Config[0.5]
+      #     Net::IMAP::Config[0.5]       == Net::IMAP::Config[0.5r]     # => true
+      #     Net::IMAP::Config["current"] == Net::IMAP::Config[:current] # => true
+      #     Net::IMAP::Config["0.5.6"]   == Net::IMAP::Config[0.5r]     # => true
       def self.version_defaults; @version_defaults end
-      @version_defaults = {}
+      @version_defaults = Hash.new {|h, k|
+        # NOTE: String responds to both so the order is significant.
+        # And ignore non-numeric conversion to zero, because: "wat!?".to_r == 0
+        (h.fetch(k.to_r, nil) || h.fetch(k.to_f, nil) if k.is_a?(Numeric)) ||
+          (h.fetch(k.to_sym, nil) if k.respond_to?(:to_sym)) ||
+          (h.fetch(k.to_r,   nil) if k.respond_to?(:to_r) && k.to_r != 0r) ||
+          (h.fetch(k.to_f,   nil) if k.respond_to?(:to_f) && k.to_f != 0.0)
+      }
 
       # :call-seq:
       #  Net::IMAP::Config[number] -> versioned config
@@ -153,18 +170,17 @@ module Net
         elsif config.nil? && global.nil?   then nil
         elsif config.respond_to?(:to_hash) then new(global, **config).freeze
         else
-          version_defaults.fetch(config) do
+          version_defaults[config] or
             case config
             when Numeric
               raise RangeError, "unknown config version: %p" % [config]
-            when Symbol
+            when String, Symbol
               raise KeyError, "unknown config name: %p" % [config]
             else
               raise TypeError, "no implicit conversion of %s to %s" % [
                 config.class, Config
               ]
             end
-          end
         end
       end
 
@@ -449,8 +465,6 @@ module Net
       version_defaults.to_a.each do |k, v|
         next unless k in Rational
         version_defaults[k.to_f] = v
-        next unless k.to_i.to_r == k
-        version_defaults[k.to_i] = v
       end
 
       current = VERSION.to_r

--- a/lib/net/imap/config.rb
+++ b/lib/net/imap/config.rb
@@ -463,7 +463,7 @@ module Net
       #   0.6r.to_f == 0.6  # => true
       #   0.6 .to_r == 0.6r # => false
       version_defaults.to_a.each do |k, v|
-        next unless k in Rational
+        next unless k.is_a? Rational
         version_defaults[k.to_f] = v
       end
 

--- a/lib/net/imap/config.rb
+++ b/lib/net/imap/config.rb
@@ -413,41 +413,52 @@ module Net
 
       version_defaults[:default] = Config[default.send(:defaults_hash)]
 
-      version_defaults[0] = Config[:default].dup.update(
+      version_defaults[0r] = Config[:default].dup.update(
         sasl_ir: false,
         parser_use_deprecated_uidplus_data: true,
         parser_max_deprecated_uidplus_data_size: 10_000,
       ).freeze
-      version_defaults[0.0] = Config[0]
-      version_defaults[0.1] = Config[0]
-      version_defaults[0.2] = Config[0]
-      version_defaults[0.3] = Config[0]
+      version_defaults[0.0r] = Config[0r]
+      version_defaults[0.1r] = Config[0r]
+      version_defaults[0.2r] = Config[0r]
+      version_defaults[0.3r] = Config[0r]
 
-      version_defaults[0.4] = Config[0.3].dup.update(
+      version_defaults[0.4r] = Config[0.3r].dup.update(
         sasl_ir: true,
         parser_max_deprecated_uidplus_data_size: 1000,
       ).freeze
 
-      version_defaults[0.5] = Config[0.4].dup.update(
+      version_defaults[0.5r] = Config[0.4r].dup.update(
         responses_without_block: :warn,
         parser_use_deprecated_uidplus_data: :up_to_max_size,
         parser_max_deprecated_uidplus_data_size: 100,
       ).freeze
 
-      version_defaults[0.6]      = Config[0.5].dup.update(
+      version_defaults[0.6r] = Config[0.5r].dup.update(
         responses_without_block: :frozen_dup,
         parser_use_deprecated_uidplus_data: false,
         parser_max_deprecated_uidplus_data_size: 0,
       ).freeze
 
-      version_defaults[0.7] = Config[0.6].dup.update(
+      version_defaults[0.7r] = Config[0.6r].dup.update(
       ).freeze
 
-      current = VERSION.to_f
+      # Safe conversions one way only:
+      #   0.6r.to_f == 0.6  # => true
+      #   0.6 .to_r == 0.6r # => false
+      version_defaults.to_a.each do |k, v|
+        next unless k in Rational
+        version_defaults[k.to_f] = v
+        next unless k.to_i.to_r == k
+        version_defaults[k.to_i] = v
+      end
+
+      current = VERSION.to_r
       version_defaults[:original] = Config[0]
       version_defaults[:current]  = Config[current]
-      version_defaults[:next]     = Config[current + 0.1]
-      version_defaults[:future]   = Config[0.7]
+      version_defaults[:next]     = Config[current + 0.1r]
+
+      version_defaults[:future]   = Config[0.7r]
 
       version_defaults.freeze
 

--- a/test/net/imap/test_config.rb
+++ b/test/net/imap/test_config.rb
@@ -140,7 +140,7 @@ class ConfigTest < Test::Unit::TestCase
 
   test ".version_defaults are all frozen, and inherit debug from global" do
     Config.version_defaults.each do |name, config|
-      assert [0, Float, Symbol].any? { _1 === name }
+      assert [0, Float, Rational, Symbol].any? { _1 === name }
       assert_kind_of Config, config
       assert config.frozen?,            "#{name} isn't frozen"
       assert config.inherited?(:debug), "#{name} doesn't inherit debug"

--- a/test/net/imap/test_config.rb
+++ b/test/net/imap/test_config.rb
@@ -216,34 +216,34 @@ class ConfigTest < Test::Unit::TestCase
 
     # to_sym
     duck = Object.new
-    def duck.to_sym = :current
+    def duck.to_sym; :current end
     assert_same Config[:current], Config[duck]
 
     # to_r
     duck = Object.new
-    def duck.to_r = 0.6r
+    def duck.to_r; 0.6r end
     assert_same Config[0.6r], Config[duck]
 
     # to_f
     duck = Object.new
-    def duck.to_f = 0.4
+    def duck.to_f; 0.4 end
     assert_same Config[0.4], Config[duck]
 
     # prefer to_r over to_f
-    def duck.to_r   = 0.5r
+    def duck.to_r; 0.5r end
     assert_same Config[0.5r], Config[duck]
 
     # prefer to_sym over to_r
-    def duck.to_sym = :original
+    def duck.to_sym; :original end
     assert_same Config[:original], Config[duck]
 
     # keeps trying if to_sym finds nothing
     duck = Object.new
-    def duck.to_sym = :nope
-    def duck.to_f   = 0.5
+    def duck.to_sym; :nope end
+    def duck.to_f;   0.5 end
     assert_same Config[0.5],  Config[duck]
     # keeps trying if to_sym and to_r both find nothing
-    def duck.to_r   = 1/11111
+    def duck.to_r;   1/11111 end
     assert_same Config[0.5],  Config[duck]
   end
 


### PR DESCRIPTION
Backports #429 to `v0.4-stable`