### PR TITLE
⏪ Revert Ractor sharability for config types

### DIFF
--- a/lib/net/imap/config/attr_type_coercion.rb
+++ b/lib/net/imap/config/attr_type_coercion.rb
@@ -28,11 +28,8 @@ module Net
         end
         private_class_method :included
 
-        if defined?(Ractor.make_shareable)
-          def self.safe(...) Ractor.make_shareable nil.instance_eval(...).freeze end
-        else
-          def self.safe(...) nil.instance_eval(...).freeze end
-        end
+        # Used in v0.5.8+ for Ractor sharability.
+        def self.safe(...) nil.instance_eval(...).freeze end
         private_class_method :safe
 
         Types = Hash.new do |h, type|


### PR DESCRIPTION
This was just one piece of making config objects ractor sharable—it is insufficient by itself.  And it caused problems with earlier versions of ruby 3.0.  It should not have been committed to the v0.4-stable branch.

Fixes: #471
Reported-by: @glaszig, @mumkymikey