### PR TITLE
✅ Test `SequenceSet#xor` and fuzz test all set operations

### DIFF
--- a/test/net/imap/test_sequence_set.rb
+++ b/test/net/imap/test_sequence_set.rb
@@ -612,6 +612,16 @@ class IMAPSequenceSetTest < Test::Unit::TestCase
     assert_equal seqset["1,5,11:99"], seqset["1,5:6,8:9,11:99"].subtract("6:9")
   end
 
+  test "#xor" do
+    seqset = -> { SequenceSet.new(_1) }
+    assert_equal seqset["1:5,11:15"], seqset["1:10"] ^ seqset["6:15"]
+    assert_equal seqset["1,3,5:6"],   seqset[1..5]   ^ [2, 4, 6]
+    assert_equal SequenceSet.empty,   seqset[1..5]   ^ seqset[1..5]
+    assert_equal seqset["1:100"],     seqset["1:50"] ^ seqset["51:100"]
+    assert_equal seqset["1:50"],      seqset["1:50"] ^ SequenceSet.empty
+    assert_equal seqset["1:50"],      SequenceSet.empty ^ seqset["1:50"]
+  end
+
   test "#min" do
     assert_equal   3, SequenceSet.new("34:3").min
     assert_equal 345, SequenceSet.new("345,678").min

--- a/test/net/imap/test_sequence_set.rb
+++ b/test/net/imap/test_sequence_set.rb
@@ -22,7 +22,7 @@ class IMAPSequenceSetTest < Test::Unit::TestCase
     assert seqset.cover? sorted.sample 100
   end
 
-  test "compared to reference Set, add many random values" do
+  test "fuzz test: add numbers and compare to reference Set" do
     set    = Set.new
     seqset = SequenceSet.new
     10.times do
@@ -31,12 +31,86 @@ class IMAPSequenceSetTest < Test::Unit::TestCase
     end
   end
 
-  test "compared to reference Set, add many large ranges" do
+  test "fuzz test: add ranges and compare to reference Set" do
     set    = Set.new
     seqset = SequenceSet.new
     (1..10_000).each_slice(250) do
       compare_to_reference_set _1, set, seqset
       assert_equal 1, seqset.elements.size
+    end
+  end
+
+  test "fuzz test: set union identities" do
+    10.times do
+      lhs = SequenceSet[Array.new(100) { rand(1..300) }]
+      rhs = SequenceSet[Array.new(100) { rand(1..300) }]
+      union = lhs | rhs
+      assert_equal union, rhs | lhs # commutative
+      assert_equal union, ~(~lhs & ~rhs) # De Morgan's Law
+      assert_equal union, lhs | (lhs ^ rhs)
+      assert_equal union, lhs | (rhs - lhs)
+      assert_equal union, (lhs & rhs) ^ (lhs ^ rhs)
+      mutable = lhs.dup
+      assert_equal union, mutable.merge(rhs)
+      assert_equal union, mutable
+    end
+  end
+
+  test "fuzz test: set intersection identities" do
+    10.times do
+      lhs = SequenceSet[Array.new(100) { rand(1..300) }]
+      rhs = SequenceSet[Array.new(100) { rand(1..300) }]
+      intersection = lhs & rhs
+      assert_equal intersection, rhs & lhs # commutative
+      assert_equal intersection, ~(~lhs | ~rhs) # De Morgan's Law
+      assert_equal intersection, lhs - ~rhs
+      assert_equal intersection, lhs - (lhs - rhs)
+      assert_equal intersection, lhs - (lhs ^ rhs)
+      assert_equal intersection, lhs ^ (lhs - rhs)
+    end
+  end
+
+  test "fuzz test: set subtraction identities" do
+    10.times do
+      lhs = SequenceSet[Array.new(100) { rand(1..300) }]
+      rhs = SequenceSet[Array.new(100) { rand(1..300) }]
+      difference = lhs - rhs
+      assert_equal difference, ~rhs - ~lhs
+      assert_equal difference, ~(~lhs | rhs)
+      assert_equal difference, lhs & (lhs ^ rhs)
+      assert_equal difference, lhs ^ (lhs & rhs)
+      assert_equal difference, rhs ^ (lhs | rhs)
+      mutable = lhs.dup
+      assert_equal difference, mutable.subtract(rhs)
+      assert_equal difference, mutable
+    end
+  end
+
+  test "fuzz test: set xor identities" do
+    10.times do
+      lhs = SequenceSet[Array.new(100) { rand(1..300) }]
+      rhs = SequenceSet[Array.new(100) { rand(1..300) }]
+      mid = SequenceSet[Array.new(100) { rand(1..300) }]
+      xor = lhs ^ rhs
+      assert_equal xor, rhs ^ lhs # commutative
+      assert_equal xor, (lhs | rhs) - (lhs & rhs)
+      assert_equal xor, (lhs ^ mid) ^ (mid ^ rhs)
+      assert_equal xor, ~lhs ^ ~rhs
+    end
+  end
+
+  test "fuzz test: set complement identities" do
+    10.times do
+      set = SequenceSet[Array.new(100) { rand(1..300) }]
+      complement = ~set
+      assert_equal set,        ~complement
+      assert_equal complement, ~set.dup
+      assert_equal complement, SequenceSet.full - set
+      mutable = set.dup
+      assert_equal complement, mutable.complement!
+      assert_equal complement, mutable
+      assert_equal set,        mutable.complement!
+      assert_equal set,        mutable
     end
   end
 


### PR DESCRIPTION
I almost accidentally committed a big bug for `#xor`.  I'm not sure how `#xor` escaped testing before now, but yikes!  I decided to take that opportunity to simply add some randomized tests on all of the set operators, based on set identities that should always hold true.

Later, these can also be used as a starting point for microbenchmarks and profiling of `SequenceSet`.