### PR TITLE
Fix JRuby SSL connection failure: use SSLContext#setup instead of freeze

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3808,7 +3808,7 @@ module Net
         params = (Hash.try_convert(ssl) || {}).freeze
         context = OpenSSL::SSL::SSLContext.new
         context.set_params(params)
-        context.freeze
+        context.setup
         [params, context]
       else
         false


### PR DESCRIPTION
## Summary

On JRuby, `OpenSSL::SSL::SSLContext#freeze` causes a `NullPointerException` because the internal SSL engine (`internalContext`) is lazily initialized on the first connection attempt. Freezing the object beforehand prevents that lazy write, leaving `internalContext` null and breaking all SSL connections.

- Replace `context.freeze` with `context.setup` in `build_ssl_ctx`
- On CRuby, `SSLContext#setup` is effectively an alias for `freeze` — no behavioral change
- On JRuby (and other implementations), `setup` eagerly initializes the context without freezing, avoiding the NPE

Fixes #624

Co-authored-by: Nicholas Evans <nevans@users.noreply.github.com>