### PR TITLE
📦 Drop digest from Gemfile (workaround for #576, backport to 0.4)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "digest"
+# gem "digest"  # not included as a workaround for #576
 gem "strscan"
 gem "base64"
 


### PR DESCRIPTION
Backports #577 to `v0.4-stable`.