### PR TITLE
💥 Do not mixin `OpenSSL` and `OpenSSL::SSL` modules

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -805,10 +805,6 @@ module Net
     autoload :StringPrep,             "#{dir}/stringprep"
 
     include MonitorMixin
-    if defined?(OpenSSL::SSL)
-      include OpenSSL
-      include SSL
-    end
 
     # :call-seq:
     #   Net::IMAP::SequenceSet(set = nil) -> SequenceSet


### PR DESCRIPTION
`Net::IMAP` has mixed in `OpenSSL::SSL` since it first added TLS support.  But that isn't very helpful, and it clutters up the namespace with irrelevant constants.

I doubt anyone is actually _using_ OpenSSL constants from Net::IMAP.  I hope not.  Nevertheless, _this is a breaking change._