### PR TITLE
 🔧 Update default config for `v0.6`

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -788,7 +788,7 @@ module Net
   # * {IMAP URLAUTH Authorization Mechanism Registry}[https://www.iana.org/assignments/urlauth-authorization-mechanism-registry/urlauth-authorization-mechanism-registry.xhtml]
   #
   class IMAP < Protocol
-    VERSION = "0.5.12"
+    VERSION = "0.6.0-dev"
 
     # Aliases for supported capabilities, to be used with the #enable command.
     ENABLE_ALIASES = {

--- a/lib/net/imap/config.rb
+++ b/lib/net/imap/config.rb
@@ -481,9 +481,9 @@ module Net
         sasl_ir: true,
         enforce_logindisabled: true,
         max_response_size: 512 << 20, # 512 MiB
-        responses_without_block: :warn,
-        parser_use_deprecated_uidplus_data: :up_to_max_size,
-        parser_max_deprecated_uidplus_data_size: 100,
+        responses_without_block: :frozen_dup,
+        parser_use_deprecated_uidplus_data: false,
+        parser_max_deprecated_uidplus_data_size: 0,
       ).freeze
 
       @global = default.new
@@ -523,6 +523,9 @@ module Net
       ).freeze
 
       version_defaults[0.7r] = Config[0.6r].dup.update(
+      ).freeze
+
+      version_defaults[0.8r] = Config[0.7r].dup.update(
       ).freeze
 
       # Safe conversions one way only:

--- a/test/net/imap/test_imap_uidplus.rb
+++ b/test/net/imap/test_imap_uidplus.rb
@@ -8,11 +8,6 @@ require_relative "fake_server"
 class IMAPUIDPlusTest < Net::IMAP::TestCase
   include Net::IMAP::FakeServer::TestHelper
 
-  def setup
-    super
-    Net::IMAP.config.parser_use_deprecated_uidplus_data = false
-  end
-
   def test_uidplus_appenduid
     with_fake_server(select: "INBOX",
                      extensions: %i[UIDPLUS]) do |server, imap|

--- a/test/net/imap/test_response_parser.rb
+++ b/test/net/imap/test_response_parser.rb
@@ -10,11 +10,6 @@ class ResponseParserTest < Net::IMAP::TestCase
   include NetIMAPTestHelpers
   extend  NetIMAPTestHelpers::TestFixtureGenerators
 
-  def setup
-    super
-    Net::IMAP.config.parser_use_deprecated_uidplus_data = false
-  end
-
   ############################################################################
   # Tests that do no more than parse an example response and assert the result
   # data has the correct values have been moved to yml test fixtures.


### PR DESCRIPTION
Breaking config changes for `v0.6` series:
* `responses_without_block` changed from `:warn` to `:frozen_dup`
* `parser_use_deprecated_uidplus_data` changed from `:up_to_max_size` to `false`
* `parser_max_deprecated_uidplus_data_size` changed from `100` to `0`

Note that `parser_use_deprecated_uidplus_data` and `parser_max_deprecated_uidplus_data_size` are both deprecated.  v0.6.0 will not use them, and will either not allow them to be changed or print a warning when they are set to anything other than the new default.  See #540.