### PR TITLE
⚡️ Faster `SequenceSet#full?`

### DIFF
--- a/benchmarks/sequence_set-full.yml
+++ b/benchmarks/sequence_set-full.yml
@@ -1,0 +1,45 @@
+---
+prelude: |
+  require "net/imap"
+
+  INPUT_COUNT = Integer ENV.fetch("BENCHMARK_INPUT_COUNT", 1000)
+  MAX_INPUT   = Integer ENV.fetch("BENCHMARK_MAX_INPUT",   1400)
+  WARMUP_RUNS = Integer ENV.fetch("BENCHMARK_WARMUP_RUNS",  200)
+
+  SETS = Array.new(1000) {
+    Net::IMAP::SequenceSet[Array.new(INPUT_COUNT) { rand(1..MAX_INPUT) }]
+  }
+
+  # warmup (esp. for JIT)
+  200.times do
+    Net::IMAP::SequenceSet.full.full?
+    Net::IMAP::SequenceSet.empty.full?
+    SETS.sample.full?
+  end
+
+benchmark:
+  - name: empty
+    prelude: set = Net::IMAP::SequenceSet.empty
+    script: set.full?
+  - name: full
+    prelude: set = Net::IMAP::SequenceSet.full
+    script: set.full?
+  - name: rand
+    script: SETS.sample.full?
+
+contexts:
+  # - name: local
+  #   prelude: |
+  #     $LOAD_PATH.unshift "./lib"
+  - name: v0.5.12
+    gems:
+      net-imap: 0.5.12
+    require: false
+  - name: 0.6.0.dev.g497b6c7c7
+    gems:
+      net-imap: 0.6.0.dev.g497b6c7c7
+    require: false
+  - name: 0.6.0.dev.gfc4e3a782.seqset.full
+    gems:
+      net-imap: 0.6.0.dev.gfc4e3a782.seqset.full
+    require: false

--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -420,6 +420,9 @@ module Net
       STARS     = [:*, ?*, -1].freeze
       private_constant :STARS
 
+      FULL_SET_DATA = [[1, STAR_INT].freeze].freeze
+      private_constant :FULL_SET_DATA
+
       INSPECT_MAX_LEN      = 512
       INSPECT_TRUNCATE_LEN =  16
       private_constant :INSPECT_MAX_LEN, :INSPECT_TRUNCATE_LEN
@@ -825,7 +828,7 @@ module Net
       def empty?; runs.empty? end
 
       # Returns true if the set contains every possible element.
-      def full?; minmaxes == [[1, STAR_INT]] end
+      def full?; set_data == FULL_SET_DATA end
 
       # :call-seq:
       #   self + other -> sequence set


### PR DESCRIPTION
This both abstracts the comparison, making it simpler to replace with another data structure, and improves performance a little bit (by not allocating a new comparison object each time).

```
Comparison:
                            empty
 using FULL_SET_DATA:  18144272.7 i/s
             v0.5.12:   7299127.9 i/s - 2.49x  slower
0.6.0.dev.g497b6c7c7:   6887110.4 i/s - 2.63x  slower

                             full
 using FULL_SET_DATA:   1842405.4 i/s
             v0.5.12:   1733075.9 i/s - 1.06x  slower
0.6.0.dev.g497b6c7c7:   1624744.9 i/s - 1.13x  slower

                      random data
 using FULL_SET_DATA:   7554952.4 i/s
0.6.0.dev.g497b6c7c7:   4376702.4 i/s - 1.73x  slower
             v0.5.12:   4361266.1 i/s - 1.73x  slower
```