### PR TITLE
⚡️ Don't memoize `SequenceSet#string` on normalized sets

### DIFF
--- a/benchmarks/sequence_set-new.yml
+++ b/benchmarks/sequence_set-new.yml
@@ -9,8 +9,17 @@ prelude: |
   N_RAND = 100
 
   def rand_nums(n, min: 1, max: (n * 1.25).to_i) = Array.new(n) { rand(1..max) }
-  def rand_entries(...) = SeqSet[rand_nums(...)].elements.shuffle
-  def rand_string(...)  = SeqSet[rand_nums(...)].string.split(?,).shuffle.join(?,)
+  def rand_entries(...) = SeqSet[rand_nums(...)].elements
+  def rand_string(...)  = SeqSet[rand_nums(...)].string
+
+  def shuffle(inputs)
+    inputs.map! do
+      case _1
+      in Array  => elements then elements.shuffle
+      in String => string   then string.split(?,).shuffle.join(?,)
+      end
+    end
+  end
 
   def build_string_inputs(n, n_rand, **)
     Array.new(n_rand) { rand_string(n, **) }
@@ -35,51 +44,83 @@ prelude: |
 
 benchmark:
 
-  - name:    n=10 ints
+  - name:    n=     10   ints   (sorted)
     prelude: inputs = build_int_inputs 10, N_RAND
     script:  SeqSet[inputs[i = (i+1) % N_RAND]]
 
-  - name:    n=10 string
+  - name:    n=     10 string   (sorted)
     prelude: inputs = build_string_inputs 10, N_RAND
     script:  SeqSet[inputs[i = (i+1) % N_RAND]]
 
-  - name:    n=100 ints
+  - name:    n=     10   ints (shuffled)
+    prelude: inputs = build_int_inputs 10, N_RAND and shuffle inputs
+    script:  SeqSet[inputs[i = (i+1) % N_RAND]]
+
+  - name:    n=     10 string (shuffled)
+    prelude: inputs = build_string_inputs 10, N_RAND and shuffle inputs
+    script:  SeqSet[inputs[i = (i+1) % N_RAND]]
+
+  - name:    n=    100   ints   (sorted)
     prelude: inputs = build_int_inputs 100, N_RAND
     script:  SeqSet[inputs[i = (i+1) % N_RAND]]
 
-  - name:    n=100 string
+  - name:    n=    100 string   (sorted)
     prelude: inputs = build_string_inputs 100, N_RAND
     script:  SeqSet[inputs[i = (i+1) % N_RAND]]
 
-  - name:    n=1000 ints
+  - name:    n=    100   ints (shuffled)
+    prelude: inputs = build_int_inputs 100, N_RAND and shuffle inputs
+    script:  SeqSet[inputs[i = (i+1) % N_RAND]]
+
+  - name:    n=    100 string (shuffled)
+    prelude: inputs = build_string_inputs 100, N_RAND and shuffle inputs
+    script:  SeqSet[inputs[i = (i+1) % N_RAND]]
+
+  - name:    n=  1,000   ints   (sorted)
     prelude: inputs = build_int_inputs 1000, N_RAND
     script:  SeqSet[inputs[i = (i+1) % N_RAND]]
 
-  - name:    n=1000 string
+  - name:    n=  1,000 string   (sorted)
     prelude: inputs = build_string_inputs 1000, N_RAND
     script:  SeqSet[inputs[i = (i+1) % N_RAND]]
 
-  - name:    n=10,000 ints
+  - name:    n=  1,000   ints (shuffled)
+    prelude: inputs = build_int_inputs 1000, N_RAND and shuffle inputs
+    script:  SeqSet[inputs[i = (i+1) % N_RAND]]
+
+  - name:    n=  1,000 string (shuffled)
+    prelude: inputs = build_string_inputs 1000, N_RAND and shuffle inputs
+    script:  SeqSet[inputs[i = (i+1) % N_RAND]]
+
+  - name:    n= 10,000   ints   (sorted)
     prelude: inputs = build_int_inputs 10_000, N_RAND
     script:  SeqSet[inputs[i = (i+1) % N_RAND]]
 
-  - name:    n=10,000 string
+  - name:    n= 10,000 string   (sorted)
     prelude: inputs = build_string_inputs 10_000, N_RAND
     script:  SeqSet[inputs[i = (i+1) % N_RAND]]
 
-  - name:    n=100,000 ints
+  - name:    n= 10,000   ints (shuffled)
+    prelude: inputs = build_int_inputs 10_000, N_RAND and shuffle inputs
+    script:  SeqSet[inputs[i = (i+1) % N_RAND]]
+
+  - name:    n= 10,000 string (shuffled)
+    prelude: inputs = build_string_inputs 10_000, N_RAND and shuffle inputs
+    script:  SeqSet[inputs[i = (i+1) % N_RAND]]
+
+  - name:    n=100,000   ints   (sorted)
     prelude: inputs = build_int_inputs 100_000, N_RAND / 2
     script:  SeqSet[inputs[i = (i+1) % N_RAND]]
 
-  - name:    n=100,000 string
+  - name:    n=100,000 string   (sorted)
     prelude: inputs = build_string_inputs 100_000, N_RAND / 2
     script:  SeqSet[inputs[i = (i+1) % (N_RAND / 2)]]
 
-#   - name:    n=1,000,000 ints
+#   - name:    n=1,000,000   ints
 #     prelude: inputs = build_int_inputs 1_000_000
 #     script:  SeqSet[inputs[i = (i+1) % N_RAND]]
 
-#   - name:    n=10,000,000 ints
+#   - name:    n=10,000,000   ints
 #     prelude: inputs = build_int_inputs 10_000_000
 #     script:  SeqSet[inputs[i = (i+1) % N_RAND]]
 
@@ -88,6 +129,10 @@ contexts:
     prelude: |
       $LOAD_PATH.unshift "./lib"
       $allowed_to_profile = true # only profile local code
+    require: false
+  - name: v0.5.12
+    gems:
+      net-imap: 0.5.12
     require: false
   - name: v0.5.9
     gems:

--- a/benchmarks/sequence_set-normalize.yml
+++ b/benchmarks/sequence_set-normalize.yml
@@ -99,6 +99,10 @@ benchmark:
 
 contexts:
   # n.b: can't use anything newer as the baseline: it's over 500x faster!
+  - name: v0.5.12
+    gems:
+      net-imap: 0.5.12
+    require: false
   - name: v0.5.9
     gems:
       net-imap: 0.5.9


### PR DESCRIPTION
Not duplicating the data in `@tuples` and `@string` saves memory.  For large sequence sets, this memory savings can be substantial.

But this is a tradeoff: it saves time when the string is not used, but uses more time when the string is used more than once.  Working with set operations can create many ephemeral sets, so avoiding unintentional string generation can save a lot of time.

Also, by quickly scanning the entries after a string is parsed, we can bypass the merge algorithm for normalized strings.  But this does cause a small penalty for non-normalized strings.

**Please note:**  It _is still possible_ to create a memoized string on a normalized SequenceSet with `#append`.  For example: create a monotonically sorted SequenceSet with non-normal final entry, then call `#append` with an adjacently following entry.  `#append` coalesces the final entry and converts it into normal form, but doesn't check whether the _preceding entries_ of the SequenceSet are normalized.

### Benchmarks
#### Results from benchmarks/sequence_set-normalize.yml

There is still room for improvement here, because `#normalize` generates the normalized string for comparison rather than just reparse the string.

```
                           normal
               local:     19938.9 i/s
             v0.5.12:      2988.7 i/s - 6.67x  slower

                frozen and normal
               local:  17011413.5 i/s
             v0.5.12:      3574.4 i/s - 4759.30x  slower

                         unsorted
               local:     19434.9 i/s
             v0.5.12:      2957.5 i/s - 6.57x  slower

                         abnormal
               local:     19835.9 i/s
             v0.5.12:      3037.1 i/s - 6.53x  slower
```

#### Results from benchmarks/sequence_set-new.yml

Note that this benchmark doesn't use `SequenceSet::new`; it uses `SequenceSet::[]`, which _freezes_ the result.  In this case, the benchmark result differences are mostly driven by improved performance of `#freeze`.  

```
             n=     10   ints   (sorted)
                      local:    118753.9 i/s
                    v0.5.12:     85411.4 i/s - 1.39x  slower

             n=     10 string   (sorted)
                    v0.5.12:    123087.2 i/s
                      local:    122746.3 i/s - 1.00x  slower

             n=     10   ints (shuffled)
                      local:    105919.2 i/s
                    v0.5.12:     79294.5 i/s - 1.34x  slower

             n=     10 string (shuffled)
                    v0.5.12:    114826.6 i/s
                      local:    108086.2 i/s - 1.06x  slower

             n=    100   ints   (sorted)
                      local:     16418.4 i/s
                    v0.5.12:     11864.2 i/s - 1.38x  slower

             n=    100 string   (sorted)
                      local:     18161.7 i/s
                    v0.5.12:     15219.3 i/s - 1.19x  slower

             n=    100   ints (shuffled)
                      local:     16640.1 i/s
                    v0.5.12:     11815.8 i/s - 1.41x  slower

             n=    100 string (shuffled)
                    v0.5.12:     14755.8 i/s
                      local:     14512.8 i/s - 1.02x  slower

             n=  1,000   ints   (sorted)
                      local:      1722.2 i/s
                    v0.5.12:      1229.0 i/s - 1.40x  slower

             n=  1,000 string   (sorted)
                      local:      1862.1 i/s
                    v0.5.12:      1543.2 i/s - 1.21x  slower

             n=  1,000   ints (shuffled)
                      local:      1684.9 i/s
                    v0.5.12:      1252.3 i/s - 1.35x  slower

             n=  1,000 string (shuffled)
                    v0.5.12:      1467.3 i/s
                      local:      1424.6 i/s - 1.03x  slower

             n= 10,000   ints   (sorted)
                      local:       158.1 i/s
                    v0.5.12:       127.9 i/s - 1.24x  slower

             n= 10,000 string   (sorted)
                      local:       187.7 i/s
                    v0.5.12:       143.4 i/s - 1.31x  slower

             n= 10,000   ints (shuffled)
                      local:       145.8 i/s
                    v0.5.12:       114.5 i/s - 1.27x  slower

             n= 10,000 string (shuffled)
                    v0.5.12:       138.4 i/s
                      local:       136.9 i/s - 1.01x  slower

             n=100,000   ints   (sorted)
                      local:        14.9 i/s
                    v0.5.12:        10.6 i/s - 1.40x  slower

             n=100,000 string   (sorted)
                      local:        19.2 i/s
                    v0.5.12:        14.0 i/s - 1.37x  slower
```

The new code is ~1-6% slower for shuffled strings, but ~30-40% faster for sorted sets (note that unsorted non-string inputs create a sorted set).