### PR TITLE
♻️ Extract ResponseReader from `get_response`

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -792,10 +792,11 @@ module Net
       "UTF8=ONLY" => "UTF8=ACCEPT",
     }.freeze
 
-    autoload :ConnectionState, File.expand_path("imap/connection_state", __dir__)
-    autoload :SASL,            File.expand_path("imap/sasl",             __dir__)
-    autoload :SASLAdapter,     File.expand_path("imap/sasl_adapter",     __dir__)
-    autoload :StringPrep,      File.expand_path("imap/stringprep",       __dir__)
+    dir = File.expand_path("imap", __dir__)
+    autoload :ConnectionState,        "#{dir}/connection_state"
+    autoload :SASL,                   "#{dir}/sasl"
+    autoload :SASLAdapter,            "#{dir}/sasl_adapter"
+    autoload :StringPrep,             "#{dir}/stringprep"
 
     include MonitorMixin
     if defined?(OpenSSL::SSL)

--- a/lib/net/imap/response_reader.rb
+++ b/lib/net/imap/response_reader.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Net
+  class IMAP
+    # See https://www.rfc-editor.org/rfc/rfc9051#section-2.2.2
+    class ResponseReader # :nodoc:
+      attr_reader :client
+
+      def initialize(client, sock)
+        @client, @sock = client, sock
+      end
+
+      def read_response_buffer
+        buff = String.new
+        catch :eof do
+          while true
+            read_line(buff)
+            break unless /\{(\d+)\}\r\n\z/n =~ buff
+            read_literal(buff, $1.to_i)
+          end
+        end
+        buff
+      end
+
+      private
+
+      def read_line(buff)
+        buff << (@sock.gets(CRLF) or throw :eof)
+      end
+
+      def read_literal(buff, literal_size)
+        literal = String.new(capacity: literal_size)
+        buff << (@sock.read(literal_size, literal) or throw :eof)
+      end
+
+    end
+  end
+end

--- a/test/net/imap/test_response_reader.rb
+++ b/test/net/imap/test_response_reader.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "net/imap"
+require "stringio"
+require "test/unit"
+
+class ResponseReaderTest < Test::Unit::TestCase
+  def setup
+    Net::IMAP.config.reset
+  end
+
+  class FakeClient
+    def config = @config ||= Net::IMAP.config.new
+  end
+
+  def literal(str) = "{#{str.bytesize}}\r\n#{str}"
+
+  test "#read_response_buffer" do
+    client = FakeClient.new
+    aaaaaaaaa    = "a" * (20 << 10)
+    many_crs     = "\r" * 1000
+    many_crlfs   = "\r\n" * 500
+    simple       = "* OK greeting\r\n"
+    long_line    = "tag ok #{aaaaaaaaa} #{aaaaaaaaa}\r\n"
+    literal_aaaa = "* fake #{literal aaaaaaaaa}\r\n"
+    literal_crlf = "tag ok #{literal many_crlfs} #{literal many_crlfs}\r\n"
+    illegal_crs  = "tag ok #{many_crs} #{many_crs}\r\n"
+    illegal_lfs  = "tag ok #{literal "\r"}\n#{literal "\r"}\n\r\n"
+    io = StringIO.new([
+      simple,
+      long_line,
+      literal_aaaa,
+      literal_crlf,
+      illegal_crs,
+      illegal_lfs,
+      simple,
+    ].join)
+    rcvr = Net::IMAP::ResponseReader.new(client, io)
+    assert_equal simple,       rcvr.read_response_buffer.to_str
+    assert_equal long_line,    rcvr.read_response_buffer.to_str
+    assert_equal literal_aaaa, rcvr.read_response_buffer.to_str
+    assert_equal literal_crlf, rcvr.read_response_buffer.to_str
+    assert_equal illegal_crs,  rcvr.read_response_buffer.to_str
+    assert_equal illegal_lfs,  rcvr.read_response_buffer.to_str
+    assert_equal simple,       rcvr.read_response_buffer.to_str
+    assert_equal "",           rcvr.read_response_buffer.to_str
+  end
+
+end


### PR DESCRIPTION
It's nice to extract a little bit of the complexity from the core `Net::IMAP` class.  But my primary motivation was so that I could directly test this code quickly and in isolation from needing to simulate a full IMAP connection.

Note that, because it wraps `@sock`, the ResponseReader _must_ be recreated (or updated) when `@sock` is replaced for TLS (or, in the future, for the `COMPRESS` extension).