### PR TITLE
🏷️ Support `mod-sequence-valzer` (RFC4551) in `NumValidator`

### DIFF
--- a/lib/net/imap/data_encoding.rb
+++ b/lib/net/imap/data_encoding.rb
@@ -182,6 +182,12 @@ module Net
         1 <= num && num < 0xffff_ffff_ffff_ffff
       end
 
+      # Check if argument is a valid 'mod-sequence-valzer' according to RFC 4551
+      #     mod-sequence-valzer = "0" / mod-sequence-value
+      def valid_mod_sequence_valzer?(num)
+        0 <= num && num < 0xffff_ffff_ffff_ffff
+      end
+
       # Ensure argument is 'number' or raise DataFormatError
       def ensure_number(num)
         return num if valid_number?(num)
@@ -201,6 +207,13 @@ module Net
         return num if valid_mod_sequence_value?(num)
         raise DataFormatError,
           "mod-sequence-value must be non-zero unsigned 64-bit integer: #{num}"
+      end
+
+      # Ensure argument is 'mod-sequence-valzer' or raise DataFormatError
+      def ensure_mod_sequence_valzer(num)
+        return num if valid_mod_sequence_valzer?(num)
+        raise DataFormatError,
+          "mod-sequence-valzer must be unsigned 64-bit integer: #{num}"
       end
 
     end

--- a/test/net/imap/test_num_validator.rb
+++ b/test/net/imap/test_num_validator.rb
@@ -9,13 +9,13 @@ class NumValidatorTest < Net::IMAP::TestCase
   TEST_VALUES = {
     -1          => %i[invalid],
 
-    0           => %i[number                             ],
-    1           => %i[number nz-number mod-sequence-value],
-    0x0000_ffff => %i[number nz-number mod-sequence-value],
-    0xffff_ffff => %i[number nz-number mod-sequence-value],
-    0x0000_0001_0000_0000 => %i[       mod-sequence-value],
-    0x0000_ffff_ffff_ffff => %i[       mod-sequence-value],
-    0xffff_ffff_ffff_fffe => %i[       mod-sequence-value],
+    0           => %i[number                              mod-sequence-valzer],
+    1           => %i[number nz-number mod-sequence-value mod-sequence-valzer],
+    0x0000_ffff => %i[number nz-number mod-sequence-value mod-sequence-valzer],
+    0xffff_ffff => %i[number nz-number mod-sequence-value mod-sequence-valzer],
+    0x0000_0001_0000_0000 => %i[       mod-sequence-value mod-sequence-valzer],
+    0x0000_ffff_ffff_ffff => %i[       mod-sequence-value mod-sequence-valzer],
+    0xffff_ffff_ffff_fffe => %i[       mod-sequence-value mod-sequence-valzer],
 
     0xffff_ffff_ffff_ffff => %i[invalid],
   }
@@ -43,6 +43,12 @@ class NumValidatorTest < Net::IMAP::TestCase
   using_test_values_for :"mod-sequence-value" do |label, value, valid|
     test "#valid_mod_sequence_value?(%s) => %p" % [label, valid] do
       assert_equal valid, NumValidator.valid_mod_sequence_value?(value)
+    end
+  end
+
+  using_test_values_for :"mod-sequence-valzer" do |label, value, valid|
+    test "#valid_mod_sequence_valzer?(%s) => %p" % [label, valid] do
+      assert_equal valid, NumValidator.valid_mod_sequence_valzer?(value)
     end
   end
 
@@ -81,6 +87,17 @@ class NumValidatorTest < Net::IMAP::TestCase
         assert_equal value, NumValidator.ensure_mod_sequence_value(value)
       else
         assert_format_error do NumValidator.ensure_mod_sequence_value(value) end
+      end
+    end
+  end
+
+  using_test_values_for :"mod-sequence-valzer" do |label, value, valid|
+    result = valid ? "=> #{label}" : "raises DataFormatError"
+    test "#ensure_mod_sequence_valzer(%s) %s" % [label, result] do
+      if valid
+        assert_equal value, NumValidator.ensure_mod_sequence_valzer(value)
+      else
+        assert_format_error do NumValidator.ensure_mod_sequence_valzer(value) end
       end
     end
   end


### PR DESCRIPTION
Matching how `mod-sequence-value` is handled, this uses the less strict version from RFC4551, not the stricter version from RFC7162.

This is not _(currently)_ used by any code inside Net::IMAP; it's made available to be used by client code.

A simple test suite was also added, and rdoc was updated.