### PR TITLE
✨ Add Net::IMAP::SequenceSet() coercion method

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -809,6 +809,22 @@ module Net
       include SSL
     end
 
+    # :call-seq:
+    #   Net::IMAP::SequenceSet(set = nil) -> SequenceSet
+    #
+    # Coerces +set+ into a SequenceSet, using either SequenceSet.try_convert or
+    # SequenceSet.new.
+    #
+    # * When +set+ is a SequenceSet, that same set is returned.
+    # * When +set+ responds to +to_sequence_set+, +set.to_sequence_set+ is
+    #   returned.
+    # * Otherwise, returns the result from calling SequenceSet.new with +set+.
+    #
+    # Related: SequenceSet.try_convert, SequenceSet.new, SequenceSet::[]
+    def self.SequenceSet(set = nil)
+      SequenceSet.try_convert(set) || SequenceSet.new(set)
+    end
+
     # Returns the global Config object
     def self.config; Config.global end
 

--- a/test/net/imap/test_sequence_set.rb
+++ b/test/net/imap/test_sequence_set.rb
@@ -273,6 +273,36 @@ class IMAPSequenceSetTest < Test::Unit::TestCase
     assert_raise DataFormatError do SequenceSet.try_convert(obj) end
   end
 
+  test "Net::IMAP::SequenceSet(set)" do
+    assert_equal SequenceSet.empty,   Net::IMAP::SequenceSet()
+    assert_equal SequenceSet.empty,   Net::IMAP::SequenceSet(nil)
+    assert_equal SequenceSet.empty,   Net::IMAP::SequenceSet([])
+    assert_equal SequenceSet.empty,   Net::IMAP::SequenceSet([[]])
+    assert_equal SequenceSet.empty,   Net::IMAP::SequenceSet("")
+    assert_equal SequenceSet[123],    Net::IMAP::SequenceSet(123)
+    assert_equal SequenceSet[12..34], Net::IMAP::SequenceSet(12..34)
+    assert_equal SequenceSet[12..34], Net::IMAP::SequenceSet("12:34")
+
+    refute Net::IMAP::SequenceSet("").frozen?
+
+    assert_raise DataFormatError do Net::IMAP::SequenceSet(Object.new) end
+
+    set = SequenceSet[123]
+    assert_same set, Net::IMAP::SequenceSet(set)
+
+    set = SequenceSet.new(123)
+    assert_same set, Net::IMAP::SequenceSet(set)
+
+    obj = Object.new
+    set = SequenceSet[192, 168, 1, 255]
+    obj.define_singleton_method(:to_sequence_set) { set }
+    assert_same set, Net::IMAP::SequenceSet(obj)
+
+    obj = Object.new
+    def obj.to_sequence_set; 192_168.001_255 end
+    assert_raise DataFormatError do Net::IMAP::SequenceSet(obj) end
+  end
+
   test "#at(non-negative index)" do
     assert_nil        SequenceSet.empty.at(0)
     assert_equal   1, SequenceSet[1..].at(0)


### PR DESCRIPTION
This new coercion method combines `::try_convert` with `::new`.  Unlike `new`, a new object won't be allocated when the input already is a SequenceSet.  Unlike `::[]`, empty sets are allowed and the result might not be frozen.