### PR TITLE
🐛 Fix `SequenceSet#include?` handling of invalid inputs

### DIFF
--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -528,8 +528,8 @@ module Net
       def cover?(other) input_to_tuples(other).none? { !include_tuple?(_1) } end
 
       # Returns +true+ when a given number or range is in +self+, and +false+
-      # otherwise.  Returns +false+ unless +number+ is an Integer, Range, or
-      # <tt>*</tt>.
+      # otherwise.  Returns +nil+ when +number+ isn't a valid SequenceSet
+      # element (Integer, Range, <tt>*</tt>, +sequence-set+ string).
       #
       #     set = Net::IMAP::SequenceSet["5:10,100,111:115"]
       #     set.include? 1      #=> false
@@ -551,7 +551,10 @@ module Net
       #     set.include?(100..) #=> false
       #
       # Related: #include_star?, #cover?, #===
-      def include?(element) include_tuple? input_to_tuple element end
+      def include?(element)
+        tuple = input_to_tuple element rescue nil
+        !!include_tuple?(tuple) if tuple
+      end
 
       alias member? include?
 

--- a/test/net/imap/test_sequence_set.rb
+++ b/test/net/imap/test_sequence_set.rb
@@ -794,13 +794,16 @@ class IMAPSequenceSetTest < Test::Unit::TestCase
   end
 
   test "#include?" do
-    assert SequenceSet["2:4"].include?(3)
-    assert SequenceSet["2,*:12"].include? :*
-    assert SequenceSet["2,*:12"].include?(-1)
+    assert_equal true, SequenceSet["2:4"].include?(3)
+    assert_equal true, SequenceSet["2,*:12"].include?(:*)
+    assert_equal true, SequenceSet["2,*:12"].include?(-1)
+    assert_nil SequenceSet["1:*"].include?("hopes and dreams")
+    assert_nil SequenceSet["1:*"].include?(:wat?)
+    assert_nil SequenceSet["1:*"].include?([1, 2, 3])
     set = SequenceSet.new Array.new(100) { rand(1..1500) }
     rev = (~set).limit(max: 1_501)
-    set.numbers.each do assert set.include?(_1) end
-    rev.numbers.each do refute set.include?(_1) end
+    set.numbers.each do assert_equal true,  set.include?(_1) end
+    rev.numbers.each do assert_equal false, set.include?(_1) end
   end
 
   test "#cover?" do


### PR DESCRIPTION
The rdoc said it returned `false`, but it actually crashed.  It's sometimes useful to make the distinction between invalid input and valid input with a false return value, so I've updated so invalid input returns `nil` (and updated the rdoc to match).

Also, some of the rdoc examples were simply wrong.  Maybe a copy/paste error from `#intersect?`