### PR TITLE
🐛 Fix `#responses()` freezing internal arrays

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3230,7 +3230,7 @@ module Net
           warn(RESPONSES_DEPRECATION_MSG, uplevel: 1, category: :deprecated)
         when :frozen_dup
           synchronize {
-            responses = @responses.transform_values(&:freeze)
+            responses = @responses.transform_values { _1.dup.freeze }
             responses.default_proc = nil
             responses.default = [].freeze
             return responses.freeze

--- a/test/net/imap/test_imap_responses.rb
+++ b/test/net/imap/test_imap_responses.rb
@@ -151,13 +151,17 @@ class IMAPResponsesTest < Net::IMAP::TestCase
         assert_equal [], imap.responses["FAKE"]
       end
       assert_empty stderr
-      # opt-in to future behavior
+      # default behavior since 0.6.0
       imap.config.responses_without_block = :frozen_dup
       stderr = EnvUtil.verbose_warning do
         assert imap.responses.frozen?
         assert imap.responses["CAPABILITY"].frozen?
         assert_equal(%w[IMAP4REV1 NAMESPACE MOVE IDLE UTF8=ACCEPT],
                      imap.responses["CAPABILITY"].last)
+        imap.responses do |r|
+          refute r.frozen?
+          refute r.values.any?(&:frozen?)
+        end
       end
       assert_empty stderr
     end


### PR DESCRIPTION
Now that `:frozen_dup` is the default behavior for `#responses` when it's called without any arguments, a critical bug has become apparent: it was freezing the internal responses arrays directly, rather than copies of them.  Freezing these arrays will, of course, lead to further issues.

Ideally, code should be updated to use one of the other forms of `#responses`, since this form is less efficient and also (intentionally) incompatibile with old code that expects it to return mutable arrays. But this is still a major bug.

Fixes #581, reported by @yurikoval.