### PR TITLE
🥅 Raise `ArgumentError` for `#fetch` with `partial`

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3684,6 +3684,9 @@ module Net
     end
 
     def fetch_internal(cmd, set, attr, mod = nil, partial: nil, changedsince: nil)
+      if partial && !cmd.start_with?("UID ")
+        raise ArgumentError, "partial can only be used with uid_fetch"
+      end
       set = SequenceSet[set]
       if partial
         mod ||= []

--- a/test/net/imap/test_imap_fetch.rb
+++ b/test/net/imap/test_imap_fetch.rb
@@ -7,6 +7,14 @@ require_relative "fake_server"
 class IMAPFetchTest < Net::IMAP::TestCase
   include Net::IMAP::FakeServer::TestHelper
 
+  test "argument errors" do
+    with_fake_server select: "inbox" do |_, imap|
+      assert_raise_with_message(ArgumentError, /\Apartial.*uid_fetch/) do
+        imap.fetch(1, "FAST", partial: 1..10)
+      end
+    end
+  end
+
   test "#fetch with FETCH responses" do
     with_fake_server select: "inbox" do |server, imap|
       server.on("FETCH") do |resp|


### PR DESCRIPTION
The `PARTIAL` fetch modifier is only valid for `UID FETCH`.  This raises an `ArgumentError`, rather than send an invalid command to the server.