### PR TITLE
📦 Update `release.yml` for `github_actions` label

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -20,6 +20,7 @@ changelog:
           - "tests-only"
           - "dependencies"
           - "workflows"
+          - "github_actions"
         authors:
           - "dependabot"
     - title: Miscellaneous


### PR DESCRIPTION
I'd already classified the "workflows" label as "Miscellaneous", but "github_actions" is the label that's actually being used.