### PR TITLE
♻️ Refactor Config.versioned_defaults to reduce merge conflicts (backport to 0.5)

### DIFF
--- a/lib/net/imap/config.rb
+++ b/lib/net/imap/config.rb
@@ -194,7 +194,7 @@ module Net
       #
       # *NOTE:* Versioned default configs inherit #debug from Config.global, and
       # #load_defaults will not override #debug.
-      attr_accessor :debug, type: :boolean
+      attr_accessor :debug, type: :boolean, default: false
 
       # method: debug?
       # :call-seq: debug? -> boolean
@@ -491,28 +491,10 @@ module Net
         to_h.reject {|k,v| DEFAULT_TO_INHERIT.include?(k) }
       end
 
-      @default = new(
-        debug: false,
-        open_timeout: 30,
-        idle_response_timeout: 5,
-        sasl_ir: true,
-        enforce_logindisabled: true,
-        max_response_size: 512 << 20, # 512 MiB
-        responses_without_block: :warn,
-        parser_use_deprecated_uidplus_data: :up_to_max_size,
-        parser_max_deprecated_uidplus_data_size: 100,
-      ).freeze
-
-      @global = default.new
-
+      @default = AttrVersionDefaults.compile_default!
+      @global  = default.new
       AttrVersionDefaults.compile_version_defaults!
 
-      if ($VERBOSE || $DEBUG) && self[:current].to_h != self[:default].to_h
-        warn "Misconfigured Net::IMAP::Config[:current] => %p,\n" \
-             " not equal to Net::IMAP::Config[:default] => %p" % [
-                self[:current].to_h, self[:default].to_h
-              ]
-      end
     end
   end
 end

--- a/lib/net/imap/config/attr_version_defaults.rb
+++ b/lib/net/imap/config/attr_version_defaults.rb
@@ -39,13 +39,23 @@ module Net
 
         def attr_accessor(name, defaults: nil, default: (unset = true), **kw)
           unless unset
-            defaults ||= { 0.0r => default }
+            version  = DEFAULT_TO_INHERIT.include?(name) ? nil : 0.0r
+            defaults = { version => default }
           end
           defaults&.each_pair do |version, default|
             AttrVersionDefaults.version_defaults[version] ||= {}
             AttrVersionDefaults.version_defaults[version][name] = default
           end
           super(name, **kw)
+        end
+
+        def self.compile_default!
+          raise "Config.default already compiled" if Config.default
+          default = VERSIONS.select { _1 <= CURRENT_VERSION }
+            .filter_map { version_defaults[_1] }
+            .prepend(version_defaults.delete(nil))
+            .inject(&:merge)
+          Config.new(**default).freeze
         end
 
         def self.compile_version_defaults!

--- a/test/net/imap/test_config.rb
+++ b/test/net/imap/test_config.rb
@@ -72,6 +72,7 @@ class ConfigTest < Net::IMAP::TestCase
   test ".default" do
     default = Config.default
     assert default.equal?(Config.default)
+    assert_nil default.parent
     assert default.is_a?(Config)
     assert default.frozen?
     refute default.debug?


### PR DESCRIPTION
Backports #544 to the `v0.5-stable ` branch.  From that PR:

> Grouping defaults by version and putting them all together at the bottom has almost guaranteed merge conflicts whenever a feature branch is merged/rebased or a backport branch is cherry-picked.
>
> At the cost of one final merge conflict per branch, this should significantly reduce future merge conflicts in the config file. It's also easier to match documentation with default values when they're right next to each other.

This handles that "one final merge conflict" for this branch.