### PR TITLE
♻️ Generate same stringprep tables with ruby 3.4

### DIFF
--- a/rakelib/string_prep_tables_generator.rb
+++ b/rakelib/string_prep_tables_generator.rb
@@ -388,9 +388,11 @@ class StringPrepTablesGenerator
   end
 
   def asgn_mapping(name, replacement = to_map(tables[name]))
+    indent = "  " * 2
+    replacement = replacement.inspect.gsub(/" => "/, '"=>"')
     cname = name.tr(?., ?_).upcase
-    "# Replacements for %s\n%s%s = %p.freeze" % [
-      "IN_#{name}", "  " * 2, "MAP_#{cname}", replacement,
+    "# Replacements for %s\n%s%s = %s.freeze" % [
+      "IN_#{name}", indent, "MAP_#{cname}", replacement,
     ]
   end
 


### PR DESCRIPTION
Ruby 3.4 changed its `Hash#inspect` representation (for the better). So, every time I run rake (after switching to a branch that updates mtimes on related files), this file is converted to the ruby 3.4+ format.

This commit normalizes the output.  It uses the older format simply to keep the diff small.  Next time we update the stringprep code, we can switch to the ruby 3.4+ format.