### PR TITLE
Wrap SystemStackError as ResponseParseError in ResponseParser

### DIFF
--- a/lib/net/imap/response_parser.rb
+++ b/lib/net/imap/response_parser.rb
@@ -691,6 +691,8 @@ module Net
         CRLF!
         EOF!
         resp
+      rescue SystemStackError => error
+        raise exception(error.message), cause: error
       end
 
       # RFC3501 & RFC9051:

--- a/test/net/imap/test_response_parser.rb
+++ b/test/net/imap/test_response_parser.rb
@@ -201,6 +201,26 @@ class ResponseParserTest < Net::IMAP::TestCase
     end
   end
 
+  test "deeply nested BODYSTRUCTURE raises ResponseParseError instead of SystemStackError" do
+    parser = Net::IMAP::ResponseParser.new
+
+    def parser.body
+      raise SystemStackError, "stack level too deep"
+    end unless ENV["TEST_RESPONSE_PARSER_STACK_LEVEL"] == "original"
+
+    depth = 10_000
+    leaf = '("TEXT" "PLAIN" NIL NIL NIL "7BIT" 1 1)'
+    bodystructure = depth.times.reduce(leaf) { |part, _| "(#{part} \"MIXED\")" }
+    response = "* 1 FETCH (BODYSTRUCTURE #{bodystructure})\r\n"
+
+    err = assert_raise(Net::IMAP::ResponseParseError) do
+      parser.parse(response)
+    end
+
+    assert_match(/stack level too deep/i, err.message)
+    assert_instance_of(SystemStackError, err.cause)
+  end
+
   def assert_deprecated_appenduid_data_warning
     assert_warn(/#{__FILE__}.*warning.*parser_use_deprecated_uidplus_data is ignored/) do
       result = yield


### PR DESCRIPTION
This makes ResponseParser#parse handle SystemStackError the same way it already handles other parse failures, by wrapping it as Net::IMAP::ResponseParseError.

The goal here is not to change the existing mitigation strategy. Parse failures should still terminate response processing and lead to disconnect behavior as they do today. This change just makes the failure mode consistent for callers, so SystemStackError does not bypass the normal ResponseParseError path.

I also added a deterministic regression test that forces SystemStackError without depending on Ruby or OS stack depth. The test asserts that parse raises ResponseParseError and preserves the original SystemStackError as its cause.
