### PR TITLE
🧵 Improve synchronization of `connection_state` transitions

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3807,7 +3807,9 @@ module Net
     end
 
     def state_unselected!
-      state_authenticated! if connection_state.to_sym == :selected
+      synchronize do
+        state_authenticated! if connection_state.to_sym == :selected
+      end
     end
 
     def state_logout!


### PR DESCRIPTION
Handles a few more connection_state synchronization issues I saw while working on #493.

While attempting to get the tests running under JRuby, `#disconnect` would sometimes deadlock. So, although I haven't seen that problem elsewhere and JRuby is still failing tests with another threading issue, this did get most tests passing for me (but not in CI).