### PR TITLE
🐛 Fix InvalidResponseError in `#get_tagged_response`

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3508,7 +3508,7 @@ module Net
         raise BadResponseError, resp
       else
         disconnect
-        raise InvalidResponseError, "invalid tagged resp: %p" % [resp.raw.chomp]
+        raise InvalidResponseError, "invalid tagged resp: %p" % [resp.raw_data.chomp]
       end
     end
 


### PR DESCRIPTION
This previously raised a NoMethodError.

Or... it would.

No tests failed because, for `response-tagged`, `ResponseParser` has been updated to strictly validate the `resp-cond-state` name, and raises this exception directly.  I'm not sure if this code even _can_ be triggered by the current `ResponseParser`.