### PR TITLE
⚡🔎 Abridged SequenceSet#inspect output

### DIFF
--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -559,7 +559,7 @@ module Net
       # If the set was created from a single string, it is not normalized.  If
       # the set is updated the string will be normalized.
       #
-      # Related: #valid_string, #normalized_string, #to_s
+      # Related: #valid_string, #normalized_string, #to_s, #inspect
       def string; @string ||= normalized_string if valid? end
 
       # Returns an array with #normalized_string when valid and an empty array
@@ -592,7 +592,7 @@ module Net
       # string when the set is empty.  Note that an empty set is invalid in the
       # \IMAP syntax.
       #
-      # Related: #valid_string, #normalized_string, #to_s
+      # Related: #string, #valid_string, #normalized_string, #inspect
       def to_s; string || "" end
 
       # Freezes and returns the set.  A frozen SequenceSet is Ractor-safe.
@@ -1625,7 +1625,7 @@ module Net
       #
       # Returns +nil+ when the set is empty.
       #
-      # Related: #normalize!, #normalize
+      # Related: #normalize!, #normalize, #string, #to_s
       def normalized_string
         @tuples.empty? ? nil : -@tuples.map { tuple_to_str _1 }.join(",")
       end
@@ -1646,6 +1646,7 @@ module Net
       #   Net::IMAP::SequenceSet[1..5, 1024, 15, 2000].inspect
       #   #=> 'Net::IMAP::SequenceSet["1:5,15,1024,2000"]'
       #
+      # Related: #to_s, #string
       def inspect
         if empty?
           (frozen? ? "%s.empty" : "%s()") % [self.class]

--- a/test/net/imap/test_sequence_set.rb
+++ b/test/net/imap/test_sequence_set.rb
@@ -894,6 +894,55 @@ class IMAPSequenceSetTest < Test::Unit::TestCase
     "denormalized" => ['Net::IMAP::SequenceSet("2,1")',   "2,1"],
     "star"         => ['Net::IMAP::SequenceSet("*")',     "*"],
     "frozen"       => ['Net::IMAP::SequenceSet["1,3,5:*"]', [1, 3, 5..], true],
+    "at limit" => [
+      "Net::IMAP::SequenceSet(\"#{((1..1024) % 2).to_a.join(",")}\")",
+      [((1..1024) % 2).to_a],
+      false
+    ],
+    "just over limit"  => [
+      '#<Net::IMAP::SequenceSet 513 entries ' \
+      '"1,3,5,7,9,11,13,15,' \
+      '17,19,21,23,25,27,29,31,' \
+      '...(481 entries omitted)...,' \
+      '995,997,999,1001,1003,1005,1007,1009,' \
+      '1011,1013,1015,1017,1019,1021,1023,1025">',
+      ((1..1025) % 2).to_a,
+      false
+    ],
+    "denormalized at limit" => [
+      "Net::IMAP::SequenceSet(\"#{(1..512).to_a.reverse.join(",")}\")",
+      (1..512).to_a.reverse.join(","),
+      false
+    ],
+    "over limit"  => [
+      '#<Net::IMAP::SequenceSet 2046 entries ' \
+      '"1:5,7,9,11,13,15,17,19,' \
+      '21,23,25,27,29,31,33,35,' \
+      '...(2014 entries omitted)...,' \
+      '4065,4067,4069,4071,4073,4075,4077,4079,' \
+      '4081,4083,4085,4087,4089,4091,4093,4095">',
+      [((1..4096) % 2).to_a, 2, 4], # add 2 and 4 to demonstrate range: "1:5"
+      false
+    ],
+    "frozen over limit"  => [
+      '#<Net::IMAP::SequenceSet 2046 entries "' \
+      '1:5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35,' \
+      '...(2014 entries omitted)...,' \
+      '4065,4067,4069,4071,4073,4075,4077,4079,' \
+      '4081,4083,4085,4087,4089,4091,4093,4095" (frozen)>',
+      [((1..4096) % 2).to_a, 2, 4], # add 2 and 4 to demonstrate range: "1:5"
+      true
+    ],
+    "denormalized over limit" => [
+      '#<Net::IMAP::SequenceSet 1000 entries "'                  \
+      '100001,100002,100003,100004,100005,100006,100007,100008,' \
+      '100009,100010,100011,100012,100013,100014,100015,100016,' \
+      '...(968 entries omitted)...,'                            \
+      '100985,100986,100987,100988,100989,100990,100991,100992,' \
+      '100993,100994,100995,100996,100997,100998,100999,101000">',
+      (100_001..101_000).to_a.join(","),
+      false
+    ],
   )
   def test_inspect((expected, input, freeze))
     seqset = SequenceSet.new(input)


### PR DESCRIPTION
When using SequenceSet to store mailbox state for mailboxes with many millions of messages, the last thing you want to do is accidentally generate a string and output that!

So this establishes a maximum number of entries to output as an inspect string, currently 512.  Above that number, we output only a much smaller number of entries from the head and tail, currently 16 from each end.  When the sequence set has an internal denormalized string, we use regexps to grab the first and last groups of entries from that.

```ruby
Net::IMAP::SequenceSet(((1..5000) % 2).to_a).inspect
#=> #<Net::IMAP::SequenceSet 2500 entries "1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,...(2468 entries omitted)...,4969,4971,4973,4975,4977,4979,4981,4983,4985,4987,4989,4991,4993,4995,4997,4999">
```

### A note on the implementation

At first, I used a simple Regexp match anchored to `\z` to grab the tail entries from the string.  But that was shockingly slow even when the string isn't extremely large.

Next I benchmarked replacing `Regexp#match` with `String#rpartition` and that performed fine, using the same naive regexps.  `String#rindex` was also fine.  They are both slower than `Regexp#match` anchored to `\A`, but not too bad and not dramatically slower based on string size.  I found myself wishing for a `String#rscan` or `String#rsplit`.  😆

Then I benchmarked replacing `\d+` with `\d{0,10}` or `[1-9]\d{1,9}`, and those both made the regexp fast... but `Regexp.linear_time?` doesn't like nested quantifiers.  Fully expanding both the `\d+` and the `(entry){100}` keeps it fast _and_ satisfies `Regexp.linear_time?`.

But that regexp is UGLY! 🙁