### PR TITLE
✅ Update ResponseReader, UIDFetchData, DeprecatedClientOptions tests

### DIFF
--- a/test/net/imap/test_deprecated_client_options.rb
+++ b/test/net/imap/test_deprecated_client_options.rb
@@ -87,31 +87,15 @@ class DeprecatedClientOptionsTest < Test::Unit::TestCase
     end
 
     test "combined options hash and keyword args raises ArgumentError" do
-      ex = nil
-      run_fake_server_in_thread(
-        ignore_io_error: true, implicit_tls: true
-      ) do |server|
-        imap = Net::IMAP.new("localhost", {port: 993}, ssl: true)
-      rescue => ex
-        nil
-      ensure
-        imap&.disconnect
+      assert_raise_with_message ArgumentError, /deprecated.*keyword arg/ do
+        Net::IMAP.new("localhost", {port: 993}, ssl: true)
       end
-      assert_equal ArgumentError, ex.class
     end
 
     test "combined options hash and ssl args raises ArgumentError" do
-      ex = nil
-      run_fake_server_in_thread(
-        ignore_io_error: true, implicit_tls: true
-      ) do |server|
-        imap = Net::IMAP.new("localhost", {port: 993}, true)
-      rescue => ex
-        nil
-      ensure
-        imap&.disconnect
+      assert_raise_with_message ArgumentError, /deprecated SSL.*options hash/ do
+        Net::IMAP.new("localhost", {port: 993}, true)
       end
-      assert_equal ArgumentError, ex.class
     end
 
   end

--- a/test/net/imap/test_fetch_data.rb
+++ b/test/net/imap/test_fetch_data.rb
@@ -36,20 +36,24 @@ class UIDFetchDataTest < Test::Unit::TestCase
     assert_equal 22222, data.uid
   end
 
-  test "#uid warns when differs from UID attribute" do
-    data = nil
+  test "#initialize warns when uid differs from attr['UID']" do
     assert_warn(/UIDs do not match/i) do
-      data = Net::IMAP::UIDFetchData.new(22222, "UID" => 54_321)
+      Net::IMAP::UIDFetchData.new(22222, "UID" => 54_321)
     end
+  end
+
+  test "#uid ignores the UID attribute" do
+    data = EnvUtil.suppress_warning {
+      Net::IMAP::UIDFetchData.new(22222, "UID" => 54_321)
+    }
     assert_equal 22222, data.uid
   end
 
   test "#deconstruct_keys" do
-    assert_warn(/UIDs do not match/i) do
-      Net::IMAP::UIDFetchData.new(22222, "UID" => 54_321) => {
-        uid: 22222
-      }
-    end
+    data = EnvUtil.suppress_warning {
+      Net::IMAP::UIDFetchData.new(22222, "UID" => 54_321)
+    }
+    assert_pattern { data => { uid: 22222 } }
   end
 end
 


### PR DESCRIPTION
Splits up `ResponseReader` tests and UIDFetchData into more fine-grained tests.  Different parts of these test pass or fail on TruffleRuby or JRuby, so splitting them off into their own tests lets us mark only specific bits as pending or omitted.

The DeprecatedClientOptions tests weren't even using the correct port for the fake server, and weren't supposed to be capable of connecting anyway, so there is reason to start the server up at all.  Also, we have issues with reliably shutting the server down after an error, for both TruffleRuby and JRuby.

(See #470.)