### PR TITLE
♻️ Move SequenceSet autoload

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -801,6 +801,7 @@ module Net
     autoload :ResponseReader,         "#{dir}/response_reader"
     autoload :SASL,                   "#{dir}/sasl"
     autoload :SASLAdapter,            "#{dir}/sasl_adapter"
+    autoload :SequenceSet,            "#{dir}/sequence_set"
     autoload :StringPrep,             "#{dir}/stringprep"
 
     include MonitorMixin

--- a/lib/net/imap/response_data.rb
+++ b/lib/net/imap/response_data.rb
@@ -6,7 +6,6 @@ module Net
     autoload :FetchData,        "#{__dir__}/fetch_data"
     autoload :UIDFetchData,     "#{__dir__}/fetch_data"
     autoload :SearchResult,     "#{__dir__}/search_result"
-    autoload :SequenceSet,      "#{__dir__}/sequence_set"
     autoload :UIDPlusData,      "#{__dir__}/uidplus_data"
     autoload :AppendUIDData,    "#{__dir__}/uidplus_data"
     autoload :CopyUIDData,      "#{__dir__}/uidplus_data"


### PR DESCRIPTION
Having this `autoload` in `response_data.rb` wasn't appropriate. SequenceSet is used internally for both commands and response data. And it's intended to be used separately from the client, e.g: for storing mailbox state.