### PR TITLE
📦 Use latest rubygems/bundler to release gem

### DIFF
--- a/.github/workflows/push_gem.yml
+++ b/.github/workflows/push_gem.yml
@@ -35,6 +35,8 @@ jobs:
         with:
           bundler-cache: true
           ruby-version: ruby
+          rubygems: latest
+          bundler: latest
 
       # Release
       - name: Publish to RubyGems


### PR DESCRIPTION
There was an issue when trying to publish v0.6.0, related to digest, with the following error:

https://github.com/ruby/net-imap/actions/runs/20212203897/job/58019727242
```
$ bundle exec rake release
bundler: failed to load command: rake (/home/runner/work/net-imap/net-imap/vendor/bundle/ruby/3.4.0/bin/rake)
/opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/bundler/runtime.rb:317:in 'Bundler::Runtime#check_for_activated_spec!': You have already activated digest 3.2.0, but your Gemfile requires digest 3.2.1. Since digest is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports digest as a default gem. (Gem::LoadError)
```

So, hopefully, upgrading to the latest rubygems and bundler will fix it.