### PR TITLE
🔒 Add `when_capabilities_cached` option for `Config#sasl_ir`

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -1518,6 +1518,7 @@ module Net
     # completes.  If the TaggedResponse to #authenticate includes updated
     # capabilities, they will be cached.
     def authenticate(*args, sasl_ir: config.sasl_ir, **props, &callback)
+      sasl_ir = may_depend_on_capabilities_cached?(sasl_ir)
       sasl_adapter.authenticate(*args, sasl_ir: sasl_ir, **props, &callback)
         .tap do state_authenticated! _1 end
     end

--- a/lib/net/imap/config.rb
+++ b/lib/net/imap/config.rb
@@ -234,12 +234,25 @@ module Net
       #   Do not use +SASL-IR+, even when it is supported by the server and the
       #   mechanism.
       #
+      # [+:when_capabilities_cached+]
+      #   Use +SASL-IR+ when Net::IMAP#capabilities_cached? is +true+ and it is
+      #   supported by the server and the mechanism, but do not send a
+      #   +CAPABILITY+ command to discover the server capabilities.
+      #
+      #   <em>(+:when_capabilities_cached+ option was added by +v0.6.0+)</em>
+      #
       # [+true+ <em>(default since +v0.4+)</em>]
       #   Use +SASL-IR+ when it is supported by the server and the mechanism.
-      attr_accessor :sasl_ir, type: :boolean, defaults: {
+      attr_accessor :sasl_ir, type: Enum[
+        false, :when_capabilities_cached, true
+      ], defaults: {
         0.0r => false,
         0.4r => true,
       }
+
+      # :stopdoc:
+      alias sasl_ir? sasl_ir
+      # :startdoc:
 
       # Controls the behavior of Net::IMAP#login when the +LOGINDISABLED+
       # capability is present.  When enforced, Net::IMAP will raise a


### PR DESCRIPTION
This is consistent with the approach used by `Config#enforce_logindisabled`.

The default config (`true`) will not change.

See https://github.com/ruby/net-imap/issues/278#issuecomment-2500552259