### PR TITLE
🐛 Config `version_defaults` should be attr_reader (backports #594)

### DIFF
--- a/lib/net/imap/config/attr_version_defaults.rb
+++ b/lib/net/imap/config/attr_version_defaults.rb
@@ -24,7 +24,7 @@ module Net
         VERSIONS = ((0.0r..FUTURE_VERSION) % 0.1r).to_a.freeze
 
         # See Config.version_defaults.
-        singleton_class.attr_accessor :version_defaults
+        singleton_class.attr_reader :version_defaults
 
         @version_defaults = Hash.new {|h, k|
           # NOTE: String responds to both so the order is significant.

--- a/test/net/imap/test_config.rb
+++ b/test/net/imap/test_config.rb
@@ -151,6 +151,10 @@ class ConfigTest < Net::IMAP::TestCase
       end
       assert_same Config.global, config.parent
     end
+    assert_raise(NameError) do Config.method(:version_defaults=) end
+    assert_raise(NameError) do
+      Config::AttrVersionDefaults.method(:version_defaults=)
+    end
   end
 
   test "Config[:default] and Config[:current] both hold default config" do


### PR DESCRIPTION
Although `version_defaults` is deeply frozen, it used `attr_accessor`!

----

This PR backports #594 to `v0.5-stable`.  It fixes a bug that was introduced in #584 (which backported #544 to this branch).