### PR TITLE
✅ CI: Mark ruby head on windows as "experimental"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,10 @@ jobs:
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         experimental: [false]
+        exclude:
+          - { ruby: head, os: windows-latest }
+        include:
+          - { ruby: head, os: windows-latest, experimental: true }
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     steps:


### PR DESCRIPTION
Currently, it looks like irb can't be installed on window on ruby head. This is most likely a temporary issue.  But IMO, it's not a significant enough issue to fail the build (which cancels all of the other jobs).