### PR TITLE
🐛 Fix inconsistently frozen SequenceSet#[] result

### DIFF
--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -1242,16 +1242,16 @@ module Net
         first = range.begin ||  0
         last  = range.end   || -1
         if range.exclude_end?
-          return SequenceSet.empty if last.zero?
+          return remain_frozen_empty if last.zero?
           last -= 1 if range.end && last != STAR_INT
         end
         if (first * last).positive? && last < first
-          SequenceSet.empty
+          remain_frozen_empty
         elsif (min = at(first))
           max = at(last)
           if    max == :*  then self & (min..)
           elsif min <= max then self & (min..max)
-          else                  SequenceSet.empty
+          else                  remain_frozen_empty
           end
         end
       end
@@ -1391,6 +1391,7 @@ module Net
       private
 
       def remain_frozen(set) frozen? ? set.freeze : set end
+      def remain_frozen_empty; frozen? ? SequenceSet.empty : SequenceSet.new end
 
       # frozen clones are shallow copied
       def initialize_clone(other)

--- a/test/net/imap/test_sequence_set.rb
+++ b/test/net/imap/test_sequence_set.rb
@@ -82,6 +82,32 @@ class IMAPSequenceSetTest < Test::Unit::TestCase
     end
   end
 
+  data "#slice(length)",   {transform: ->{ _1.slice(0, 10)    }, }
+  data "#slice(range)",    {transform: ->{ _1.slice(0...10)   }, }
+  data "#slice => empty",  {transform: ->{ _1.slice(0...0)    }, }
+  data "#slice => empty",  {transform: ->{ _1.slice(10..9)    }, }
+  data "#union",           {transform: ->{ _1 | (1..100)      }, }
+  data "#intersection",    {transform: ->{ _1 & (1..100)      }, }
+  data "#difference",      {transform: ->{ _1 - (1..100)      }, }
+  # data "#xor",             {transform: ->{ _1 ^ (1..100)      }, }
+  data "#complement",      {transform: ->{ ~_1                }, }
+  data "#normalize",       {transform: ->{ _1.normalize       }, }
+  data "#limit",           {transform: ->{ _1.limit(max: 22)  }, freeze: :always }
+  data "#limit => empty",  {transform: ->{ _1.limit(max: 1)   }, freeze: :always }
+  test "transforms keep frozen status" do |data|
+    data => {transform:}
+    set = SequenceSet.new("2:4,7:11,99,999")
+    result = transform.to_proc.(set)
+    if data in {freeze: :always}
+      assert result.frozen?, "this transform always returns frozen"
+    else
+      refute result.frozen?, "transform of non-frozen returned frozen"
+    end
+    set.freeze
+    result = transform.to_proc.(set)
+    assert result.frozen?, "transform of frozen returned non-frozen"
+  end
+
   %i[clone dup].each do |method|
     test "##{method}" do
       orig = SequenceSet.new "2:4,7:11,99,999"


### PR DESCRIPTION
This maybe isn't actually documented very well (or at all...?) but most SequenceSet transform methods return a frozen result when `self` is frozen and a mutable result when `self` is mutable.  Except `limit` which always returns a frozen result.  And (before this commit) `slice`, which inconsistently returned with matching frozen status when the result wasn't empty, but always returned a frozen set when the result _was_ empty.

(Adding these tests exposed a _much_ more significant bug: `SequenceSet#xor` mutates the receiver: #457.)