### PR TITLE
🔥 Delete deprecated `MessageSet`

### DIFF
--- a/lib/net/imap/command_data.rb
+++ b/lib/net/imap/command_data.rb
@@ -184,19 +184,6 @@ module Net
       end
     end
 
-    # *DEPRECATED*.  Replaced by SequenceSet.
-    class MessageSet < CommandData # :nodoc:
-      def initialize(data:)
-        data = SequenceSet[data]
-        super
-        warn("DEPRECATED: #{MessageSet} should be replaced with #{SequenceSet}.",
-             uplevel: 1, category: :deprecated)
-      end
-
-      def send_data(imap, tag) data.send_data imap, tag end
-      def validate;            data.validate            end
-    end
-
     class ClientID < CommandData # :nodoc:
 
       def send_data(imap, tag)

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -600,29 +600,6 @@ class IMAPTest < Net::IMAP::TestCase
       end
       assert_empty server.commands
 
-      # MessageSet numbers may be non-zero uint32
-      stderr = EnvUtil.verbose_warning do
-        imap.__send__(:send_command, "TEST", Net::IMAP::MessageSet.new(-1))
-        assert_equal "*", server.commands.pop.args
-
-        assert_raise(Net::IMAP::DataFormatError) do
-          imap.__send__(:send_command, "TEST", Net::IMAP::MessageSet.new(0))
-        end
-        assert_empty server.commands
-
-        imap.__send__(:send_command, "TEST", Net::IMAP::MessageSet.new(1))
-        assert_equal "1", server.commands.pop.args
-
-        imap.__send__(:send_command, "TEST", Net::IMAP::MessageSet.new(2**32 - 1))
-        assert_equal (2**32 - 1).to_s, server.commands.pop.args
-
-        assert_raise(Net::IMAP::DataFormatError) do
-          imap.__send__(:send_command, "TEST", Net::IMAP::MessageSet.new(2**32))
-        end
-        assert_empty server.commands
-      end
-      assert_match(/DEPRECATED:.+MessageSet.+replace.+with.+SequenceSet/, stderr)
-
       # SequenceSet numbers may be non-zero uint3, and -1 is translated to *
       imap.__send__(:send_command, "TEST", Net::IMAP::SequenceSet.new(-1))
       assert_equal "*", server.commands.pop.args


### PR DESCRIPTION
This has been deprecated since v0.5.0 (see #282).  As far as I can tell, there are no public usages of it on github.  Any code that _does_ use it can trivially replace it with `SequenceSet`.  It's time for it to go.