### PR TITLE
🔍 Improve Config#pretty_print (for `Kernel::pp`)

### DIFF
--- a/test/net/imap/test_config.rb
+++ b/test/net/imap/test_config.rb
@@ -484,4 +484,33 @@ class ConfigTest < Net::IMAP::TestCase
     )
   end
 
+  test "#pretty_print" do
+    default_attrs = Config.global.to_h.map { "%s=%p" % _1 }
+    width = 80
+    output = String.new
+    PP.pp Config.global, output, width
+    assert_equal(<<~PP, output)
+      #<#{Config}.global
+        inherits from #{Config}.default
+          #{default_attrs.join("\n    ")}>
+    PP
+
+    Config.global.debug = true
+    config = Config[0.5].new(enforce_logindisabled: :when_capabilities_cached)
+    default_attrs = Config[0.5].to_h.except(:debug, :enforce_logindisabled)
+      .map { "%s=%p" % _1 }
+
+    output = String.new
+    PP.pp config, output, width
+    assert_equal(<<~PP, output)
+      #<#{Config}:0x#{config_id(config)}
+        enforce_logindisabled=:when_capabilities_cached
+        inherits from #{Config}[0.5]
+          #{default_attrs.join("\n    ")}
+          inherits from #{Config}.global
+            debug=true
+            inherits from #{Config}.default
+              (overridden)>
+    PP
+  end
 end


### PR DESCRIPTION
Viewing config objects in Irb was _much_ to messy to easily inspect: it printed every attribute for each ancestor, and most of them would simply be the Net::IMAP::Config::AttrInheritance::INHERITED const, repeated over and over.

So, just like `Config#inspect` was improved by #546, this simplifies the `pp` output to make it more useful for inspection on the console.

Unlike `Config#inspect`, `Config#pretty_print` prints _every_ config attribute, including attributes that have been defined by a named default config.