### PR TITLE
✨ Backport `response_handlers`option to `new` 

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -160,6 +160,8 @@ module Net
   # Use paginated or limited versions of commands whenever possible.
   #
   # Use #add_response_handler to handle responses after each one is received.
+  # Use the +response_handlers+ argument to ::new to assign response handlers
+  # before the receiver thread is started.
   #
   # == Errors
   #
@@ -1994,6 +1996,11 @@ module Net
     #     end
     #   }
     #
+    # Response handlers can also be added when the client is created before the
+    # receiver thread is started, by the +response_handlers+ argument to ::new.
+    # This ensures every server response is handled, including the #greeting.
+    #
+    # Related: #remove_response_handler, #response_handlers
     def add_response_handler(handler = nil, &block)
       raise ArgumentError, "two Procs are passed" if handler && block
       @response_handlers.push(block || handler)
@@ -2029,6 +2036,12 @@ module Net
     #         OpenSSL::SSL::SSLContext#set_params as parameters.
     # open_timeout:: Seconds to wait until a connection is opened
     # idle_response_timeout:: Seconds to wait until an IDLE response is received
+    # response_handlers:: A list of response handlers to be added before the
+    #                     receiver thread is started.  This ensures every server
+    #                     response is handled, including the #greeting.  Note
+    #                     that the greeting is handled in the current thread,
+    #                     but all other responses are handled in the receiver
+    #                     thread.
     #
     # The most common errors are:
     #
@@ -2071,6 +2084,7 @@ module Net
         @responses = Hash.new([].freeze)
         @tagged_responses = {}
         @response_handlers = []
+        options[:response_handlers]&.each do |h| add_response_handler(h) end
         @tagged_response_arrival = new_cond
         @continued_command_tag = nil
         @continuation_request_arrival = new_cond
@@ -2087,6 +2101,7 @@ module Net
         if @greeting.name == "BYE"
           raise ByeResponseError, @greeting
         end
+        @response_handlers.each do |handler| handler.call(@greeting) end
 
         @client_thread = Thread.current
         @receiver_thread = Thread.start {

--- a/test/net/imap/test_imap_response_handlers.rb
+++ b/test/net/imap/test_imap_response_handlers.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "net/imap"
+require "test/unit"
+require_relative "fake_server"
+
+class IMAPResponseHandlersTest < Test::Unit::TestCase
+  include Net::IMAP::FakeServer::TestHelper
+
+  def setup
+    Net::IMAP.config.reset
+    @do_not_reverse_lookup = Socket.do_not_reverse_lookup
+    Socket.do_not_reverse_lookup = true
+    @threads = []
+  end
+
+  def teardown
+    if !@threads.empty?
+      assert_join_threads(@threads)
+    end
+  ensure
+    Socket.do_not_reverse_lookup = @do_not_reverse_lookup
+  end
+
+  test "#add_response_handlers" do
+    responses = []
+    with_fake_server do |server, imap|
+      server.on("NOOP") do |resp|
+        3.times do resp.untagged("#{_1 + 1} EXPUNGE") end
+        resp.done_ok
+      end
+
+      assert_equal 0, imap.response_handlers.length
+      imap.add_response_handler do responses << [:block, _1] end
+      assert_equal 1, imap.response_handlers.length
+      imap.add_response_handler(->{ responses << [:proc, _1] })
+      assert_equal 2, imap.response_handlers.length
+
+      imap.noop
+      assert_pattern do
+        responses => [
+          [:block, Net::IMAP::UntaggedResponse[name: "EXPUNGE", data: 1]],
+          [:proc,  Net::IMAP::UntaggedResponse[name: "EXPUNGE", data: 1]],
+          [:block, Net::IMAP::UntaggedResponse[name: "EXPUNGE", data: 2]],
+          [:proc,  Net::IMAP::UntaggedResponse[name: "EXPUNGE", data: 2]],
+          [:block, Net::IMAP::UntaggedResponse[name: "EXPUNGE", data: 3]],
+          [:proc,  Net::IMAP::UntaggedResponse[name: "EXPUNGE", data: 3]],
+        ]
+      end
+    end
+  end
+
+end

--- a/test/net/imap/test_imap_response_handlers.rb
+++ b/test/net/imap/test_imap_response_handlers.rb
@@ -50,4 +50,41 @@ class IMAPResponseHandlersTest < Test::Unit::TestCase
     end
   end
 
+  test "::new with response_handlers kwarg" do
+    greeting = nil
+    expunges = []
+    alerts   = []
+    untagged = 0
+    handler0 = ->{ greeting ||= _1 }
+    handler1 = ->{ alerts   << _1.data.text if _1 in {data: {code: {name: "ALERT"}}} }
+    handler2 = ->{ expunges << _1.data if _1 in {name: "EXPUNGE"} }
+    handler3 = ->{ untagged += 1 if _1.is_a?(Net::IMAP::UntaggedResponse) }
+    response_handlers = [handler0, handler1, handler2, handler3]
+
+    run_fake_server_in_thread do |server|
+      port = server.port
+      imap = Net::IMAP.new("localhost", port:, response_handlers:)
+      assert_equal response_handlers, imap.response_handlers
+      refute_same  response_handlers, imap.response_handlers
+
+      # handler0 recieved the greeting and handler3 counted it
+      assert_equal imap.greeting, greeting
+      assert_equal 1, untagged
+
+      server.on("NOOP") do |resp|
+        resp.untagged "1 EXPUNGE"
+        resp.untagged "1 EXPUNGE"
+        resp.untagged "OK [ALERT] The first alert."
+        resp.done_ok  "[ALERT] Did you see the alert?"
+      end
+
+      imap.noop
+      assert_equal 4, untagged
+      assert_equal [1, 1], expunges # from handler2
+      assert_equal ["The first alert.", "Did you see the alert?"], alerts
+    ensure
+      imap&.logout! unless imap&.disconnected?
+    end
+  end
+
 end


### PR DESCRIPTION
Backports #419 (with backport fixes from #427) to `v0.3-stable`.