### PR TITLE
♻️ Avoid unnecessary allocation in `SequenceSet[]`

### DIFF
--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -390,11 +390,8 @@ module Net
         # Related: ::new, ::try_convert
         def [](first, *rest)
           if rest.empty?
-            if first.is_a?(SequenceSet) && first.frozen? && first.valid?
-              first
-            else
-              new(first).validate.freeze
-            end
+            set = try_convert(first)&.validate
+            set&.frozen? ? set : (set&.dup || new(first).validate).freeze
           else
             new(first).merge(*rest).validate.freeze
           end

--- a/test/net/imap/test_sequence_set.rb
+++ b/test/net/imap/test_sequence_set.rb
@@ -237,6 +237,17 @@ class IMAPSequenceSetTest < Test::Unit::TestCase
   test ".[frozen SequenceSet] returns that SequenceSet" do
     frozen_seqset = SequenceSet[123..456]
     assert_same frozen_seqset, SequenceSet[frozen_seqset]
+
+    coercible = Object.new
+    frozen_seqset = SequenceSet[192, 168, 1, 255]
+    coercible.define_singleton_method(:to_sequence_set) { frozen_seqset }
+    assert_same frozen_seqset, SequenceSet[coercible]
+
+    coercible = Object.new
+    mutable_seqset = SequenceSet.new([192, 168, 1, 255])
+    coercible.define_singleton_method(:to_sequence_set) { mutable_seqset }
+    assert_equal mutable_seqset, SequenceSet[coercible]
+    refute_same  mutable_seqset, SequenceSet[coercible]
   end
 
   test ".new, input may be empty" do


### PR DESCRIPTION
This updates `SequenceSet[]` so a frozen result from `input.to_sequence_set` is returned directly, not duplicated.

It is also updated to delegate to `SequenceSet.try_convert`.