### PR TITLE
🏷️ Add `NumValidator.coerce_{type}` methods

### DIFF
--- a/lib/net/imap/data_encoding.rb
+++ b/lib/net/imap/data_encoding.rb
@@ -155,6 +155,7 @@ module Net
 
     # Common validators of number and nz_number types
     module NumValidator # :nodoc
+      NUMBER_RE = /\A(?:0|[1-9]\d*)\z/
       module_function
 
       # Check if argument is a valid 'number' according to RFC 3501
@@ -214,6 +215,46 @@ module Net
         return num if valid_mod_sequence_valzer?(num)
         raise DataFormatError,
           "mod-sequence-valzer must be unsigned 64-bit integer: #{num}"
+      end
+
+      # Like #ensure_number, but usable with numeric String input.
+      def coerce_number(num)
+        case num
+        when Integer   then ensure_number num
+        when NUMBER_RE then ensure_number Integer num
+        else
+          raise DataFormatError, "%p is not a valid number" % [num]
+        end
+      end
+
+      # Like #ensure_nz_number, but usable with numeric String input.
+      def coerce_nz_number(num)
+        case num
+        when Integer   then ensure_nz_number num
+        when NUMBER_RE then ensure_nz_number Integer num
+        else
+          raise DataFormatError, "%p is not a valid nz-number" % [num]
+        end
+      end
+
+      # Like #ensure_mod_sequence_value, but usable with numeric String input.
+      def coerce_mod_sequence_value(num)
+        case num
+        when Integer   then ensure_mod_sequence_value num
+        when NUMBER_RE then ensure_mod_sequence_value Integer num
+        else
+          raise DataFormatError, "%p is not a valid mod-sequence-value" % [num]
+        end
+      end
+
+      # Like #ensure_mod_sequence_valzer, but usable with numeric String input.
+      def coerce_mod_sequence_valzer(num)
+        case num
+        when Integer   then ensure_mod_sequence_valzer num
+        when NUMBER_RE then ensure_mod_sequence_valzer Integer num
+        else
+          raise DataFormatError, "%p is not a valid mod-sequence-valzer" % [num]
+        end
       end
 
     end

--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -1921,14 +1921,7 @@ module Net
       end
 
       def import_num(obj) STARS.include?(obj) ? STAR_INT : nz_number(obj) end
-
-      def nz_number(num)
-        String === num && !/\A[1-9]\d*\z/.match?(num) and
-          raise DataFormatError, "%p is not a valid nz-number" % [num]
-        NumValidator.ensure_nz_number Integer num
-      rescue TypeError # To catch errors from Integer()
-        raise DataFormatError, $!.message
-      end
+      def nz_number(num) = NumValidator.coerce_nz_number(num)
 
       ######################################################################{{{2
       # Export methods

--- a/test/net/imap/test_num_validator.rb
+++ b/test/net/imap/test_num_validator.rb
@@ -102,4 +102,56 @@ class NumValidatorTest < Net::IMAP::TestCase
     end
   end
 
+  using_test_values_for :number do |label, value, valid|
+    result = valid ? "=> #{value}" : "raises DataFormatError"
+    [value, value.to_s].each do |input|
+      test "#coerce_number(%p) %s" % [input, result] do
+        if valid
+          assert_equal value, NumValidator.coerce_number(input)
+        else
+          assert_format_error do NumValidator.coerce_number(input) end
+        end
+      end
+    end
+  end
+
+  using_test_values_for :"nz-number" do |label, value, valid|
+    result = valid ? "=> #{value}" : "raises DataFormatError"
+    [value, value.to_s].each do |input|
+      test "#coerce_nz_number(%p) %s" % [input, result] do
+        if valid
+          assert_equal value, NumValidator.coerce_nz_number(input)
+        else
+          assert_format_error do NumValidator.coerce_nz_number(input) end
+        end
+      end
+    end
+  end
+
+  using_test_values_for :"mod-sequence-value" do |label, value, valid|
+    result = valid ? "=> #{value}" : "raises DataFormatError"
+    [value, value.to_s].each do |input|
+      test "#coerce_mod_sequence_value(%p) %s" % [input, result] do
+        if valid
+          assert_equal value, NumValidator.coerce_mod_sequence_value(input)
+        else
+          assert_format_error do NumValidator.coerce_mod_sequence_value(input) end
+        end
+      end
+    end
+  end
+
+  using_test_values_for :"mod-sequence-valzer" do |label, value, valid|
+    result = valid ? "=> #{value}" : "raises DataFormatError"
+    [value, value.to_s].each do |input|
+      test "#coerce_mod_sequence_valzer(%p) %s" % [input, result] do
+        if valid
+          assert_equal value, NumValidator.coerce_mod_sequence_valzer(input)
+        else
+          assert_format_error do NumValidator.coerce_mod_sequence_valzer(input) end
+        end
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
A `#coerce_{type}` method is added to NumValidator for every corresponding `#ensure_{type}` method, but usable with numeric string input.  A simple Regexp is used to ensure they are in the simple decimal format, as allowed by the IMAP grammar.  Other string formats (e.g: `0xffff` or `0001`) are not legal in IMAP grammar and are _intentionally_ unsupported here.