### PR TITLE
Test TruffleRuby release in CI for improved stability

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         experimental: [false]
         include:
-          - { ruby: truffleruby-head, os: ubuntu-latest,  experimental: true }
+          - { ruby: truffleruby, os: ubuntu-latest,  experimental: true }
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     timeout-minutes: 15


### PR DESCRIPTION
Now that TruffleRuby 34 has been released and contains the necessary fixes for net-imap.