### PR TITLE
💥 Don't set `verify_callback` to `VerifyCallbackProc`

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3780,9 +3780,6 @@ module Net
         params = (Hash.try_convert(ssl) || {}).freeze
         context = OpenSSL::SSL::SSLContext.new
         context.set_params(params)
-        if defined?(VerifyCallbackProc)
-          context.verify_callback = VerifyCallbackProc
-        end
         context.freeze
         [params, context]
       else


### PR DESCRIPTION
The `VerifyCallbackProc` constant will no longer be automatically assigned to `context.verify_callback`.

The callback can still be set explicitly:
```ruby
# for implicit TLS
imap = Net::IMAP.new(host, ssl: {verify_callback: VerifyCallbackProc})

# for STARTTLS
imap = Net::IMAP.new(host)
imap.starttls(verify_callback: VerifyCallbackProc)
```

Prior to this commit, if `VerifyCallbackProc` were set (it could be any of `Net::IMAP::VerifyCallbackProc`, `OpenSSL::SSL::VerifyCallbackProc`, `OpenSSL::VerifyCallbackProc`, `Net::VerifyCallbackProc`, or `::VerifyCallbackProc`), it would automatically be assigned to `context.verify_callback`.  I can't find any evidence that this constant has ever been set for `net-imap`, `openssl`, or ruby.  But it _is_ also used by `net-ftp`.

This functionality existed from the beginning of `net-imap`'s TLS support, but was never documented.  I don't know the original motivation for this.  (Perhaps it's still useful for inserting a debug logger?)  But I'm guessing that past motivations for this code are less significant now.  Earlier versions of ruby's `openssl` did not have very secure defaults, but the modern `openssl` gem already handles the verify callback just fine.