### PR TITLE
🏷️ Add number64 and nz-number64 to NumValidator

### DIFF
--- a/lib/net/imap/data_encoding.rb
+++ b/lib/net/imap/data_encoding.rb
@@ -174,6 +174,22 @@ module Net
         0 < num && num <= 0xffff_ffff
       end
 
+      # Check if argument is a valid 'number64' according to RFC 9051
+      #     number64        = 1*DIGIT
+      #                        ; Unsigned 63-bit integer
+      #                        ; (0 <= n <= 9,223,372,036,854,775,807)
+      def valid_number64?(num)
+        0 <= num && num <= 0x7fff_ffff_ffff_ffff
+      end
+
+      # Check if argument is a valid 'number64' according to RFC 9051
+      #     number64        = 1*DIGIT
+      #                        ; Unsigned 63-bit integer
+      #                        ; (0 <= n <= 9,223,372,036,854,775,807)
+      def valid_nz_number64?(num)
+        0 < num && num <= 0x7fff_ffff_ffff_ffff
+      end
+
       # Check if argument is a valid 'mod-sequence-value' according to RFC 4551
       #     mod-sequence-value  = 1*DIGIT
       #                            ; Positive unsigned 64-bit integer
@@ -201,6 +217,20 @@ module Net
         return num if valid_nz_number?(num)
         raise DataFormatError,
           "nz-number must be non-zero unsigned 32-bit integer: #{num}"
+      end
+
+      # Ensure argument is 'number64' or raise DataFormatError
+      def ensure_number64(num)
+        return num if valid_number64?(num)
+        raise DataFormatError,
+          "number64 must be unsigned 63-bit integer: #{num}"
+      end
+
+      # Ensure argument is 'nz-number64' or raise DataFormatError
+      def ensure_nz_number64(num)
+        return num if valid_nz_number64?(num)
+        raise DataFormatError,
+          "nz-number64 must be non-zero unsigned 63-bit integer: #{num}"
       end
 
       # Ensure argument is 'mod-sequence-value' or raise DataFormatError
@@ -234,6 +264,26 @@ module Net
         when NUMBER_RE then ensure_nz_number Integer num
         else
           raise DataFormatError, "%p is not a valid nz-number" % [num]
+        end
+      end
+
+      # Like #ensure_number64, but usable with numeric String input.
+      def coerce_number64(num)
+        case num
+        when Integer   then ensure_number64 num
+        when NUMBER_RE then ensure_number64 Integer num
+        else
+          raise DataFormatError, "%p is not a valid number64" % [num]
+        end
+      end
+
+      # Like #ensure_nz_number64, but usable with numeric String input.
+      def coerce_nz_number64(num)
+        case num
+        when Integer   then ensure_nz_number64 num
+        when NUMBER_RE then ensure_nz_number64 Integer num
+        else
+          raise DataFormatError, "%p is not a valid nz-number64" % [num]
         end
       end
 

--- a/test/net/imap/test_num_validator.rb
+++ b/test/net/imap/test_num_validator.rb
@@ -9,13 +9,15 @@ class NumValidatorTest < Net::IMAP::TestCase
   TEST_VALUES = {
     -1          => %i[invalid],
 
-    0           => %i[number                              mod-sequence-valzer],
-    1           => %i[number nz-number mod-sequence-value mod-sequence-valzer],
-    0x0000_ffff => %i[number nz-number mod-sequence-value mod-sequence-valzer],
-    0xffff_ffff => %i[number nz-number mod-sequence-value mod-sequence-valzer],
-    0x0000_0001_0000_0000 => %i[       mod-sequence-value mod-sequence-valzer],
-    0x0000_ffff_ffff_ffff => %i[       mod-sequence-value mod-sequence-valzer],
-    0xffff_ffff_ffff_fffe => %i[       mod-sequence-value mod-sequence-valzer],
+    0           => %i[number           number64                                mod-sequence-valzer],
+    1           => %i[number nz-number number64 nz-number64 mod-sequence-value mod-sequence-valzer],
+    0x0000_ffff => %i[number nz-number number64 nz-number64 mod-sequence-value mod-sequence-valzer],
+    0xffff_ffff => %i[number nz-number number64 nz-number64 mod-sequence-value mod-sequence-valzer],
+    0x0000_0001_0000_0000 => %i[       number64 nz-number64 mod-sequence-value mod-sequence-valzer],
+    0x0000_ffff_ffff_ffff => %i[       number64 nz-number64 mod-sequence-value mod-sequence-valzer],
+    0x7fff_ffff_ffff_ffff => %i[       number64 nz-number64 mod-sequence-value mod-sequence-valzer],
+    0x8000_0000_0000_0000 => %i[                            mod-sequence-value mod-sequence-valzer],
+    0xffff_ffff_ffff_fffe => %i[                            mod-sequence-value mod-sequence-valzer],
 
     0xffff_ffff_ffff_ffff => %i[invalid],
   }
@@ -37,6 +39,18 @@ class NumValidatorTest < Net::IMAP::TestCase
   using_test_values_for :"nz-number" do |label, value, valid|
     test "#valid_nz_number?(%s) => %p" % [label, valid] do
       assert_equal valid, NumValidator.valid_nz_number?(value)
+    end
+  end
+
+  using_test_values_for :number64 do |label, value, valid|
+    test "#valid_number64?(%s) => %p" % [label, valid] do
+      assert_equal valid, NumValidator.valid_number64?(value)
+    end
+  end
+
+  using_test_values_for :"nz-number64" do |label, value, valid|
+    test "#valid_nz_number64?(%s) => %p" % [label, valid] do
+      assert_equal valid, NumValidator.valid_nz_number64?(value)
     end
   end
 
@@ -76,6 +90,28 @@ class NumValidatorTest < Net::IMAP::TestCase
         assert_equal value, NumValidator.ensure_nz_number(value)
       else
         assert_format_error do NumValidator.ensure_nz_number(value) end
+      end
+    end
+  end
+
+  using_test_values_for :number64 do |label, value, valid|
+    result = valid ? "=> #{label}" : "raises DataFormatError"
+    test "#ensure_number64(%s) %s" % [label, result] do
+      if valid
+        assert_equal value, NumValidator.ensure_number64(value)
+      else
+        assert_format_error do NumValidator.ensure_number64(value) end
+      end
+    end
+  end
+
+  using_test_values_for :"nz-number64" do |label, value, valid|
+    result = valid ? "=> #{label}" : "raises DataFormatError"
+    test "#ensure_nz_number64(%s) %s" % [label, result] do
+      if valid
+        assert_equal value, NumValidator.ensure_nz_number64(value)
+      else
+        assert_format_error do NumValidator.ensure_nz_number64(value) end
       end
     end
   end
@@ -123,6 +159,32 @@ class NumValidatorTest < Net::IMAP::TestCase
           assert_equal value, NumValidator.coerce_nz_number(input)
         else
           assert_format_error do NumValidator.coerce_nz_number(input) end
+        end
+      end
+    end
+  end
+
+  using_test_values_for :number64 do |label, value, valid|
+    result = valid ? "=> #{value}" : "raises DataFormatError"
+    [value, value.to_s].each do |input|
+      test "#coerce_number64(%p) %s" % [input, result] do
+        if valid
+          assert_equal value, NumValidator.coerce_number64(input)
+        else
+          assert_format_error do NumValidator.coerce_number64(input) end
+        end
+      end
+    end
+  end
+
+  using_test_values_for :"nz-number64" do |label, value, valid|
+    result = valid ? "=> #{value}" : "raises DataFormatError"
+    [value, value.to_s].each do |input|
+      test "#coerce_nz_number64(%p) %s" % [input, result] do
+        if valid
+          assert_equal value, NumValidator.coerce_nz_number64(input)
+        else
+          assert_format_error do NumValidator.coerce_nz_number64(input) end
         end
       end
     end


### PR DESCRIPTION
This uses the uint63 definition, from RFC9051.

This isn't used by any internal Net::IMAP code, _yet_.