### PR TITLE
✅ Update Regexp.linear_time? tests for non-CRuby

### DIFF
--- a/test/net/imap/regexp_collector.rb
+++ b/test/net/imap/regexp_collector.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class RegexpCollector
+  Data = Net::IMAP::Data
+
   ConstantRegexp = Data.define(:mod, :const_name, :regexp) do
     def name = "%s::%s" % [mod, const_name]
   end

--- a/test/net/imap/test_regexps.rb
+++ b/test/net/imap/test_regexps.rb
@@ -3,8 +3,6 @@
 require "net/imap"
 require "test/unit"
 
-return unless Regexp.respond_to?(:linear_time?)
-
 begin
   require_relative "regexp_collector"
 rescue LoadError
@@ -34,7 +32,13 @@ class IMAPRegexpsTest < Test::Unit::TestCase
   )
 
   def test_linear_time(data)
-    assert Regexp.linear_time?(data.regexp)
+    regexp = data.regexp
+    assert Regexp.linear_time?(regexp), "%p might backtrack" % [regexp]
+  rescue NoMethodError
+    pend "Regexp.linear_time? not implemented by #{RUBY_ENGINE} #{RUBY_ENGINE_VERSION}"
+  rescue Test::Unit::AssertionFailedError
+    raise if RUBY_ENGINE == "ruby"
+    pend "%p might backtrack in %s %s" % [regexp, RUBY_ENGINE, RUBY_ENGINE_VERSION]
   end
 
 end


### PR DESCRIPTION
We'll attempt to load these tests for all ruby engines, but we'll catch failures and mark them as pending.

On @eregon's suggestion, this also prints out regexp.inspect when it fails.