### PR TITLE
✨ QRESYNC: Add `vanished` keyword to `#uid_fetch`

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -2632,6 +2632,7 @@ module Net
 
     # :call-seq:
     #   uid_fetch(set, attr, changedsince: nil, partial: nil) -> array of FetchData (or UIDFetchData)
+    #   uid_fetch(set, attr, changedsince:, vanished: true, partial: nil) -> array of VanishedData and FetchData (or UIDFetchData)
     #
     # Sends a {UID FETCH command [IMAP4rev1 §6.4.8]}[https://www.rfc-editor.org/rfc/rfc3501#section-6.4.8]
     # to retrieve data associated with a message in the mailbox.
@@ -2647,6 +2648,22 @@ module Net
     #   whether a +UID+ was specified as a message data item to the +FETCH+.
     #
     # +changedsince+ (optional) behaves the same as with #fetch.
+    #
+    # +vanished+ can be used to request a list all of the message UIDs in +set+
+    # that have been expunged since +changedsince+.  Setting +vanished+ to true
+    # prepends a VanishedData object to the returned array.  If the server does
+    # not return a +VANISHED+ response, an empty VanishedData object will still
+    # be added.
+    # <em>The +QRESYNC+ capabability must be enabled.</em>
+    # {[RFC7162]}[https://rfc-editor.org/rfc/rfc7162]
+    #
+    # For example:
+    #
+    #   imap.enable("QRESYNC") # must enable before selecting the mailbox
+    #   imap.select("INBOX")
+    #   # first value in the array is VanishedData
+    #   vanished, *fetched = imap.uid_fetch(301..500, %w[flags],
+    #                                       changedsince: 12345, vanished: true)
     #
     # +partial+ is an optional range to limit the number of results returned.
     # It's useful when +set+ contains an unknown number of messages.
@@ -2679,6 +2696,9 @@ module Net
     # Related: #fetch, FetchData
     #
     # ==== Capabilities
+    #
+    # QRESYNC[https://www.rfc-editor.org/rfc/rfc7162] must be enabled in order
+    # to use the +vanished+ fetch modifier.
     #
     # The server's capabilities must include +PARTIAL+
     # {[RFC9394]}[https://rfc-editor.org/rfc/rfc9394] in order to use the
@@ -2959,9 +2979,8 @@ module Net
     #   See {[RFC7162 §3.1]}[https://www.rfc-editor.org/rfc/rfc7162.html#section-3.1].
     #
     # [+QRESYNC+ {[RFC7162]}[https://www.rfc-editor.org/rfc/rfc7162.html]]
-    #   *NOTE:* Enabling QRESYNC will replace +EXPUNGE+ with +VANISHED+, but
-    #   the extension arguments to #select, #examine, and #uid_fetch are not
-    #   supported yet.
+    #   *NOTE:* The +QRESYNC+ argument to #select and #examine is not supported
+    #   yet.
     #
     #   Adds quick resynchronization options to #select, #examine, and
     #   #uid_fetch.  +QRESYNC+ _must_ be explicitly enabled before using any of
@@ -3680,19 +3699,23 @@ module Net
       end
     end
 
-    def fetch_internal(cmd, set, attr, mod = nil, partial: nil, changedsince: nil)
-      if partial && !cmd.start_with?("UID ")
+    def fetch_internal(cmd, set, attr, mod = nil,
+                       partial: nil,
+                       changedsince: nil,
+                       vanished: false)
+      if cmd.start_with?("UID ")
+        if vanished && !changedsince
+          raise ArgumentError, "vanished must be used with changedsince"
+        end
+      elsif vanished
+        raise ArgumentError, "vanished can only be used with uid_fetch"
+      elsif partial
         raise ArgumentError, "partial can only be used with uid_fetch"
       end
       set = SequenceSet[set]
-      if partial
-        mod ||= []
-        mod << "PARTIAL" << PartialRange[partial]
-      end
-      if changedsince
-        mod ||= []
-        mod << "CHANGEDSINCE" << Integer(changedsince)
-      end
+      (mod ||= []) << "PARTIAL"      << PartialRange[partial] if partial
+      (mod ||= []) << "CHANGEDSINCE" << Integer(changedsince) if changedsince
+      (mod ||= []) << "VANISHED"                              if vanished
       case attr
       when String then
         attr = RawData.new(attr)
@@ -3704,7 +3727,7 @@ module Net
 
       args = [cmd, set, attr]
       args << mod if mod
-      send_command_returning_fetch_results(*args)
+      send_command_returning_fetch_results(*args, vanished:)
     end
 
     def store_internal(cmd, set, attr, flags, unchangedsince: nil)
@@ -3715,14 +3738,20 @@ module Net
       send_command_returning_fetch_results(cmd, *args)
     end
 
-    def send_command_returning_fetch_results(...)
+    def send_command_returning_fetch_results(*args, vanished: false)
       synchronize do
         clear_responses("FETCH")
         clear_responses("UIDFETCH")
-        send_command(...)
+        send_command(*args)
         fetches    = clear_responses("FETCH")
         uidfetches = clear_responses("UIDFETCH")
-        uidfetches.any? ? uidfetches : fetches
+        fetches    = uidfetches if uidfetches.any?
+        if vanished
+          vanished = extract_responses("VANISHED", &:earlier?).last ||
+            VanishedData[uids: SequenceSet.empty, earlier: true]
+          fetches = [vanished, *fetches].freeze
+        end
+        fetches
       end
     end
 


### PR DESCRIPTION
The `vanished` kwarg to `#uid_fetch` can be used to request a list all of the message UIDs in `set` that have been expunged since `changedsince`.  Setting `vanished` to true prepends a `VanishedData` object to the returned array.  If the server does not return a `VANISHED` response, an empty `VanishedData` object will still be added.

For example:
```ruby
  imap.enable("QRESYNC") # must enable before selecting the mailbox
  imap.select("INBOX")
  # the first value in the returned array is a VanishedData object
  vanished, *fetched = imap.uid_fetch(301..500, %w[FLAGS],
                                      changedsince: 12345,
                                      vanished: true)
```

_The `QRESYNC` capabability must be enabled._ [RFC7162](https://rfc-editor.org/rfc/rfc7162)

### Alternatives for return type

This PR chose to prepend a `VanishedData` object to the returned array.  Because it only does this when the `vanished: true` kwarg is sent, it should be fully backward compatible.  Other API choices were considered:

* Make no changes and continue returning only an array of fetch data.  This is not very user friendly.
* Return a tuple of `[vanished, fetched_array]`.  I strongly prefer a flat array of responses (`[vanished, *fetched_array]`).  IMO, it's more consistent with the original API, and just as easy to work with.
* Return a new `FetchResult` type, with a `#vanished` method.
  * This could subclass Array, like `SearchResult`.  That was done to minimize any backward compatibility issues.  Also, there's no simple way to distinguish between a modseq integer and a UID or sequence number.  But I'd prefer not to subclass Array.
  * This could delegate to the fetch data array.  This is my preferred approach.  _But_ I don't want to only enable it for `vanished`.  I'd prefer to _always_ return `FetchResult` according to a `fetch_result` config option.  And that wouldn't be backward compatible enough to enable by default for the next release.