### PR TITLE
🔧 Update `Config#inherited?` for any number of args

### DIFF
--- a/lib/net/imap/config/attr_inheritance.rb
+++ b/lib/net/imap/config/attr_inheritance.rb
@@ -54,9 +54,22 @@ module Net
         # Creates a new config, which inherits from +self+.
         def new(**attrs) self.class.new(self, **attrs) end
 
+        # :call-seq:
+        #   inherited?(attr)   -> true or false
+        #   inherited?(*attrs) -> true or false
+        #   inherited?         -> true or false
+        #
         # Returns +true+ if +attr+ is inherited from #parent and not overridden
         # by this config.
-        def inherited?(attr) data[attr] == INHERITED end
+        #
+        # When multiple +attrs+ are given, returns +true+ if *all* of them are
+        # inherited, or +false+ if any of them are overriden.  When no +attrs+
+        # are given, returns +true+ if *all* attributes are inherited, or
+        # +false+ if any attribute is overriden.
+        def inherited?(*attrs)
+          attrs = data.members if attrs.empty?
+          attrs.all? { data[_1] == INHERITED }
+        end
 
         # :call-seq:
         #   reset -> self

--- a/test/net/imap/test_config.rb
+++ b/test/net/imap/test_config.rb
@@ -308,21 +308,41 @@ class ConfigTest < Net::IMAP::TestCase
     assert_equal 1, copy.open_timeout
   end
 
-  test "#inherited? and #reset(attr)" do
+  test "#inherited? and #reset" do
     base = Config.new debug: false, open_timeout: 99, idle_response_timeout: 15
     child = base.new debug: true, open_timeout: 15, idle_response_timeout: 10
+    refute child.inherited?
     refute child.inherited?(:idle_response_timeout)
+    refute child.inherited?(:idle_response_timeout, :open_timeout)
+    refute child.inherited?(:sasl_ir, :open_timeout)
+    assert child.inherited?(:sasl_ir, :max_response_size)
+    assert child.inherited?(:sasl_ir)
+
     assert_equal 10, child.reset(:idle_response_timeout)
-    assert child.inherited?(:idle_response_timeout)
     assert_equal 15, child.idle_response_timeout
+    refute child.inherited?
+    assert child.inherited?(:idle_response_timeout)
+    refute child.inherited?(:idle_response_timeout, :open_timeout)
+    refute child.inherited?(:sasl_ir, :open_timeout)
+    assert child.inherited?(:sasl_ir, :max_response_size)
+    assert child.inherited?(:sasl_ir)
     refute child.inherited?(:open_timeout)
     refute child.inherited?(:debug)
+
     child.debug = false
+    refute child.inherited?
     refute child.inherited?(:debug)
+
     assert_equal false, child.reset(:debug)
+    refute child.inherited?
     assert child.inherited?(:debug)
     assert_equal false, child.debug
+
     assert_equal nil, child.reset(:debug)
+
+    assert_same child, child.reset
+    assert child.inherited?
+    assert child.inherited?(:debug, :idle_response_timeout, :open_timeout)
   end
 
   test "#reset all attributes" do


### PR DESCRIPTION
When multiple attrs are given, returns `true` if *all* of them are inherited (or `false` if any is overriden).  When no attrs are given, returns `true` if *all* attributes are inherited (or `false` if any is overriden).