### PR TITLE
✨ Allow `obj.to_sequence_set => nil` in try_convert

### DIFF
--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -444,14 +444,14 @@ module Net
         # +to_sequence_set+, calls +obj.to_sequence_set+ and returns the result.
         # Otherwise returns +nil+.
         #
-        # If +obj.to_sequence_set+ doesn't return a SequenceSet, an exception is
-        # raised.
+        # If +obj.to_sequence_set+ doesn't return a SequenceSet or +nil+, an
+        # exception is raised.
         #
         # Related: Net::IMAP::SequenceSet(), ::new, ::[]
         def try_convert(obj)
           return obj if obj.is_a?(SequenceSet)
           return nil unless obj.respond_to?(:to_sequence_set)
-          obj = obj.to_sequence_set
+          return nil unless obj = obj.to_sequence_set
           return obj if obj.is_a?(SequenceSet)
           raise DataFormatError, "invalid object returned from to_sequence_set"
         end

--- a/test/net/imap/test_sequence_set.rb
+++ b/test/net/imap/test_sequence_set.rb
@@ -294,6 +294,10 @@ class IMAPSequenceSetTest < Test::Unit::TestCase
     assert_nil SequenceSet.try_convert(Object.new)
 
     obj = Object.new
+    def obj.to_sequence_set; nil end
+    assert_nil SequenceSet.try_convert(obj)
+
+    obj = Object.new
     def obj.to_sequence_set; SequenceSet[192, 168, 1, 255] end
     assert_equal SequenceSet[192, 168, 1, 255], SequenceSet.try_convert(obj)
 


### PR DESCRIPTION
If `obj.to_sequence_set` returns `nil`, then `SequenceSet.try_convert` should return `nil`.  This is consistent with how ruby's built-in `try_convert` methods work.