### PR TITLE
♻️ Refactor ResponseReader

### DIFF
--- a/test/net/imap/test_response_reader.rb
+++ b/test/net/imap/test_response_reader.rb
@@ -24,6 +24,7 @@ class ResponseReaderTest < Test::Unit::TestCase
     long_line    = "tag ok #{aaaaaaaaa} #{aaaaaaaaa}\r\n"
     literal_aaaa = "* fake #{literal aaaaaaaaa}\r\n"
     literal_crlf = "tag ok #{literal many_crlfs} #{literal many_crlfs}\r\n"
+    zero_literal = "tag ok #{literal ""} #{literal ""}\r\n"
     illegal_crs  = "tag ok #{many_crs} #{many_crs}\r\n"
     illegal_lfs  = "tag ok #{literal "\r"}\n#{literal "\r"}\n\r\n"
     io = StringIO.new([
@@ -31,6 +32,7 @@ class ResponseReaderTest < Test::Unit::TestCase
       long_line,
       literal_aaaa,
       literal_crlf,
+      zero_literal,
       illegal_crs,
       illegal_lfs,
       simple,
@@ -40,6 +42,7 @@ class ResponseReaderTest < Test::Unit::TestCase
     assert_equal long_line,    rcvr.read_response_buffer.to_str
     assert_equal literal_aaaa, rcvr.read_response_buffer.to_str
     assert_equal literal_crlf, rcvr.read_response_buffer.to_str
+    assert_equal zero_literal, rcvr.read_response_buffer.to_str
     assert_equal illegal_crs,  rcvr.read_response_buffer.to_str
     assert_equal illegal_lfs,  rcvr.read_response_buffer.to_str
     assert_equal simple,       rcvr.read_response_buffer.to_str


### PR DESCRIPTION
Save `@buff` and `@literal_size` in ivars rather locals.  This avoids the need to pass them to every method that uses them. That's not a big deal now, but it simplifies the next few changes.

Also added a missing test for empty literals: `"{0}\r\n"`.