### PR TITLE
🐛 Fix SearchResult#== for LHS with no modseq

### DIFF
--- a/lib/net/imap/search_result.rb
+++ b/lib/net/imap/search_result.rb
@@ -60,9 +60,8 @@ module Net
       #     [3, 5, 7] == Net::IMAP::SearchResult[3, 5, 7, modseq: 99] # => true
       #
       def ==(other)
-        (modseq ?
-         other.is_a?(self.class) && modseq == other.modseq :
-         other.is_a?(Array)) &&
+        other.is_a?(Array) &&
+          modseq == (other.modseq if other.respond_to?(:modseq)) &&
           size == other.size &&
           sort == other.sort
       end

--- a/test/net/imap/test_search_result.rb
+++ b/test/net/imap/test_search_result.rb
@@ -24,6 +24,10 @@ class SearchDataTests < Test::Unit::TestCase
     sorted   = SearchResult[2, 4, 99, 2048, modseq: 99_999]
     assert_equal unsorted, sorted
     assert_equal sorted, unsorted
+
+    nomodseq = SearchResult[2, 4, 99, 2048]
+    refute_equal sorted, nomodseq
+    refute_equal nomodseq, sorted
   end
 
   test "SearchResult[*nz_numbers] == Array[*nz_numbers]" do


### PR DESCRIPTION
If `#modseq` wasn't set, `SearchResult#==` wouldn't check rhs's modseq.