### PR TITLE
🐛 Always remove idle response handler after done

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3062,8 +3062,8 @@ module Net
             raise @exception || Net::IMAP::Error.new("connection closed")
           end
         ensure
+          remove_response_handler(response_handler)
           unless @receiver_thread_terminating
-            remove_response_handler(response_handler)
             put_string("DONE#{CRLF}")
             response = get_tagged_response(tag, "IDLE", idle_response_timeout)
           end


### PR DESCRIPTION
Remove idle response handler if connection terminates.  There's no reason to hang onto dthe response handler when the connection is terminating anyway.