### PR TITLE
🔖 Release 0.6

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -788,7 +788,7 @@ module Net
   # * {IMAP URLAUTH Authorization Mechanism Registry}[https://www.iana.org/assignments/urlauth-authorization-mechanism-registry/urlauth-authorization-mechanism-registry.xhtml]
   #
   class IMAP < Protocol
-    VERSION = "0.6.0-dev"
+    VERSION = "0.6.0"
 
     # Aliases for supported capabilities, to be used with the #enable command.
     ENABLE_ALIASES = {


### PR DESCRIPTION
My plan is to release v0.6.0 on Sunday.

There are two remaining blockers:
* [x] #540
  This requires only a few tweaks to the current PR, so the _config options_ can have their own deprecation period.  They'll raise a warning in the parser when they would've triggered.  This is related to deprecation and deletion, so it really is a blocker for v0.6.0.
* [ ] #484
  This won't be _done_, but I did want to at least move off of the array of arrays approach, which uses 6x more memory than necessary!  My current run length encoded branch is significantly faster on _most_ benchmarks... except for operations that index into it as if it were an array of numbers: `#at`, `#slice`/`#[]`, `#find_index`, etc.  These are all already `O(n)` in the _current_ implementation... but dealing with the encoded runs slows them down even more (at least in the current implementation).  And, for how I use `SequenceSet`, I really need these operations operations to be significantly _faster_ than they already are.

  If I'm not happy with my (simple) "chunked RLE" sequence set implementation by Sunday, we'll just ship what we already have.

I did also hope to finish the QRESYNC code, and I'll probably even be working on that this week and next for my employer.  But I don't think I'll have time to make the `net-imap` parts of that work release ready.  Everything else can wait for v0.6.1 or v0.7.0.