### PR TITLE
🐛 Fix SequenceSet#delete?(num..num) to return set (backport to 0.5)

### DIFF
--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -1024,8 +1024,9 @@ module Net
       # Related: #delete, #delete_at, #subtract, #difference, #disjoint?
       def delete?(element)
         modifying! # short-circuit before input_to_tuple
+        element = input_try_convert(element)
         tuple = input_to_tuple element
-        if tuple.first == tuple.last
+        if number_input?(element)
           return unless include_tuple? tuple
           tuple_subtract tuple
           normalize!
@@ -1788,6 +1789,14 @@ module Net
           Integer.try_convert(input) ||
           String.try_convert(input) ||
           input
+      end
+
+      # NOTE: input_try_convert must be called on input first
+      def number_input?(input)
+        case input
+        when *STARS, Integer then true
+        when String          then !input.include?(/[:,]/)
+        end
       end
 
       def range_to_tuple(range)

--- a/test/net/imap/test_sequence_set.rb
+++ b/test/net/imap/test_sequence_set.rb
@@ -813,13 +813,21 @@ class IMAPSequenceSetTest < Net::IMAP::TestCase
 
   test "#delete?" do
     set = SequenceSet.new [5..10, 20]
+    # deleting a number
     assert_nil   set.delete?(11)
     assert_equal SequenceSet[5..10, 20], set
     assert_equal 6, set.delete?(6)
     assert_equal SequenceSet[5, 7..10, 20], set
+    # deleting a range
     assert_equal SequenceSet[9..10, 20],    set.delete?(9..)
     assert_equal SequenceSet[5, 7..8],      set
     assert_nil   set.delete?(11..)
+    set = SequenceSet.new [5..11, 20, 30..40]
+    assert_equal SequenceSet[9..11, 20, 30..33], set.delete?(9..33)
+    assert_equal SequenceSet[5..8, 34..40], set
+    set = SequenceSet.new [5..11, 20, 30..40]
+    # deleting a single-member range
+    assert_equal SequenceSet[9], set.delete?(9..9)
   end
 
   test "#slice!" do


### PR DESCRIPTION
Backports #583 to `v0.5-stable`.  From that PR:

> According to the rdoc, using a range with `#delete?` should return a sequence set (or nil), but the check came after importing the input, and was based on whether the imported run contained multiple values.  So deleting a single number range (e.g: `1..1` or `"1:1"`) would return a number not a set.