### PR TITLE
🐛 Fix `SequenceSet#max(n)` when `cardinality < n <= size` (backport to 0.5)

### DIFF
--- a/lib/net/imap/sequence_set.rb
+++ b/lib/net/imap/sequence_set.rb
@@ -755,7 +755,13 @@ module Net
       # Related: #min, #minmax, #slice
       def max(count = nil, star: :*)
         if count
-          slice(-[count, size].min..) || remain_frozen_empty
+          # n.b: #cardinality has not been backported to 0.5
+          cardinality = @tuples.sum(@tuples.count) { _2 - _1 }
+          if cardinality <= count
+            frozen? ? self : dup
+          else
+            slice(-count..) || remain_frozen_empty
+          end
         elsif (val = @tuples.last&.last)
           val == STAR_INT ? star : val
         end

--- a/test/net/imap/test_sequence_set.rb
+++ b/test/net/imap/test_sequence_set.rb
@@ -787,6 +787,15 @@ class IMAPSequenceSetTest < Net::IMAP::TestCase
     assert_equal SequenceSet["678"],     SequenceSet["345,678"].max(1)
     assert_equal SequenceSet["345,678"], SequenceSet["345,678"].max(222)
     assert_equal SequenceSet.empty,      SequenceSet.new.max(5)
+    # with different cardinality (150) vs size (200)
+    set = SequenceSet["101:200,51:150"]
+    assert_equal SequenceSet["52:200"], set.max(149)
+    assert_equal SequenceSet["51:200"], set.max(150)
+    assert_equal SequenceSet["51:200"], set.max(200)
+    # with different cardinality (2**32) vs count (2**32 - 1)
+    set = SequenceSet[1..]
+    assert_equal SequenceSet["2:*"], set.max(2**32 - 1)
+    assert_equal SequenceSet["1:*"], set.max(2**32)
   end
 
   test "#minmax" do


### PR DESCRIPTION
This backports #580 to `v0.5-stable`.

When `SequenceSet#max(n)` is called with `n > cardinality`, it _should_ return a duplicate of the whole set.  But, `#max(n)` is implemented using `#slice(-n..)`, and (copying the behavior of `Array`), when a slicing starts from an out-of-range index, it returns `nil`.

It was using `-[count, size].min` to keep the index from going out-of-range.  Prior to 0.6.0, `#size` is the same as `#count`, so it gives incorrect results when the set contains an endless range.  `SequenceSet#cardinality` has not been backported to 0.5, so this makes that calculation inline.

This change should also give a small performance boost, because it bypasses the complexity of `#slice(range)` and just calls `#dup` (or returns `self` when the set is frozen).