### PR TITLE
✅ Add modern ruby versions to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     name: build (${{ matrix.ruby }} / ${{ matrix.os }})
     strategy:
       matrix:
-        ruby: [ head, '3.0', '2.7' ]
+        ruby: [ head, '3.3', '3.2', '3.1', '3.0', '2.7' ]
         os: [ ubuntu-latest, macos-latest ]
         experimental: [false]
         include:


### PR DESCRIPTION
In prep for the final 0.2.x release, I want to make sure we're testing against all relevant ruby versions.