### PR TITLE
🐛 Fix `SequenceSet#slice` when length > result size

### DIFF
--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -1249,6 +1249,7 @@ module Net
           remain_frozen_empty
         elsif (min = at(first))
           max = at(last)
+          max = :* if max.nil?
           if    max == :*  then self & (min..)
           elsif min <= max then self & (min..max)
           else                  remain_frozen_empty

--- a/test/net/imap/test_sequence_set.rb
+++ b/test/net/imap/test_sequence_set.rb
@@ -296,6 +296,9 @@ class IMAPSequenceSetTest < Test::Unit::TestCase
                  SequenceSet[((1..10_000) % 10).to_a][-5, 4]
     assert_nil SequenceSet[111..222, 888..999][2000, 4]
     assert_nil SequenceSet[111..222, 888..999][-2000, 4]
+    # with length longer than the remaining members
+    assert_equal SequenceSet[101...200],
+                 SequenceSet[1...200][100, 10000]
   end
 
   test "#[range]" do
@@ -322,6 +325,8 @@ class IMAPSequenceSetTest < Test::Unit::TestCase
     assert_nil SequenceSet.empty[2..4]
     assert_nil SequenceSet[101..200][1000..1060]
     assert_nil SequenceSet[101..200][-1000..-60]
+    # with length longer than the remaining members
+    assert_equal SequenceSet[101..1111], SequenceSet[1..1111][100..999_999]
   end
 
   test "#find_index" do


### PR DESCRIPTION
The goal is for `#[]` (aliased as `#slice`) to behave similarly to `Array#[]`/`Array#slice`.  When `Array#slice` has a length or range that extends beyond the end of the array, they simply return everything up to the end.