### PR TITLE
✨ Customize SequenceSet YAML serialization

### DIFF
--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -1369,6 +1369,18 @@ module Net
         imap.__send__(:put_string, valid_string)
       end
 
+      # For YAML serialization
+      def encode_with(coder) # :nodoc:
+        # we can perfectly reconstruct from the string
+        coder['string'] = to_s
+      end
+
+      # For YAML deserialization
+      def init_with(coder) # :nodoc:
+        @tuples = []
+        self.string = coder['string']
+      end
+
       protected
 
       attr_reader :tuples # :nodoc:

--- a/test/net/imap/fixtures/response_parser/esearch_responses.yml
+++ b/test/net/imap/fixtures/response_parser/esearch_responses.yml
@@ -25,11 +25,6 @@
         - - ALL
           - !ruby/object:Net::IMAP::SequenceSet
             string: 2,10:11
-            tuples:
-            - - 2
-              - 2
-            - - 10
-              - 11
       raw_data: "* ESEARCH (TAG \"A283\") ALL 2,10:11\r\n"
 
   rfc9051_6.4.4_ESEARCH_example_3:
@@ -53,9 +48,6 @@
         - - ALL
           - !ruby/object:Net::IMAP::SequenceSet
             string: '43'
-            tuples:
-            - - 43
-              - 43
       raw_data: "* ESEARCH (TAG \"A285\") ALL 43\r\n"
 
   rfc9051_6.4.4_ESEARCH_example_5:
@@ -107,11 +99,6 @@
         - - ALL
           - !ruby/object:Net::IMAP::SequenceSet
             string: '17,900,901'
-            tuples:
-            - - 17
-              - 17
-            - - 900
-              - 901
       raw_data: "* ESEARCH (TAG \"A301\") UID ALL 17,900,901\r\n"
 
   rfc9051_6.4.4.4_ESEARCH_example_2:
@@ -125,15 +112,6 @@
         - - ALL
           - !ruby/object:Net::IMAP::SequenceSet
             string: 882,1102,3003,3005:3006
-            tuples:
-            - - 882
-              - 882
-            - - 1102
-              - 1102
-            - - 3003
-              - 3003
-            - - 3005
-              - 3006
       raw_data: "* ESEARCH (TAG \"P283\") ALL 882,1102,3003,3005:3006\r\n"
 
   rfc9051_6.4.4.4_ESEARCH_example_3:
@@ -147,13 +125,6 @@
         - - ALL
           - !ruby/object:Net::IMAP::SequenceSet
             string: 3:15,27,29:103
-            tuples:
-            - - 3
-              - 15
-            - - 27
-              - 27
-            - - 29
-              - 103
       raw_data: "* ESEARCH (TAG \"G283\") ALL 3:15,27,29:103\r\n"
 
   rfc9051_6.4.4.4_ESEARCH_example_4:
@@ -167,13 +138,6 @@
         - - ALL
           - !ruby/object:Net::IMAP::SequenceSet
             string: 2,10:15,21
-            tuples:
-            - - 2
-              - 2
-            - - 10
-              - 15
-            - - 21
-              - 21
       raw_data: "* ESEARCH (TAG \"C283\") ALL 2,10:15,21\r\n"
 
   rfc9051_6.4.4.4_ESEARCH_example_5:
@@ -231,13 +195,6 @@
         - - ALL
           - !ruby/object:Net::IMAP::SequenceSet
             string: 2,10:15,21
-            tuples:
-            - - 2
-              - 2
-            - - 10
-              - 15
-            - - 21
-              - 21
       raw_data: "* ESEARCH (TAG \"C286\") MIN 2 ALL 2,10:15,21\r\n"
 
   rfc9051_7.1_ESEARCH_example_1:
@@ -251,19 +208,6 @@
         - - ALL
           - !ruby/object:Net::IMAP::SequenceSet
             string: 1:3,5,8,13,21,42
-            tuples:
-            - - 1
-              - 3
-            - - 5
-              - 5
-            - - 8
-              - 8
-            - - 13
-              - 13
-            - - 21
-              - 21
-            - - 42
-              - 42
       raw_data: "* ESEARCH (TAG \"h\") ALL 1:3,5,8,13,21,42\r\n"
 
   rfc9051_7.3.4_ESEARCH_example_1:
@@ -279,13 +223,6 @@
         - - ALL
           - !ruby/object:Net::IMAP::SequenceSet
             string: 4:18,21,28
-            tuples:
-            - - 4
-              - 18
-            - - 21
-              - 21
-            - - 28
-              - 28
       raw_data: "* ESEARCH UID COUNT 17 ALL 4:18,21,28\r\n"
 
   rfc9051_7.3.4_ESEARCH_example_2:
@@ -301,13 +238,6 @@
         - - ALL
           - !ruby/object:Net::IMAP::SequenceSet
             string: 4:18,21,28
-            tuples:
-            - - 4
-              - 18
-            - - 21
-              - 21
-            - - 28
-              - 28
       raw_data: "* ESEARCH (TAG \"a567\") UID COUNT 17 ALL 4:18,21,28\r\n"
 
   rfc9051_7.3.4_ESEARCH_example_3:
@@ -323,9 +253,4 @@
         - - ALL
           - !ruby/object:Net::IMAP::SequenceSet
             string: 1:17,21
-            tuples:
-            - - 1
-              - 17
-            - - 21
-              - 21
       raw_data: "* ESEARCH COUNT 18 ALL 1:17,21\r\n"

--- a/test/net/imap/fixtures/response_parser/rfc7162_condstore_qresync_responses.yml
+++ b/test/net/imap/fixtures/response_parser/rfc7162_condstore_qresync_responses.yml
@@ -55,12 +55,7 @@
         code: !ruby/struct:Net::IMAP::ResponseCode
           name: MODIFIED
           data: !ruby/object:Net::IMAP::SequenceSet
-            str: '7,9'
-            tuples:
-            - - 7
-              - 7
-            - - 9
-              - 9
+            string: '7,9'
         text: Conditional STORE failed
       raw_data: "d105 OK [MODIFIED 7,9] Conditional STORE failed\r\n"
 
@@ -109,11 +104,6 @@
         - - ALL
           - !ruby/object:Net::IMAP::SequenceSet
             string: 1:3,5
-            tuples:
-            - - 1
-              - 3
-            - - 5
-              - 5
         - - MODSEQ
           - 1236
       raw_data: "* ESEARCH (TAG \"a\") ALL 1:3,5 MODSEQ 1236\r\n"
@@ -129,11 +119,6 @@
         - - ALL
           - !ruby/object:Net::IMAP::SequenceSet
             string: '5,3,2,1'
-            tuples:
-            - - 1
-              - 3
-            - - 5
-              - 5
         - - MODSEQ
           - 1236
       raw_data: "* ESEARCH (TAG \"a\") ALL 5,3,2,1 MODSEQ 1236\r\n"
@@ -145,17 +130,6 @@
       data: !ruby/object:Net::IMAP::VanishedData
         uids: !ruby/object:Net::IMAP::SequenceSet
           string: 41,43:116,118,120:211,214:540
-          tuples:
-          - - 41
-            - 41
-          - - 43
-            - 116
-          - - 118
-            - 118
-          - - 120
-            - 211
-          - - 214
-            - 540
         earlier: true
       raw_data: "* VANISHED (EARLIER) 41,43:116,118,120:211,214:540\r\n"
 
@@ -166,14 +140,5 @@
       data: !ruby/object:Net::IMAP::VanishedData
         uids: !ruby/object:Net::IMAP::SequenceSet
           string: '405,407,410,425'
-          tuples:
-          - - 405
-            - 405
-          - - 407
-            - 407
-          - - 410
-            - 410
-          - - 425
-            - 425
         earlier: false
       raw_data: "* VANISHED 405,407,410,425\r\n"

--- a/test/net/imap/fixtures/response_parser/rfc9394_partial.yml
+++ b/test/net/imap/fixtures/response_parser/rfc9394_partial.yml
@@ -20,11 +20,6 @@
               excl: false
             results: !ruby/object:Net::IMAP::SequenceSet
               string: 200:250,252:300
-              tuples:
-              - - 200
-                - 250
-              - - 252
-                - 300
       raw_data: "* ESEARCH (TAG \"A01\") UID PARTIAL (-1:-100 200:250,252:300)\r\n"
 
   "RFC9394 PARTIAL 3.1. example 2":
@@ -43,9 +38,6 @@
               excl: false
             results: !ruby/object:Net::IMAP::SequenceSet
               string: 55500:56000
-              tuples:
-              - - 55500
-                - 56000
       raw_data: "* ESEARCH (TAG \"A02\") UID PARTIAL (23500:24000 55500:56000)\r\n"
 
   "RFC9394 PARTIAL 3.1. example 3":

--- a/test/net/imap/fixtures/response_parser/status_responses.yml
+++ b/test/net/imap/fixtures/response_parser/status_responses.yml
@@ -52,11 +52,6 @@
           SEQ: !ruby/struct:Net::IMAP::ExtensionData
             data: !ruby/object:Net::IMAP::SequenceSet
               string: 1234:5,*:789654
-              tuples:
-              - - 5
-                - 1234
-              - - 789654
-                - 4294967296
           COMP-EMPTY: !ruby/struct:Net::IMAP::ExtensionData
             data: []
           COMP-QUOTED: !ruby/struct:Net::IMAP::ExtensionData


### PR DESCRIPTION
We can perfectly reconstruct the SequenceSet from the string.  The string is the canonical IMAP representation.  And, even if the tuples representation uses less memory, the string representation will always be more compact than the naive YAML serialization of the tuples.

So only serialize the string.