### PR TITLE
🔎 Update `SequenceSet#inspect` format to `Net::IMAP::SequenceSet(str)`

### DIFF
--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -1630,13 +1630,27 @@ module Net
         @tuples.empty? ? nil : -@tuples.map { tuple_to_str _1 }.join(",")
       end
 
+      # Returns an inspection string for the SequenceSet.
+      #
+      #   Net::IMAP::SequenceSet.new.inspect
+      #   #=> "#<Net::IMAP::SequenceSet empty>"
+      #
+      #   Net::IMAP::SequenceSet(1..5, 1024, 15, 2000).inspect
+      #   #=> '#<Net::IMAP::SequenceSet "1:5,15,1024,2000">'
+      #
+      # Frozen sets have slightly different output:
+      #
+      #   Net::IMAP::SequenceSet.empty.inspect
+      #   #=> "Net::IMAP::SequenceSet.empty"
+      #
+      #   Net::IMAP::SequenceSet[1..5, 1024, 15, 2000].inspect
+      #   #=> 'Net::IMAP::SequenceSet["1:5,15,1024,2000"]'
+      #
       def inspect
         if empty?
-          (frozen? ?  "%s.empty" : "#<%s empty>") % [self.class]
-        elsif frozen?
-          "%s[%p]"   % [self.class, to_s]
+          (frozen? ? "%s.empty" : "#<%s empty>") % [self.class]
         else
-          "#<%s %p>" % [self.class, to_s]
+          (frozen? ? "%s[%p]" : "#<%s %p>") % [self.class, to_s]
         end
       end
 

--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -1633,10 +1633,10 @@ module Net
       # Returns an inspection string for the SequenceSet.
       #
       #   Net::IMAP::SequenceSet.new.inspect
-      #   #=> "#<Net::IMAP::SequenceSet empty>"
+      #   #=> "Net::IMAP::SequenceSet()"
       #
       #   Net::IMAP::SequenceSet(1..5, 1024, 15, 2000).inspect
-      #   #=> '#<Net::IMAP::SequenceSet "1:5,15,1024,2000">'
+      #   #=> 'Net::IMAP::SequenceSet("1:5,15,1024,2000")'
       #
       # Frozen sets have slightly different output:
       #
@@ -1648,9 +1648,9 @@ module Net
       #
       def inspect
         if empty?
-          (frozen? ? "%s.empty" : "#<%s empty>") % [self.class]
+          (frozen? ? "%s.empty" : "%s()") % [self.class]
         else
-          (frozen? ? "%s[%p]" : "#<%s %p>") % [self.class, to_s]
+          (frozen? ? "%s[%p]" : "%s(%p)") % [self.class, to_s]
         end
       end
 

--- a/test/net/imap/test_sequence_set.rb
+++ b/test/net/imap/test_sequence_set.rb
@@ -888,11 +888,11 @@ class IMAPSequenceSetTest < Test::Unit::TestCase
 
   data(
     # desc         => [expected, input, freeze]
-    "empty"        => ["#<Net::IMAP::SequenceSet empty>",   nil],
+    "empty"        => ["Net::IMAP::SequenceSet()",          nil],
     "frozen empty" => ["Net::IMAP::SequenceSet.empty",      nil, true],
-    "normalized"   => ['#<Net::IMAP::SequenceSet "1:2">',   [2, 1]],
-    "denormalized" => ['#<Net::IMAP::SequenceSet "2,1">',   "2,1"],
-    "star"         => ['#<Net::IMAP::SequenceSet "*">',     "*"],
+    "normalized"   => ['Net::IMAP::SequenceSet("1:2")',   [2, 1]],
+    "denormalized" => ['Net::IMAP::SequenceSet("2,1")',   "2,1"],
+    "star"         => ['Net::IMAP::SequenceSet("*")',     "*"],
     "frozen"       => ['Net::IMAP::SequenceSet["1,3,5:*"]', [1, 3, 5..], true],
   )
   def test_inspect((expected, input, freeze))


### PR DESCRIPTION
Similarly to how `#inspect` already outputs frozen sets as valid ruby to recreate an identical set with `Net::IMAP::SequenceSet[str]`, this does that for mutuble sets too using `Net::IMAP::SequenceSet(str)`.