### PR TITLE
🐛 Fix `SequenceSet#slice` with range `(start...0)`

### DIFF
--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -1241,7 +1241,10 @@ module Net
       def slice_range(range)
         first = range.begin ||  0
         last  = range.end   || -1
-        last -= 1 if range.exclude_end? && range.end && last != STAR_INT
+        if range.exclude_end?
+          return SequenceSet.empty if last.zero?
+          last -= 1 if range.end && last != STAR_INT
+        end
         if (first * last).positive? && last < first
           SequenceSet.empty
         elsif (min = at(first))

--- a/test/net/imap/test_sequence_set.rb
+++ b/test/net/imap/test_sequence_set.rb
@@ -289,6 +289,8 @@ class IMAPSequenceSetTest < Test::Unit::TestCase
     assert_equal SequenceSet.empty, SequenceSet[1..100][-50..-60]
     assert_equal SequenceSet.empty, SequenceSet[1..100][-10..10]
     assert_equal SequenceSet.empty, SequenceSet[1..100][60..-60]
+    assert_equal SequenceSet.empty, SequenceSet[1..100][10...0]
+    assert_equal SequenceSet.empty, SequenceSet[1..100][0...0]
     assert_nil SequenceSet.empty[2..4]
     assert_nil SequenceSet[101..200][1000..1060]
     assert_nil SequenceSet[101..200][-1000..-60]


### PR DESCRIPTION
The bug was that exclusive ranges ending in zero would be converted to end on `-1`, which would be interpreted as the last value in the range.