### PR TITLE
🧵 Close socket in `#disconnect` before waiting for lock & thread join

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -1151,9 +1151,7 @@ module Net
       rescue Exception => e
         @receiver_thread.raise(e)
       end
-      synchronize do
-        @sock.close
-      end
+      @sock.close
       @receiver_thread.join
       raise e if e
     ensure

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -1131,6 +1131,9 @@ module Net
 
     # Disconnects from the server.
     #
+    # Waits for receiver thread to close before returning.  Slow or stuck
+    # response handlers can cause #disconnect to hang until they complete.
+    #
     # Related: #logout, #logout!
     def disconnect
       in_logout_state = try_state_logout?

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -1139,13 +1139,7 @@ module Net
       in_logout_state = try_state_logout?
       return if disconnected?
       begin
-        begin
-          # try to call SSL::SSLSocket#io.
-          @sock.io.shutdown
-        rescue NoMethodError
-          # @sock is not an SSL::SSLSocket.
-          @sock.shutdown
-        end
+        @sock.to_io.shutdown
       rescue Errno::ENOTCONN
         # ignore `Errno::ENOTCONN: Socket is not connected' on some platforms.
       rescue Exception => e

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -1148,10 +1148,10 @@ module Net
       rescue Exception => e
         @receiver_thread.raise(e)
       end
-      @receiver_thread.join
       synchronize do
         @sock.close
       end
+      @receiver_thread.join
       raise e if e
     ensure
       # Try again after shutting down the receiver thread.  With no reciever

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -1133,7 +1133,7 @@ module Net
     #
     # Related: #logout, #logout!
     def disconnect
-      state_logout! unless connection_state.to_sym == :logout
+      in_logout_state = try_state_logout?
       return if disconnected?
       begin
         begin
@@ -1153,6 +1153,10 @@ module Net
         @sock.close
       end
       raise e if e
+    ensure
+      # Try again after shutting down the receiver thread.  With no reciever
+      # left to wait for, any remaining locks should be _very_ brief.
+      state_logout! unless in_logout_state
     end
 
     # Returns true if disconnected from the server.
@@ -3815,6 +3819,16 @@ module Net
       synchronize do
         @connection_state = ConnectionState::Logout.new
       end
+    end
+
+    # don't wait to aqcuire the lock
+    def try_state_logout?
+      return true if connection_state in [:logout, *]
+      return false unless acquired_lock = mon_try_enter
+      state_logout!
+      true
+    ensure
+      mon_exit if acquired_lock
     end
 
     def sasl_adapter

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -1133,8 +1133,8 @@ module Net
     #
     # Related: #logout, #logout!
     def disconnect
+      state_logout! unless connection_state.to_sym == :logout
       return if disconnected?
-      state_logout!
       begin
         begin
           # try to call SSL::SSLSocket#io.


### PR DESCRIPTION
While attempting to get the tests running under JRuby, `#disconnect` would sometimes deadlock.  So, although I haven't seen that problem elsewhere _and_ JRuby is still failing tests with another threading issue, this  (and #494) did get most tests passing _for me_ (but not in CI).

This updates `#disconnect` so that the socket is shutdown and closed before joining the receiver thread and before waiting for the lock to change `connection_state` (It will still _attempt_ to change `connection_state` before closing the socket, but it won't wait if the lock isn't available).