### PR TITLE
📦 Drop digest from Gemfile (workaround for #576)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "digest"
+# gem "digest"  # not included as a workaround for #576
 gem "strscan"
 gem "base64"
 gem "psych", ">= 5.3.0" # 5.2.5 for Data serialization, 5.3.0 for TruffleRuby


### PR DESCRIPTION
`digest` 3.2.1 was released since the last `net-imap` release.  And apparently `bundle exec rake release` activates `digest` _before_ loading the Gemfile.  But, since `digest` is a default gem anyway, not including it in the Gemfile should be okay, I think.

See the errors here:
* 1st attempt: https://github.com/ruby/net-imap/actions/runs/20212203897/job/58019727242
* Merged https://github.com/ruby/net-imap/pull/575
* 2nd attempt: https://github.com/ruby/net-imap/actions/runs/20219369554/job/58038064382