### PR TITLE
♻️ Allow `VanishedData#uids` to be `SequenceSet.empty`

### DIFF
--- a/lib/net/imap/vanished_data.rb
+++ b/lib/net/imap/vanished_data.rb
@@ -19,7 +19,7 @@ module Net
       # * +uids+ will be converted by SequenceSet.[].
       # * +earlier+ will be converted to +true+ or +false+
       def initialize(uids:, earlier:)
-        uids    = SequenceSet[uids]
+        uids    = SequenceSet[uids] unless uids.equal? SequenceSet.empty
         earlier = !!earlier
         super
       end

--- a/test/net/imap/test_vanished_data.rb
+++ b/test/net/imap/test_vanished_data.rb
@@ -29,6 +29,12 @@ class VanishedDataTest < Net::IMAP::TestCase
     assert_raise DataFormatError do VanishedData.new nil, true end
   end
 
+  test ".new allows SequenceSet.empty singleton, not other empty sets" do
+    assert_same SequenceSet.empty, VanishedData[SequenceSet.empty, true].uids
+    assert_raise DataFormatError do VanishedData[SequenceSet.new, true] end
+    assert_raise DataFormatError do VanishedData[SequenceSet.new.freeze, true] end
+  end
+
   test ".[uids: string, earlier: bool]" do
     vanished = VanishedData[uids: "1,3:5,7", earlier: true]
     assert_equal SequenceSet["1,3:5,7"], vanished.uids


### PR DESCRIPTION
This isn't a valid server response.  But it's useful as a null object.  It will be used when `Net::IMAP#uid_fetch` is called with `vanished: true` but the server returns nothing.