### PR TITLE
⏪ Revert #472 (✅ CI: Mark ruby head on windows as "experimental")

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,6 @@ jobs:
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         experimental: [false]
-        exclude:
-          - { ruby: head, os: windows-latest }
-        include:
-          - { ruby: head, os: windows-latest, experimental: true }
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     timeout-minutes: 15


### PR DESCRIPTION
This reverts commit c8f55e8a2246d4907712752f7e915f8f616bf633 (#472).

Everything seems to be passing now, so hopefully it'll stay that way. 🤞