### PR TITLE
✅ Add TruffleRuby to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,8 @@ jobs:
       timeout-minutes: 5 # _should_ finish in under a minute
 
     - uses: joshmfrankel/simplecov-check-action@main
-      if: matrix.os == 'ubuntu-latest' && github.event_name != 'pull_request'
+      if: ${{ matrix.os == 'ubuntu-latest' && github.event_name != 'pull_request' &&
+        !startsWith(matrix.ruby, 'truffleruby') && !startsWith(matrix.ruby, 'jruby') }}
       with:
         check_job_name: "SimpleCov - ${{ matrix.ruby }}"
         minimum_suite_coverage: 90

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,8 @@ jobs:
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         experimental: [false]
+        include:
+          - { ruby: truffleruby-head, os: ubuntu-latest,  experimental: true }
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     timeout-minutes: 15

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem "benchmark-driver", require: false
 gem "vernier", require: false, platform: :mri
 
 group :test do
-  gem "simplecov",        require: false
-  gem "simplecov-html",   require: false
-  gem "simplecov-json",   require: false
+  gem "simplecov",        require: false, platforms: %i[mri windows]
+  gem "simplecov-html",   require: false, platforms: %i[mri windows]
+  gem "simplecov-json",   require: false, platforms: %i[mri windows]
 end

--- a/test/lib/helper.rb
+++ b/test/lib/helper.rb
@@ -1,4 +1,6 @@
-unless ENV["SIMPLECOV_DISABLE"] in /\A(1|y(es)?|t(rue)?)\z/i
+if !(ENV["SIMPLECOV_DISABLE"] in /\A(1|y(es)?|t(rue)?)\z/i) &&
+    RUBY_ENGINE == "ruby" # C Ruby only
+
   require "simplecov"
 
   # Cannot use ".simplecov" file: simplecov-json triggers a circular require.

--- a/test/lib/helper.rb
+++ b/test/lib/helper.rb
@@ -73,6 +73,46 @@ class Net::IMAP::TestCase < Test::Unit::TestCase
     end
   end
 
+  def pend_if(condition, *args, &block)
+    if condition
+      pend(*args, &block)
+    else
+      block.call if block
+    end
+  end
+
+  def pend_unless(condition, *args, &block)
+    if condition
+      block.call if block
+    else
+      pend(*args, &block)
+    end
+  end
+
+  def omit_unless_cruby(msg = "test omitted for non-CRuby", &block)
+    omit_unless(RUBY_ENGINE == "ruby", msg, &block)
+  end
+
+  def omit_if_truffleruby(msg = "test omitted on TruffleRuby", &block)
+    omit_if(RUBY_ENGINE == "truffleruby", msg, &block)
+  end
+
+  def omit_if_jruby(msg = "test omitted on JRuby", &block)
+    omit_if(RUBY_ENGINE == "jruby", msg, &block)
+  end
+
+  def pend_unless_cruby(msg = "test is pending for non-CRuby", &block)
+    pend_unless(RUBY_ENGINE == "ruby", msg, &block)
+  end
+
+  def pend_if_truffleruby(msg = "test is pending on TruffleRuby", &block)
+    pend_if(RUBY_ENGINE == "truffleruby", msg, &block)
+  end
+
+  def pend_if_jruby(msg = "test is pending on JRuby", &block)
+    pend_if(RUBY_ENGINE == "jruby", msg, &block)
+  end
+
 end
 
 require_relative "profiling_helper"

--- a/test/net/imap/test_connection_state.rb
+++ b/test/net/imap/test_connection_state.rb
@@ -25,21 +25,25 @@ class ConnectionStateTest < Net::IMAP::TestCase
   end
 
   test "#deconstruct" do
-    assert_equal [:not_authenticated], NotAuthenticated[].deconstruct
-    assert_equal [:authenticated],     Authenticated[]   .deconstruct
-    assert_equal [:selected],          Selected[]        .deconstruct
-    assert_equal [:logout],            Logout[]          .deconstruct
+    pend_if_truffleruby "TruffleRuby bug overriding ::Data methods" do
+      assert_equal [:not_authenticated], NotAuthenticated[].deconstruct
+      assert_equal [:authenticated],     Authenticated[]   .deconstruct
+      assert_equal [:selected],          Selected[]        .deconstruct
+      assert_equal [:logout],            Logout[]          .deconstruct
+    end
   end
 
   test "#deconstruct_keys" do
-    assert_equal({symbol: :not_authenticated}, NotAuthenticated[].deconstruct_keys([:symbol]))
-    assert_equal({symbol: :authenticated},     Authenticated[]   .deconstruct_keys([:symbol]))
-    assert_equal({symbol: :selected},          Selected[]        .deconstruct_keys([:symbol]))
-    assert_equal({symbol: :logout},            Logout[]          .deconstruct_keys([:symbol]))
-    assert_equal({name: "not_authenticated"},  NotAuthenticated[].deconstruct_keys([:name]))
-    assert_equal({name: "authenticated"},      Authenticated[]   .deconstruct_keys([:name]))
-    assert_equal({name: "selected"},           Selected[]        .deconstruct_keys([:name]))
-    assert_equal({name: "logout"},             Logout[]          .deconstruct_keys([:name]))
+    pend_if_truffleruby "TruffleRuby bug overriding ::Data methods" do
+      assert_equal({symbol: :not_authenticated}, NotAuthenticated[].deconstruct_keys([:symbol]))
+      assert_equal({symbol: :authenticated},     Authenticated[]   .deconstruct_keys([:symbol]))
+      assert_equal({symbol: :selected},          Selected[]        .deconstruct_keys([:symbol]))
+      assert_equal({symbol: :logout},            Logout[]          .deconstruct_keys([:symbol]))
+      assert_equal({name: "not_authenticated"},  NotAuthenticated[].deconstruct_keys([:name]))
+      assert_equal({name: "authenticated"},      Authenticated[]   .deconstruct_keys([:name]))
+      assert_equal({name: "selected"},           Selected[]        .deconstruct_keys([:name]))
+      assert_equal({name: "logout"},             Logout[]          .deconstruct_keys([:name]))
+    end
   end
 
   test "#not_authenticated?" do

--- a/test/net/imap/test_data_lite.rb
+++ b/test/net/imap/test_data_lite.rb
@@ -374,7 +374,9 @@ module Net
 
       def test_subclass_override_deconstruct
         data = InheritsOverride[:foo]
-        assert_equal %i[ok foo], data.deconstruct
+        pend_if_truffleruby do
+          assert_equal %i[ok foo], data.deconstruct
+        end
       end
 
     end


### PR DESCRIPTION
No application code is updated by this PR; only the test suite.  3 tests are marked pending, but the rest are all passing.  So, with a few caveats, it looks like TruffleRuby _mostly_ works.  This doesn't mean that TruffleRuby is "officially supported", but it _does_ mean that we'll try not to merge PRs that break tests that aren't broken.

Partially replaces #454.