### PR TITLE
🐛 Check for Ractor (for JRuby, TruffleRuby)

### DIFF
--- a/lib/net/imap/config/attr_type_coercion.rb
+++ b/lib/net/imap/config/attr_type_coercion.rb
@@ -28,7 +28,11 @@ module Net
         end
         private_class_method :included
 
-        def self.safe(...) = Ractor.make_shareable nil.instance_eval(...).freeze
+        if defined?(Ractor.make_shareable)
+          def self.safe(...) Ractor.make_shareable nil.instance_eval(...).freeze end
+        else
+          def self.safe(...) nil.instance_eval(...).freeze end
+        end
         private_class_method :safe
 
         Types = Hash.new do |h, type| type => Proc | nil; safe{type} end


### PR DESCRIPTION
This is the same code I used in the `v0.4-stable` backport.  I didn't use it in the main branch because the minimum ruby version is 3.1.  But that breaks when JRuby and TruffleRuby try to `require "net/imap"`.

Fixes #452.