### PR TITLE
♻️ Backport `ResponseReader`to v0.3 

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -2226,10 +2226,12 @@ module Net
 
     def get_response
       buff = String.new
-      while true
-        get_response_line(buff) or break
-        break unless /\{(\d+)\}\r\n\z/n =~ buff
-        get_response_literal(buff, $1.to_i) or break
+      catch :eof do
+        while true
+          get_response_line(buff)
+          break unless /\{(\d+)\}\r\n\z/n =~ buff
+          get_response_literal(buff, $1.to_i)
+        end
       end
       return nil if buff.length == 0
       $stderr.print(buff.gsub(/^/n, "S: ")) if @@debug
@@ -2237,13 +2239,13 @@ module Net
     end
 
     def get_response_line(buff)
-      line = @sock.gets(CRLF) or return
+      line = @sock.gets(CRLF) or throw :eof
       buff << line
     end
 
     def get_response_literal(buff, literal_size)
       literal = String.new(capacity: literal_size)
-      @sock.read(literal_size, literal) or return
+      @sock.read(literal_size, literal) or throw :eof
       buff << literal
     end
 

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -2230,7 +2230,7 @@ module Net
         s = @sock.gets(CRLF)
         break unless s
         buff.concat(s)
-        if /\{(\d+)\}\r\n/n =~ s
+        if /\{(\d+)\}\r\n\z/n =~ buff
           s = @sock.read($1.to_i)
           buff.concat(s)
         else

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -2245,7 +2245,8 @@ module Net
     end
 
     def get_response_literal(buff, literal_size)
-      literal = @sock.read(literal_size) or return
+      literal = String.new(capacity: literal_size)
+      @sock.read(literal_size, literal) or return
       buff << literal
     end
 

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -2227,12 +2227,9 @@ module Net
     def get_response
       buff = String.new
       while true
-        s = @sock.gets(CRLF)
-        break unless s
-        buff.concat(s)
+        get_response_line(buff) or break
         if /\{(\d+)\}\r\n\z/n =~ buff
-          s = @sock.read($1.to_i)
-          buff.concat(s)
+          get_response_literal(buff, $1.to_i) or break
         else
           break
         end
@@ -2241,6 +2238,18 @@ module Net
       $stderr.print(buff.gsub(/^/n, "S: ")) if @@debug
       @parser.parse(buff)
     end
+
+    def get_response_line(buff)
+      line = @sock.gets(CRLF) or return
+      buff << line
+    end
+
+    def get_response_literal(buff, literal_size)
+      literal = @sock.read(literal_size) or return
+      buff << literal
+    end
+
+    #############################
 
     def record_response(name, data)
       unless @responses.has_key?(name)

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -737,6 +737,8 @@ module Net
   class IMAP < Protocol
     VERSION = "0.3.8"
 
+    autoload :ResponseReader, File.expand_path("imap/response_reader", __dir__)
+
     include MonitorMixin
     if defined?(OpenSSL::SSL)
       include OpenSSL
@@ -2074,6 +2076,7 @@ module Net
       @idle_response_timeout = options[:idle_response_timeout] || 5
       @parser = ResponseParser.new
       @sock = tcp_socket(@host, @port)
+      @reader = ResponseReader.new(self, @sock)
       begin
         if options[:ssl]
           start_tls_session(options[:ssl])
@@ -2225,28 +2228,10 @@ module Net
     end
 
     def get_response
-      buff = String.new
-      catch :eof do
-        while true
-          get_response_line(buff)
-          break unless /\{(\d+)\}\r\n\z/n =~ buff
-          get_response_literal(buff, $1.to_i)
-        end
-      end
+      buff = @reader.read_response_buffer
       return nil if buff.length == 0
       $stderr.print(buff.gsub(/^/n, "S: ")) if @@debug
       @parser.parse(buff)
-    end
-
-    def get_response_line(buff)
-      line = @sock.gets(CRLF) or throw :eof
-      buff << line
-    end
-
-    def get_response_literal(buff, literal_size)
-      literal = String.new(capacity: literal_size)
-      @sock.read(literal_size, literal) or throw :eof
-      buff << literal
     end
 
     #############################
@@ -2428,6 +2413,7 @@ module Net
         context.verify_callback = VerifyCallbackProc
       end
       @sock = SSLSocket.new(@sock, context)
+      @reader = ResponseReader.new(self, @sock)
       @sock.sync_close = true
       @sock.hostname = @host if @sock.respond_to? :hostname=
       ssl_socket_connect(@sock, @open_timeout)

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -2228,11 +2228,8 @@ module Net
       buff = String.new
       while true
         get_response_line(buff) or break
-        if /\{(\d+)\}\r\n\z/n =~ buff
-          get_response_literal(buff, $1.to_i) or break
-        else
-          break
-        end
+        break unless /\{(\d+)\}\r\n\z/n =~ buff
+        get_response_literal(buff, $1.to_i) or break
       end
       return nil if buff.length == 0
       $stderr.print(buff.gsub(/^/n, "S: ")) if @@debug

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -2238,10 +2238,8 @@ module Net
         end
       end
       return nil if buff.length == 0
-      if @@debug
-        $stderr.print(buff.gsub(/^/n, "S: "))
-      end
-      return @parser.parse(buff)
+      $stderr.print(buff.gsub(/^/n, "S: ")) if @@debug
+      @parser.parse(buff)
     end
 
     def record_response(name, data)

--- a/lib/net/imap/response_reader.rb
+++ b/lib/net/imap/response_reader.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Net
+  class IMAP
+    # See https://www.rfc-editor.org/rfc/rfc9051#section-2.2.2
+    class ResponseReader # :nodoc:
+      attr_reader :client
+
+      def initialize(client, sock)
+        @client, @sock = client, sock
+      end
+
+      def read_response_buffer
+        buff = String.new
+        catch :eof do
+          while true
+            read_line(buff)
+            break unless /\{(\d+)\}\r\n\z/n =~ buff
+            read_literal(buff, $1.to_i)
+          end
+        end
+        buff
+      end
+
+      private
+
+      def read_line(buff)
+        buff << (@sock.gets(CRLF) or throw :eof)
+      end
+
+      def read_literal(buff, literal_size)
+        literal = String.new(capacity: literal_size)
+        buff << (@sock.read(literal_size, literal) or throw :eof)
+      end
+
+    end
+  end
+end

--- a/lib/net/imap/response_reader.rb
+++ b/lib/net/imap/response_reader.rb
@@ -28,7 +28,7 @@ module Net
 
       attr_reader :buff, :literal_size
 
-      def get_literal_size    = /\{(\d+)\}\r\n\z/n =~ buff && $1.to_i
+      def get_literal_size; /\{(\d+)\}\r\n\z/n =~ buff && $1.to_i end
 
       def read_line
         buff << (@sock.gets(CRLF) or throw :eof)

--- a/test/net/imap/test_response_reader.rb
+++ b/test/net/imap/test_response_reader.rb
@@ -5,12 +5,7 @@ require "stringio"
 require "test/unit"
 
 class ResponseReaderTest < Test::Unit::TestCase
-  def setup
-    Net::IMAP.config.reset
-  end
-
   class FakeClient
-    def config; @config ||= Net::IMAP.config.new end
   end
 
   def literal(str) "{#{str.bytesize}}\r\n#{str}" end

--- a/test/net/imap/test_response_reader.rb
+++ b/test/net/imap/test_response_reader.rb
@@ -19,6 +19,7 @@ class ResponseReaderTest < Test::Unit::TestCase
     long_line    = "tag ok #{aaaaaaaaa} #{aaaaaaaaa}\r\n"
     literal_aaaa = "* fake #{literal aaaaaaaaa}\r\n"
     literal_crlf = "tag ok #{literal many_crlfs} #{literal many_crlfs}\r\n"
+    zero_literal = "tag ok #{literal ""} #{literal ""}\r\n"
     illegal_crs  = "tag ok #{many_crs} #{many_crs}\r\n"
     illegal_lfs  = "tag ok #{literal "\r"}\n#{literal "\r"}\n\r\n"
     io = StringIO.new([
@@ -26,6 +27,7 @@ class ResponseReaderTest < Test::Unit::TestCase
       long_line,
       literal_aaaa,
       literal_crlf,
+      zero_literal,
       illegal_crs,
       illegal_lfs,
       simple,
@@ -35,6 +37,7 @@ class ResponseReaderTest < Test::Unit::TestCase
     assert_equal long_line,    rcvr.read_response_buffer.to_str
     assert_equal literal_aaaa, rcvr.read_response_buffer.to_str
     assert_equal literal_crlf, rcvr.read_response_buffer.to_str
+    assert_equal zero_literal, rcvr.read_response_buffer.to_str
     assert_equal illegal_crs,  rcvr.read_response_buffer.to_str
     assert_equal illegal_lfs,  rcvr.read_response_buffer.to_str
     assert_equal simple,       rcvr.read_response_buffer.to_str

--- a/test/net/imap/test_response_reader.rb
+++ b/test/net/imap/test_response_reader.rb
@@ -10,10 +10,10 @@ class ResponseReaderTest < Test::Unit::TestCase
   end
 
   class FakeClient
-    def config = @config ||= Net::IMAP.config.new
+    def config; @config ||= Net::IMAP.config.new end
   end
 
-  def literal(str) = "{#{str.bytesize}}\r\n#{str}"
+  def literal(str) "{#{str.bytesize}}\r\n#{str}" end
 
   test "#read_response_buffer" do
     client = FakeClient.new

--- a/test/net/imap/test_response_reader.rb
+++ b/test/net/imap/test_response_reader.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "net/imap"
+require "stringio"
+require "test/unit"
+
+class ResponseReaderTest < Test::Unit::TestCase
+  def setup
+    Net::IMAP.config.reset
+  end
+
+  class FakeClient
+    def config = @config ||= Net::IMAP.config.new
+  end
+
+  def literal(str) = "{#{str.bytesize}}\r\n#{str}"
+
+  test "#read_response_buffer" do
+    client = FakeClient.new
+    aaaaaaaaa    = "a" * (20 << 10)
+    many_crs     = "\r" * 1000
+    many_crlfs   = "\r\n" * 500
+    simple       = "* OK greeting\r\n"
+    long_line    = "tag ok #{aaaaaaaaa} #{aaaaaaaaa}\r\n"
+    literal_aaaa = "* fake #{literal aaaaaaaaa}\r\n"
+    literal_crlf = "tag ok #{literal many_crlfs} #{literal many_crlfs}\r\n"
+    illegal_crs  = "tag ok #{many_crs} #{many_crs}\r\n"
+    illegal_lfs  = "tag ok #{literal "\r"}\n#{literal "\r"}\n\r\n"
+    io = StringIO.new([
+      simple,
+      long_line,
+      literal_aaaa,
+      literal_crlf,
+      illegal_crs,
+      illegal_lfs,
+      simple,
+    ].join)
+    rcvr = Net::IMAP::ResponseReader.new(client, io)
+    assert_equal simple,       rcvr.read_response_buffer.to_str
+    assert_equal long_line,    rcvr.read_response_buffer.to_str
+    assert_equal literal_aaaa, rcvr.read_response_buffer.to_str
+    assert_equal literal_crlf, rcvr.read_response_buffer.to_str
+    assert_equal illegal_crs,  rcvr.read_response_buffer.to_str
+    assert_equal illegal_lfs,  rcvr.read_response_buffer.to_str
+    assert_equal simple,       rcvr.read_response_buffer.to_str
+    assert_equal "",           rcvr.read_response_buffer.to_str
+  end
+
+end


### PR DESCRIPTION
Backports the following to `v0.3-stable`:
* #422 
* #433
  includes backport fixes from #434)
* #435 