### PR TITLE
⚡️ Slightly faster `SequenceSet#xor`

### DIFF
--- a/benchmarks/sequence_set-xor.yml
+++ b/benchmarks/sequence_set-xor.yml
@@ -23,6 +23,12 @@ prelude: |
       def xor2(other) remain_frozen dup.xor2! other end
       def xor3(other) remain_frozen dup.xor3! other end
 
+      unless instance_methods.include?(:xor!)
+        def xor!(other)
+          replace(self ^ other)
+        end
+      end
+
       # (L | R) - (L & R)
       def xor1!(other)
         modifying!
@@ -69,8 +75,8 @@ prelude: |
   end
 
 benchmark:
-  "      L ^ R":             l, r = sets; l ^ r
-  "      L.xor! R":          l, r = sets; l.xor! r
+  "builtin:          L ^ R": l, r = sets; l ^ r
+  "builtin:       L.xor! R": l, r = sets; l.xor! r
   "      (L | R) - (R & L)": l, r = sets; (l | r) - (r & l)
   "0.5.8 (L | R) - (R & L)": l, r = sets; l.xor0  r
   "dup1  (L | R) - (R & L)": l, r = sets; l.xor1  r

--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -1778,10 +1778,10 @@ module Net
       #
       # Related: #xor, #merge, #subtract
       def xor!(other)
-        modifying!
-        other = IMAP::SequenceSet(other)
-        both = self & other
-        merge(other).subtract(both)
+        modifying! # short-circuit before processing input
+        other = SequenceSet.new(other)
+        copy  = dup
+        merge(other).subtract(other.subtract(copy.complement!))
       end
 
       # Returns whether #string is fully normalized: entries have been sorted,


### PR DESCRIPTION
The results are highly dependant on data, YJIT, etc... but in my tests this implementation seems to _consistently_ run faster.

```
Comparison:
             builtin: L ^ R
                  local:       967.0 i/s
before #567 (559b86a8b):       917.5 i/s - 1.05x  slower
before #562 (a228ee1d5):       901.2 i/s - 1.07x  slower
                v0.5.12:       840.0 i/s - 1.15x  slower
                 v0.5.0:       830.7 i/s - 1.16x  slower
                v0.4.21:       797.0 i/s - 1.21x  slower
                 v0.5.9:       790.4 i/s - 1.22x  slower

             builtin: L.xor! R
                  local:       960.9 i/s
before #567 (559b86a8b):       954.3 i/s - 1.01x  slower
before #562 (a228ee1d5):       940.0 i/s - 1.02x  slower
                v0.5.12:       796.4 i/s - 1.21x  slower
                 v0.5.0:       633.9 i/s - 1.52x  slower
                v0.4.21:       620.1 i/s - 1.55x  slower
                 v0.5.9:       619.0 i/s - 1.55x  slower
```

When I first wrote this code, the `master` branch was consistently 1.3x-1.5x slower.  The speedup is much less now, so other implementation details are probably more important.  Specifically, most of the speedup probably came from the change in #550, which coerced `rhs` to a SequenceSet before using it.

When the internal set data implementation is changed (see https://github.com/ruby/net-imap/issues/484), this and other operations should be re-evaluated.  I suspect an iterative "merge" may be the fastest overall approach, but that code is more complex than simply relying on the core add/subtract/complement methods with simple boolean algebra.