### PR TITLE
⚡ Much faster ResponseReader performance

### DIFF
--- a/benchmarks/response_reader.yml
+++ b/benchmarks/response_reader.yml
@@ -1,0 +1,87 @@
+prelude: |
+  require "net/imap"
+  require "stringio"
+
+  @io = StringIO.new("", "rb")
+  client = Object.new
+  def client.config = @config ||= Net::IMAP::Config.new
+  def client.max_response_size = config.max_response_size
+  client.config # force memoization
+
+  @reader = Net::IMAP::ResponseReader.new(client, @io)
+  def read
+    @io.rewind
+    @reader.read_response_buffer
+  rescue Net::IMAP::ResponseTooLargeError
+    # intentionally ignoring this
+  end
+
+  def b(str) = str.to_str.b
+
+  # Pathological case: nothing but empty literals
+  EMPTY_CONT = "{0}\r\n"               #  5 bytes
+  SMALL_CONT = "{19}\r\nアイマップ4。" # 25 bytes
+  def pathological(size)   = b EMPTY_CONT * (size.to_int / EMPTY_CONT.bytesize) + "\r\n"
+  def small_literals(size) = b SMALL_CONT * (size.to_int / SMALL_CONT.bytesize) + "\r\n"
+  def no_literals(size)    = b "a" * size + "\r\n"
+  def pathological!(...)   = @io.string = pathological(...)
+  def small_literals!(...) = @io.string = small_literals(...)
+  def no_literals!(...)    = @io.string = no_literals(...)
+
+  def warmup(input)
+    @io.string = input
+    output = read
+    output == input or raise "Invalid input? output=%p" % [output]
+    1000.times do read end
+  end
+
+  warmup no_literals    100
+  warmup small_literals 100
+  warmup pathological   100
+
+  no_literals!(1)
+
+benchmark:
+  - { name: "100  B with no literals", prelude: "no_literals!    1e2", script: "read" }
+  - { name: "  1KiB with no literals", prelude: "no_literals!    1e3", script: "read" }
+  - { name: " 10KiB with no literals", prelude: "no_literals!    1e4", script: "read" }
+  - { name: "100KiB with no literals", prelude: "no_literals!    1e5", script: "read" }
+  - { name: "  1MiB with no literals", prelude: "no_literals!    1e6", script: "read" }
+
+  - { name: "100  B of  25B literals", prelude: "small_literals! 1e2", script: "read" }
+  - { name: "  1KiB of  25B literals", prelude: "small_literals! 1e3", script: "read" }
+  - { name: " 10KiB of  25B literals", prelude: "small_literals! 1e4", script: "read" }
+  - { name: "100KiB of  25B literals", prelude: "small_literals! 1e5", script: "read" }
+  # - { name: "  1MiB of  25 byte literals", prelude: "small_literals! 1e6", script: "read" }
+  # - { name: "100MiB of  25 byte literals", prelude: "small_literals! 1e8", script: "read" }
+
+  - { name: "100  B of   0B literals", prelude: "pathological!   1e2", script: "read" }
+  - { name: "  1KiB of   0B literals", prelude: "pathological!   1e3", script: "read" }
+  - { name: " 10KiB of   0B literals", prelude: "pathological!   1e4", script: "read" }
+  # - { name: "100KiB of   0B literals", prelude: "pathological!   1e5", script: "read" }
+  # - { name: "  1MiB of   0 byte literals", prelude: "pathological!   1e6", script: "read" }
+  # - { name: "100MiB of   0 byte literals", prelude: "pathological!   1e8", script: "read" }
+
+contexts:
+  - name: local
+    prelude: |
+      $LOAD_PATH.unshift "./lib"
+    require: false
+  - name: local YJIT
+    prelude: |
+      $LOAD_PATH.unshift "./lib"
+      RubyVM::YJIT.enable
+    require: false
+
+  # - name: v0.6.3
+  #   gems:
+  #     net-imap: 0.6.3
+  #   require: false
+  # - name: v0.5.13
+  #   gems:
+  #     net-imap: 0.5.13
+  #   require: false
+  # - name: v0.4.23
+  #   gems:
+  #     net-imap: 0.4.23
+  #   require: false

--- a/benchmarks/response_reader.yml
+++ b/benchmarks/response_reader.yml
@@ -58,7 +58,7 @@ benchmark:
   - { name: "100  B of   0B literals", prelude: "pathological!   1e2", script: "read" }
   - { name: "  1KiB of   0B literals", prelude: "pathological!   1e3", script: "read" }
   - { name: " 10KiB of   0B literals", prelude: "pathological!   1e4", script: "read" }
-  # - { name: "100KiB of   0B literals", prelude: "pathological!   1e5", script: "read" }
+  - { name: "100KiB of   0B literals", prelude: "pathological!   1e5", script: "read" }
   # - { name: "  1MiB of   0 byte literals", prelude: "pathological!   1e6", script: "read" }
   # - { name: "100MiB of   0 byte literals", prelude: "pathological!   1e8", script: "read" }
 

--- a/lib/net/imap/response_reader.rb
+++ b/lib/net/imap/response_reader.rb
@@ -19,7 +19,10 @@ module Net
         @buff = String.new
         catch :eof do
           while true
+            guard_response_too_large!
             read_line
+            # check before allocating memory for literal
+            guard_response_too_large!
             break unless literal_size
             read_literal
           end
@@ -47,23 +50,16 @@ module Net
       end
 
       def read_line
-        line = (@sock.gets(CRLF, read_limit) or throw :eof)
-        buff << line
-        max_response_remaining! unless line_done?
+        line = (@sock.gets(CRLF, max_response_remaining) or throw :eof)
         @literal_size = get_literal_size(line)
+        buff << line
       end
 
       def read_literal
-        # check before allocating memory for literal
-        max_response_remaining!
         literal = String.new(capacity: literal_size)
-        buff << (@sock.read(read_limit(literal_size), literal) or throw :eof)
+        buff << (@sock.read(literal_size, literal) or throw :eof)
       ensure
         @literal_size = nil
-      end
-
-      def read_limit(limit = nil)
-        [limit, max_response_remaining!].compact.min
       end
 
       def max_response_remaining = max_response_size &.- bytes_read
@@ -74,10 +70,11 @@ module Net
         empty? ? 3 : done? ? 0 : (literal_size || 0) + 2
       end
 
-      def max_response_remaining!
-        return max_response_remaining unless response_too_large?
-        raise ResponseTooLargeError.new(
-          max_response_size:, bytes_read:, literal_size:,
+      def guard_response_too_large! = (raise self if response_too_large?)
+
+      def exception(msg = nil)
+        ResponseTooLargeError.new(
+          msg, max_response_size:, bytes_read:, literal_size:,
         )
       end
 

--- a/lib/net/imap/response_reader.rb
+++ b/lib/net/imap/response_reader.rb
@@ -8,6 +8,7 @@ module Net
 
       def initialize(client, sock)
         @client, @sock = client, sock
+        @buff = @literal_size = nil
       end
 
       def read_response_buffer
@@ -15,13 +16,13 @@ module Net
         catch :eof do
           while true
             read_line
-            break unless (@literal_size = get_literal_size)
+            break unless literal_size
             read_literal
           end
         end
         buff
       ensure
-        @buff = nil
+        @buff = @literal_size = nil
       end
 
       private
@@ -30,16 +31,18 @@ module Net
 
       def bytes_read          = buff.bytesize
       def empty?              = buff.empty?
-      def done?               = line_done? && !get_literal_size
+      def done?               = line_done? && !literal_size
       def line_done?          = buff.end_with?(CRLF)
 
-      def get_literal_size
+      def get_literal_size(buff)
         buff.end_with?("}\r\n") && buff.rindex(/\{(\d+)\}\r\n\z/n) && $1.to_i
       end
 
       def read_line
-        buff << (@sock.gets(CRLF, read_limit) or throw :eof)
+        line = (@sock.gets(CRLF, read_limit) or throw :eof)
+        buff << line
         max_response_remaining! unless line_done?
+        @literal_size = get_literal_size(line)
       end
 
       def read_literal

--- a/lib/net/imap/response_reader.rb
+++ b/lib/net/imap/response_reader.rb
@@ -32,7 +32,10 @@ module Net
       def empty?              = buff.empty?
       def done?               = line_done? && !get_literal_size
       def line_done?          = buff.end_with?(CRLF)
-      def get_literal_size    = buff.rindex(/\{(\d+)\}\r\n\z/n) && $1.to_i
+
+      def get_literal_size
+        buff.end_with?("}\r\n") && buff.rindex(/\{(\d+)\}\r\n\z/n) && $1.to_i
+      end
 
       def read_line
         buff << (@sock.gets(CRLF, read_limit) or throw :eof)

--- a/lib/net/imap/response_reader.rb
+++ b/lib/net/imap/response_reader.rb
@@ -32,7 +32,7 @@ module Net
       def empty?              = buff.empty?
       def done?               = line_done? && !get_literal_size
       def line_done?          = buff.end_with?(CRLF)
-      def get_literal_size    = /\{(\d+)\}\r\n\z/n =~ buff && $1.to_i
+      def get_literal_size    = buff.rindex(/\{(\d+)\}\r\n\z/n) && $1.to_i
 
       def read_line
         buff << (@sock.gets(CRLF, read_limit) or throw :eof)

--- a/lib/net/imap/response_reader.rb
+++ b/lib/net/imap/response_reader.rb
@@ -8,10 +8,14 @@ module Net
 
       def initialize(client, sock)
         @client, @sock = client, sock
+        # cached config
+        @max_response_size = nil
+        # response buffer state
         @buff = @literal_size = nil
       end
 
       def read_response_buffer
+        @max_response_size = client.max_response_size
         @buff = String.new
         catch :eof do
           while true
@@ -27,6 +31,10 @@ module Net
 
       private
 
+      # cached config
+      attr_reader :max_response_size
+
+      # response buffer state
       attr_reader :buff, :literal_size
 
       def bytes_read          = buff.bytesize
@@ -58,7 +66,6 @@ module Net
         [limit, max_response_remaining!].compact.min
       end
 
-      def max_response_size      = client.max_response_size
       def max_response_remaining = max_response_size &.- bytes_read
       def response_too_large?    = max_response_size &.< min_response_size
       def min_response_size      = bytes_read + min_response_remaining

--- a/test/lib/helper.rb
+++ b/test/lib/helper.rb
@@ -62,6 +62,117 @@ class Net::IMAP::TestCase < Test::Unit::TestCase
     end
   end
 
+  # assert_linear_performance didn't fail reliably until "n" was far too high,
+  # even though the problem was very obvious at lower "n" values, by looking at
+  # the mean (plus stddev) rather than the max (plus variance-based "safety
+  # factor").
+  #
+  # So rather than use "max" as the baseline, this uses μ + 2σ (or max).
+  def assert_strict_linear_time(sequence, prepare: proc do end,
+                                base_repeats: 100,
+                                repeats:        5,
+                                allow_stdev_above_mean: 2,
+                                outlier_safety_factor:  3,
+                                mean_safety_factor:     2,
+                                verbose: false,
+                                &code)
+    pend "No PERFORMANCE_CLOCK found" unless defined?(PERFORMANCE_CLOCK)
+
+    measure  = proc do |&block|
+      st = Process.clock_gettime(PERFORMANCE_CLOCK)
+      block.call
+      t = Process.clock_gettime(PERFORMANCE_CLOCK)
+      t - st
+    end
+
+    measure_base = proc do |sequence, prepare:, &code|
+      stats = RunningStats.new
+      base_repeats.times do
+        *args = prepare.(sequence.first)
+        time = measure.call { code.call(*args) }
+        warn "  - %0.9f" % [time] if verbose == :very
+        stats.push time
+      end
+      stats
+    end
+
+    scale = ->(base, base_size, size) { base * size.fdiv(base_size) }
+
+    warn "Measuring (#{base_repeats} times) for n=#{sequence.first}." if verbose
+    base_stats = measure_base.(sequence, prepare:, &code)
+    base_time  = [base_stats.stddev_above_mean(3), base_stats.max].min
+
+    base_timeout_msg = "min=%s max=%s mean=%s stddev=%s timeout=%s" % [
+      base_stats.min, base_stats.max, base_stats.mean, base_stats.stddev,
+      base_time
+    ].map { "%0.6f" % _1 }
+
+    warn "  n=%d -> %p" % [sequence.first, base_stats] if verbose
+    warn "  base timeout=%0.6f" % [base_time] if verbose
+
+    sequence.each.drop(1).to_h {|n|
+      linear_limit = scale.(base_time, sequence.first, n)
+      each_timeout = linear_limit * outlier_safety_factor
+      mean_timeout = linear_limit *    mean_safety_factor
+      full_timeout = mean_timeout * repeats * 1.1
+      timeout_msg = "for n=%s linear_limit=%0.6f timeout=%0.6f mean_timeout=%0.6f" % [
+        n, linear_limit, each_timeout, mean_timeout
+      ]
+      warn "Measuring (#{repeats} times) #{timeout_msg}:" if verbose
+      timeout_msg = "#{timeout_msg} #{base_timeout_msg}"
+      *args = prepare.call(n)
+      times = Timeout.timeout(full_timeout, Timeout::Error, timeout_msg) do
+        Array.new(repeats) {
+          time = Timeout.timeout(each_timeout, Timeout::Error, timeout_msg) do
+            measure.call do code.call(*args) end
+          end
+          assert_operator time, :<=, each_timeout,
+            "super-linear time %0.6f %s" % [time, timeout_msg]
+          warn "  ---- %0.9f" % [time] if verbose == :very
+          time
+        }
+      end
+      stats = RunningStats.new(times)
+      warn "  n=%d -> %p" % [n, stats] if verbose
+      assert_operator stats.mean, :<=, mean_timeout,
+        "super-linear mean time %0.6f %s" % [stats.mean, timeout_msg]
+      [n, stats]
+    }
+  end
+
+  class RunningStats
+    attr_reader :samples, :min, :max, :mean
+
+    def initialize(input = nil)
+      @samples = 0
+      @mean    = 0.0
+      @s       = 0.0
+      @min     = nil
+      @max     = nil
+      input&.each do push _1 end
+    end
+
+    def push(x)
+      @min      = @min ? [@min, x].min : x
+      @max      = @max ? [@max, x].max : x
+      @samples += 1
+      delta     = (x - @mean)
+      @mean    += delta / @samples
+      @s       += delta * (x - @mean)
+    end
+
+    def variance; (@samples >= 1) ? @s / (@samples - 1) : 0.0 end
+    def stddev;   Math.sqrt(variance) end
+
+    def stddev_above_mean(mult = 1) = mean + mult * stddev
+
+    def inspect
+      "#<%s samples=%d min=%0.6f max=%0.6f mean=%0.6f stddev=%0.6f>" % [
+        self.class, samples, min, max, mean, stddev
+      ]
+    end
+  end
+
   # Copied from minitest
   def assert_pattern
     flunk "assert_pattern requires a block to capture errors." unless block_given?

--- a/test/net/imap/test_response_reader.rb
+++ b/test/net/imap/test_response_reader.rb
@@ -82,4 +82,26 @@ class ResponseReaderTest < Net::IMAP::TestCase
     end
   end
 
+  test "linear performance detecting literal continuation" do
+    omit_unless_cruby "flaky on different platforms"
+    omit_if(ENV["CI"], "slow and flaky, skipping in CI")
+
+    client = FakeClient.new
+    io = StringIO.new "", "rb"
+    rcvr = Net::IMAP::ResponseReader.new(client, io)
+
+    sequence = [100, 1_000, 10_000]
+    assert_strict_linear_time(sequence, prepare: ->(n) {
+      parts = Array.new(n) {|i| "BODY[#{i.succ}] {1}\r\nX" }.join(" ")
+      response = "* 1 FETCH (#{parts})\r\n"
+      embedded = "#{response}* OK next response\r\n"
+      io.string = embedded
+      assert_equal response, rcvr.read_response_buffer
+      io.rewind
+      response
+    }) do
+      io.rewind
+      rcvr.read_response_buffer
+    end
+  end
 end

--- a/test/net/imap/test_response_reader.rb
+++ b/test/net/imap/test_response_reader.rb
@@ -54,7 +54,7 @@ class ResponseReaderTest < Net::IMAP::TestCase
     exact = "+ 345678\r\n"
     very_over     = "+ 3456789 #{?a * (16<<10)}}\r\n"
     slightly_over = "+ 34567890\r\n" # CRLF after the limit
-    io = StringIO.new([under, exact, very_over, slightly_over].join)
+    io = StringIO.new([under, exact, very_over, slightly_over].join, "rb")
     rcvr = Net::IMAP::ResponseReader.new(client, io)
     assert_equal under, rcvr.read_response_buffer.to_str
     assert_equal exact, rcvr.read_response_buffer.to_str
@@ -62,7 +62,7 @@ class ResponseReaderTest < Net::IMAP::TestCase
       result = rcvr.read_response_buffer
       flunk "Got result: %p" % [result]
     end
-    io = StringIO.new(slightly_over)
+    io = StringIO.new(slightly_over, "rb")
     rcvr = Net::IMAP::ResponseReader.new(client, io)
     assert_raise Net::IMAP::ResponseTooLargeError do
       result = rcvr.read_response_buffer
@@ -74,7 +74,7 @@ class ResponseReaderTest < Net::IMAP::TestCase
     barely_over = "+ 3456789\r\n"  # CRLF straddles the boundary
     client = FakeClient.new
     client.config.max_response_size = 10
-    io = StringIO.new(barely_over)
+    io = StringIO.new(barely_over, "rb")
     rcvr = Net::IMAP::ResponseReader.new(client, io)
     assert_raise Net::IMAP::ResponseTooLargeError do
       result = rcvr.read_response_buffer


### PR DESCRIPTION
> [!NOTE]
> This PR fixes quadratic time complexity when reading large responses containing many string literals.
> This should only be an issue when connecting to an _untrusted hostile server_ (or without TLS).


This _significant_ improves the performance of `ResponseReader`, which runs in the receiver thread.

For responses which contain many literals, **_v0.6.3's runs in O(n²) time_**!

`v0.6.3` is **1.15x to 1.5x** slower reading responses with no literals.
`v0.6.3` is **4x** slower reading 100 byte responses with four literals.
`v0.6.3` is **800x** slower reading 100KiB "pathological" responses (filled with zero-byte literals).

### 💥 Minor breaking change

_NOTE: It is not expected that this will affect any current usage.  If you **are** affected by this, please describe your scenario in a comment or a new issue._

Rather than read `config.max_response_size` from the client once (or more) per line/literal, it's now loaded from the config only once per response.  This gives a gives a greater speedup for each literal in the response.

Previously, changing `max_response_size` took effect after each line or literal is read.  They now take effect after each whole response is read.  This only makes a difference for responses that contain literals.

The config change latency was _already_ non-deterministic, prior to this change.  The simplest workaround is to simply call `#noop` after making the change, to flush the current response and reset the response reader with the new config.

### 📉 Benchmarks

The benchmarks below (behind the disclosure summaries) were run against the each of the following commits:
* 8c2fb18 — v0.6.3
* 341ab62 — "0: rindex re" - fixes dominant O(n²) issue, but slower for "no literals".
* 49c516d — "1: end_with?" - fixes "no literal" case, and always faster than v0.6.3.
* 6f82e28 — "2: get literal" - fixes secondary issue (maybe O(n²)?) with large responses.
* 0e89dbb — "3: memo config" - linear (per literal) improvement, minor breaking change
* 7e1af98 — "4: chk too big" - linear (per literal) improvement

Please note that, because the iteration counts for the following benchmarks were determined by the performance of v0.6.3, and the current version runs _so much_ faster (especially for larger responses), the current version's benchmarks benchmarks finish before they've had time to get up to speed, so those numbers are lower than they would be if the benchmark were given a longer warmup.  This is especially true for the YJIT numbers.

#### Benchmarks with no literals
##### Without YJIT
<details><summary><tt>benchmark-driver benchmarks/response_reader.yml --filter "no literals" --run-duration 15</tt></summary>

```console
Warming up --------------------------------------
100  B with no literals   288.099k i/s -      1.465M times in 5.086617s (3.47μs/i)
  1KiB with no literals   181.067k i/s -    912.872k times in 5.041628s (5.52μs/i)
 10KiB with no literals    47.537k i/s -    239.088k times in 5.029486s (21.04μs/i)
100KiB with no literals     5.666k i/s -     28.808k times in 5.084499s (176.50μs/i)
  1MiB with no literals    569.047 i/s -      2.856k times in 5.018915s (1.76ms/i)
100MiB with no literals      4.767 i/s -      24.000 times in 5.034681s (209.78ms/i)
Calculating -------------------------------------
                            v0.6.3  0: rindex re   1: end_with?  2: get literal 3: memo config 4: chk too big
                                       (240bf42)      (796f268)       (abed457)      (af9c496)      (fa68d48)
100  B with no literals   292.136k      270.741k       292.042k        312.188k       411.981k       419.641k i/s -      4.321M times in 14.792748s 15.961703s 14.797472s 13.842582s 10.489528s 10.298050s
  1KiB with no literals   172.641k      132.309k       180.135k        181.671k       226.676k       221.356k i/s -      2.716M times in 15.732089s 20.527734s 15.077629s 14.950114s 11.981851s 12.269855s
 10KiB with no literals    47.446k       25.688k        55.498k         55.786k        58.931k        59.044k i/s -    713.058k times in 15.028900s 27.758676s 12.848333s 12.781987s 12.099954s 12.076764s
100KiB with no literals     5.651k        2.838k         6.645k          6.646k         6.663k         6.685k i/s -     84.987k times in 15.038445s 29.947143s 12.789348s 12.787033s 12.755541s 12.712552s
  1MiB with no literals    567.389       299.453        667.603         667.625        667.253        666.995 i/s -      8.535k times in 15.042600s 28.501932s 12.784551s 12.784128s 12.791259s 12.796197s
100MiB with no literals      4.770         2.670          5.495           5.483          5.490          5.317 i/s -      71.000 times in 14.886105s 26.591573s 12.920007s 12.949437s 12.931516s 13.353553s

Comparison:
             100  B with no literals
4: chk too big (fa68d48):    419641.3 i/s
3: memo config (af9c496):    411981.1 i/s - 1.02x  slower
2: get literal (abed457):    312187.9 i/s - 1.34x  slower
                 v0.6.3:    292135.5 i/s - 1.44x  slower
1: end_with?   (796f268):    292042.2 i/s - 1.44x  slower
0: rindex re   (240bf42):    270741.0 i/s - 1.55x  slower

               1KiB with no literals
3: memo config (af9c496):    226676.4 i/s
4: chk too big (fa68d48):    221355.8 i/s - 1.02x  slower
2: get literal (abed457):    181671.1 i/s - 1.25x  slower
1: end_with?   (796f268):    180134.6 i/s - 1.26x  slower
                 v0.6.3:    172641.0 i/s - 1.31x  slower
0: rindex re   (240bf42):    132309.0 i/s - 1.71x  slower

              10KiB with no literals
4: chk too big (fa68d48):     59043.8 i/s
3: memo config (af9c496):     58930.6 i/s - 1.00x  slower
2: get literal (abed457):     55786.2 i/s - 1.06x  slower
1: end_with?   (796f268):     55498.1 i/s - 1.06x  slower
                 v0.6.3:     47445.8 i/s - 1.24x  slower
0: rindex re   (240bf42):     25687.8 i/s - 2.30x  slower

             100KiB with no literals
4: chk too big (fa68d48):      6685.3 i/s
3: memo config (af9c496):      6662.8 i/s - 1.00x  slower
2: get literal (abed457):      6646.3 i/s - 1.01x  slower
1: end_with?   (796f268):      6645.1 i/s - 1.01x  slower
                 v0.6.3:      5651.3 i/s - 1.18x  slower
0: rindex re   (240bf42):      2837.9 i/s - 2.36x  slower

               1MiB with no literals
2: get literal (abed457):       667.6 i/s
1: end_with?   (796f268):       667.6 i/s - 1.00x  slower
3: memo config (af9c496):       667.3 i/s - 1.00x  slower
4: chk too big (fa68d48):       667.0 i/s - 1.00x  slower
                 v0.6.3:       567.4 i/s - 1.18x  slower
0: rindex re   (240bf42):       299.5 i/s - 2.23x  slower

             100MiB with no literals
1: end_with?   (796f268):         5.5 i/s
3: memo config (af9c496):         5.5 i/s - 1.00x  slower
2: get literal (abed457):         5.5 i/s - 1.00x  slower
4: chk too big (fa68d48):         5.3 i/s - 1.03x  slower
                 v0.6.3:         4.8 i/s - 1.15x  slower
0: rindex re   (240bf42):         2.7 i/s - 2.06x  slower
```

</details>

* `100  B: 419641.3 i/s vs 292135.5 i/s - 1.44x  slower`
* `100KiB:   6685.3 i/s vs   5651.3 i/s - 1.18x  slower`
* `100MiB:      5.5 i/s vs      4.8 i/s - 1.15x  slower`

##### With YJIT
<details><summary><tt>benchmark-driver benchmarks/response_reader.yml --filter "no literals" --run-duration 15</tt></summary>

```console
Warming up --------------------------------------
100  B with no literals   453.164k i/s -      2.283M times in 5.038529s (2.21μs/i, 882clocks/i)
  1KiB with no literals   229.832k i/s -      1.169M times in 5.087791s (4.35μs/i)
 10KiB with no literals    51.225k i/s -    258.752k times in 5.051323s (19.52μs/i)
100KiB with no literals     5.606k i/s -     28.392k times in 5.064312s (178.37μs/i)
  1MiB with no literals    553.067 i/s -      2.808k times in 5.077144s (1.81ms/i)
100MiB with no literals      4.654 i/s -      24.000 times in 5.156626s (214.86ms/i)
Calculating -------------------------------------
                            v0.6.3  0: rindex re   1: end_with?  2: get literal 3: memo config 4: chk too big
                                       (240bf42)      (796f268)       (abed457)      (af9c496)      (fa68d48)
100  B with no literals   451.137k      414.647k       475.297k        488.211k       624.113k       664.625k i/s -      6.797M times in 15.067415s 16.393393s 14.301524s 13.923223s 10.891408s 10.227528s
  1KiB with no literals   218.986k      151.789k       221.386k        212.556k       250.990k       248.244k i/s -      3.447M times in 15.742979s 22.712409s 15.572303s 16.219209s 13.735526s 13.887482s
 10KiB with no literals    49.523k       27.837k        59.148k         59.110k        61.042k        61.257k i/s -    768.368k times in 15.515300s 27.602581s 12.990574s 12.998956s 12.587601s 12.543441s
100KiB with no literals     5.574k        2.980k         6.518k          6.523k         6.545k         6.550k i/s -     84.094k times in 15.086607s 28.221283s 12.901780s 12.892199s 12.848237s 12.839694s
  1MiB with no literals    549.464       294.550        641.204         640.060        641.545        641.428 i/s -      8.296k times in 15.098364s 28.165016s 12.938161s 12.961280s 12.931280s 12.933649s
100MiB with no literals      4.618         2.546          5.180           5.219          5.231          5.257 i/s -      69.000 times in 14.941662s 27.100016s 13.319229s 13.221718s 13.191433s 13.125139s

Comparison:
             100  B with no literals
4: chk too big (fa68d48):    664624.5 i/s
3: memo config (af9c496):    624112.7 i/s - 1.06x  slower
2: get literal (abed457):    488210.7 i/s - 1.36x  slower
1: end_with?   (796f268):    475296.6 i/s - 1.40x  slower
                 v0.6.3:    451136.8 i/s - 1.47x  slower
0: rindex re   (240bf42):    414646.7 i/s - 1.60x  slower

               1KiB with no literals
3: memo config (af9c496):    250990.4 i/s
4: chk too big (fa68d48):    248244.1 i/s - 1.01x  slower
1: end_with?   (796f268):    221385.7 i/s - 1.13x  slower
                 v0.6.3:    218985.6 i/s - 1.15x  slower
2: get literal (abed457):    212555.7 i/s - 1.18x  slower
0: rindex re   (240bf42):    151788.6 i/s - 1.65x  slower

              10KiB with no literals
4: chk too big (fa68d48):     61256.6 i/s
3: memo config (af9c496):     61041.7 i/s - 1.00x  slower
1: end_with?   (796f268):     59148.1 i/s - 1.04x  slower
2: get literal (abed457):     59110.0 i/s - 1.04x  slower
                 v0.6.3:     49523.2 i/s - 1.24x  slower
0: rindex re   (240bf42):     27836.8 i/s - 2.20x  slower

             100KiB with no literals
4: chk too big (fa68d48):      6549.5 i/s
3: memo config (af9c496):      6545.2 i/s - 1.00x  slower
2: get literal (abed457):      6522.9 i/s - 1.00x  slower
1: end_with?   (796f268):      6518.0 i/s - 1.00x  slower
                 v0.6.3:      5574.1 i/s - 1.17x  slower
0: rindex re   (240bf42):      2979.8 i/s - 2.20x  slower

               1MiB with no literals
3: memo config (af9c496):       641.5 i/s
4: chk too big (fa68d48):       641.4 i/s - 1.00x  slower
1: end_with?   (796f268):       641.2 i/s - 1.00x  slower
2: get literal (abed457):       640.1 i/s - 1.00x  slower
                 v0.6.3:       549.5 i/s - 1.17x  slower
0: rindex re   (240bf42):       294.5 i/s - 2.18x  slower

             100MiB with no literals
4: chk too big (fa68d48):         5.3 i/s
3: memo config (af9c496):         5.2 i/s - 1.01x  slower
2: get literal (abed457):         5.2 i/s - 1.01x  slower
1: end_with?   (796f268):         5.2 i/s - 1.01x  slower
                 v0.6.3:         4.6 i/s - 1.14x  slower
0: rindex re   (240bf42):         2.5 i/s - 2.06x  slower
```

</details>

* `100  B: 664624.5 i/s vs 414646.7 i/s - 1.60x  slower`
* `100KiB:   6549.5 i/s vs   5574.1 i/s - 1.17x  slower`
* `100MiB:      5.3 i/s vs      4.6 i/s - 1.14x  slower`

Although this shows YJIT is slightly slower for "no literals" at higher sizes, that particular benchmark is dominated by `StringIO` performance.  It might be different for `Socket` or `OpenSSL::SSL::SSLSocket`.

#### Benchmarks with many small literals
##### Without YJIT

<details><summary><tt>benchmark-driver benchmarks/response_reader.yml --filter "25B literals" --run-duration 60</tt></summary>

```console
Warming up --------------------------------------
100  B of  25B literals    24.158k i/s -    484.226k times in 20.044082s (41.39μs/i)
  1KiB of  25B literals     1.883k i/s -     37.800k times in 20.073170s (531.04μs/i)
 10KiB of  25B literals     62.126 i/s -      1.246k times in 20.055972s (16.10ms/i)
100KiB of  25B literals      0.808 i/s -      17.000 times in 21.040743s (1.24s/i)
Calculating -------------------------------------
                            v0.6.3  0: rindex re   1: end_with?  2: get literal 3: memo config 4: chk too big
                                       (240bf42)      (796f268)       (abed457)      (af9c496)      (fa68d48)
100  B of  25B literals    23.587k       24.276k        24.405k         29.424k        71.970k        95.027k i/s -      1.449M times in 61.452397s 59.707354s 59.391984s 49.262485s 20.140002s 15.253340s
  1KiB of  25B literals     1.964k        2.575k         2.526k          3.141k         8.271k        11.177k i/s -    112.986k times in 57.527128s 43.879215s 44.736556s 35.965926s 13.659769s 10.108633s
 10KiB of  25B literals     62.256       242.180        238.744         322.509        859.278         1.235k i/s -      3.727k times in 59.865786s 15.389386s 15.610894s 11.556253s 4.337361s 3.017252s
100KiB of  25B literals      0.785        18.534         17.103          31.749         85.465        121.861 i/s -      48.000 times in 61.151868s 2.589866s 2.806499s 1.511852s 0.561632s 0.393893s

Comparison:
             100  B of  25B literals
4: chk too big (fa68d48):     95027.3 i/s
3: memo config (af9c496):     71970.4 i/s - 1.32x  slower
2: get literal (abed457):     29423.7 i/s - 3.23x  slower
1: end_with?   (796f268):     24405.4 i/s - 3.89x  slower
0: rindex re   (240bf42):     24276.5 i/s - 3.91x  slower
                 v0.6.3:     23587.1 i/s - 4.03x  slower

               1KiB of  25B literals
4: chk too big (fa68d48):     11177.2 i/s
3: memo config (af9c496):      8271.4 i/s - 1.35x  slower
2: get literal (abed457):      3141.5 i/s - 3.56x  slower
0: rindex re   (240bf42):      2574.9 i/s - 4.34x  slower
1: end_with?   (796f268):      2525.6 i/s - 4.43x  slower
                 v0.6.3:      1964.0 i/s - 5.69x  slower

              10KiB of  25B literals
4: chk too big (fa68d48):      1235.2 i/s
3: memo config (af9c496):       859.3 i/s - 1.44x  slower
2: get literal (abed457):       322.5 i/s - 3.83x  slower
0: rindex re   (240bf42):       242.2 i/s - 5.10x  slower
1: end_with?   (796f268):       238.7 i/s - 5.17x  slower
                 v0.6.3:        62.3 i/s - 19.84x  slower

             100KiB of  25B literals
4: chk too big (fa68d48):       121.9 i/s
3: memo config (af9c496):        85.5 i/s - 1.43x  slower
2: get literal (abed457):        31.7 i/s - 3.84x  slower
0: rindex re   (240bf42):        18.5 i/s - 6.58x  slower
1: end_with?   (796f268):        17.1 i/s - 7.13x  slower
                 v0.6.3:         0.8 i/s - 155.25x  slower
```

</details>

* `100  B: 95027.3 i/s vs 23587.1 i/s - 4.03x  slower`
* `100KiB:   121.9 i/s vs     0.8 i/s - 155.25x slower`

##### With YJIT

<details><summary><tt>benchmark-driver benchmarks/response_reader.yml --filter "25B literals" --run-duration 60</tt></summary>

```console
Warming up --------------------------------------
100  B of  25B literals    33.744k i/s -    675.690k times in 20.023769s (29.63μs/i)
  1KiB of  25B literals     2.438k i/s -     48.945k times in 20.072979s (410.11μs/i)
 10KiB of  25B literals     64.820 i/s -      1.302k times in 20.086488s (15.43ms/i)
100KiB of  25B literals      0.797 i/s -      17.000 times in 21.320777s (1.25s/i)
Calculating -------------------------------------
                            v0.6.3  0: rindex re   1: end_with?  2: get literal 3: memo config 4: chk too big
                                       (240bf42)      (796f268)       (abed457)      (af9c496)      (fa68d48)
100  B of  25B literals    34.272k       37.090k        37.607k         46.229k       119.491k       152.494k i/s -      2.025M times in 59.075786s 54.587487s 53.837503s 43.796287s 16.943994s 13.276983s
  1KiB of  25B literals     2.603k        3.836k         3.767k          4.981k        13.835k        18.364k i/s -    146.301k times in 56.213622s 38.136606s 38.838296s 29.371869s 10.574379s 7.966941s
 10KiB of  25B literals     64.496       349.574        345.032         536.724         1.421k         1.897k i/s -      3.889k times in 60.298250s 11.124976s 11.271417s 7.245811s 2.737518s 2.050355s
100KiB of  25B literals      0.807        22.720         23.324          50.270        142.229        193.879 i/s -      47.000 times in 58.213116s 2.068631s 2.015057s 0.934952s 0.330452s 0.242419s

Comparison:
             100  B of  25B literals
4: chk too big (fa68d48):    152494.2 i/s
3: memo config (af9c496):    119491.5 i/s - 1.28x  slower
2: get literal (abed457):     46229.1 i/s - 3.30x  slower
1: end_with?   (796f268):     37606.9 i/s - 4.05x  slower
0: rindex re   (240bf42):     37090.2 i/s - 4.11x  slower
                 v0.6.3:     34272.3 i/s - 4.45x  slower

               1KiB of  25B literals
4: chk too big (fa68d48):     18363.5 i/s
3: memo config (af9c496):     13835.4 i/s - 1.33x  slower
2: get literal (abed457):      4981.0 i/s - 3.69x  slower
0: rindex re   (240bf42):      3836.2 i/s - 4.79x  slower
1: end_with?   (796f268):      3766.9 i/s - 4.87x  slower
                 v0.6.3:      2602.6 i/s - 7.06x  slower

              10KiB of  25B literals
4: chk too big (fa68d48):      1896.7 i/s
3: memo config (af9c496):      1420.6 i/s - 1.34x  slower
2: get literal (abed457):       536.7 i/s - 3.53x  slower
0: rindex re   (240bf42):       349.6 i/s - 5.43x  slower
1: end_with?   (796f268):       345.0 i/s - 5.50x  slower
                 v0.6.3:        64.5 i/s - 29.41x  slower

             100KiB of  25B literals
4: chk too big (fa68d48):       193.9 i/s
3: memo config (af9c496):       142.2 i/s - 1.36x  slower
2: get literal (abed457):        50.3 i/s - 3.86x  slower
1: end_with?   (796f268):        23.3 i/s - 8.31x  slower
0: rindex re   (240bf42):        22.7 i/s - 8.53x  slower
                 v0.6.3:         0.8 i/s - 240.13x  slower
```

</details>

* `100  B: 152494.2 i/s vs 34272.3 i/s -   4.45x  slower`
* `100KiB:    193.9 i/s vs     0.8 i/s - 240.13x  slower`

#### Pathological case (zero byte literals)
##### Without YJIT

<details><summary><tt>benchmark-driver benchmarks/response_reader.yml --filter "0B literals" --run-duration 120</tt></summary>

```console
Warming up --------------------------------------
100  B of   0B literals     4.177k i/s -    167.265k times in 40.044676s (239.41μs/i)
  1KiB of   0B literals    180.537 i/s -      7.239k times in 40.096979s (5.54ms/i)
 10KiB of   0B literals      2.919 i/s -     117.000 times in 40.079651s (342.56ms/i)
100KiB of   0B literals      0.031 i/s -       2.000 times in 64.270326s (32.14s/i)
Calculating -------------------------------------
                            v0.6.3  0: rindex re   1: end_with?  2: get literal 3: memo config 4: chk too big
                                       (240bf42)      (796f268)       (abed457)      (af9c496)      (fa68d48)
100  B of   0B literals     4.145k        4.805k         4.879k          6.277k        16.575k        23.539k i/s -    501.235k times in 120.919985s 104.323946s 102.732467s 79.846490s 30.241248s 21.294027s
  1KiB of   0B literals    178.325       480.398        449.299         638.776         1.708k         2.386k i/s -     21.664k times in 121.485736s 45.095958s 48.217309s 33.914847s 12.683382s 9.079982s
 10KiB of   0B literals      2.922        43.162         40.639          63.266        164.019        236.745 i/s -     350.000 times in 119.766178s 8.108922s 8.612443s 5.532230s 2.133898s 1.478383s
100KiB of   0B literals      0.030         2.833          2.620           6.300         17.298         24.779 i/s -       3.000 times in 101.130973s 1.059097s 1.144915s 0.476176s 0.173433s 0.121069s

Comparison:
             100  B of   0B literals
4: chk too big (fa68d48):     23538.8 i/s
3: memo config (af9c496):     16574.5 i/s - 1.42x  slower
2: get literal (abed457):      6277.5 i/s - 3.75x  slower
1: end_with?   (796f268):      4879.0 i/s - 4.82x  slower
0: rindex re   (240bf42):      4804.6 i/s - 4.90x  slower
                 v0.6.3:      4145.2 i/s - 5.68x  slower

               1KiB of   0B literals
4: chk too big (fa68d48):      2385.9 i/s
3: memo config (af9c496):      1708.1 i/s - 1.40x  slower
2: get literal (abed457):       638.8 i/s - 3.74x  slower
0: rindex re   (240bf42):       480.4 i/s - 4.97x  slower
1: end_with?   (796f268):       449.3 i/s - 5.31x  slower
                 v0.6.3:       178.3 i/s - 13.38x  slower

              10KiB of   0B literals
4: chk too big (fa68d48):       236.7 i/s
3: memo config (af9c496):       164.0 i/s - 1.44x  slower
2: get literal (abed457):        63.3 i/s - 3.74x  slower
0: rindex re   (240bf42):        43.2 i/s - 5.48x  slower
1: end_with?   (796f268):        40.6 i/s - 5.83x  slower
                 v0.6.3:         2.9 i/s - 81.01x  slower

             100KiB of   0B literals
4: chk too big (fa68d48):        24.8 i/s
3: memo config (af9c496):        17.3 i/s - 1.43x  slower
2: get literal (abed457):         6.3 i/s - 3.93x  slower
0: rindex re   (240bf42):         2.8 i/s - 8.75x  slower
1: end_with?   (796f268):         2.6 i/s - 9.46x  slower
                 v0.6.3:         0.0 i/s - 835.31x  slower
```

</details>

* `100  B: 23538.8 i/s vs 4145.2 i/s -   5.68x slower`
* `100KiB:    24.8 i/s vs    0.0 i/s - 835.31x slower`

##### With YJIT

<details><summary><tt>benchmark-driver benchmarks/response_reader.yml --filter "0B literals" --run-duration 120</tt></summary>

```console
Warming up --------------------------------------
100  B of   0B literals     5.810k i/s -    232.934k times in 40.089911s (172.11μs/i)
  1KiB of   0B literals    213.312 i/s -      8.536k times in 40.016417s (4.69ms/i)
 10KiB of   0B literals      2.815 i/s -     113.000 times in 40.146352s (355.28ms/i)
100KiB of   0B literals      0.031 i/s -       2.000 times in 64.013721s (32.01s/i)
Calculating -------------------------------------
                            v0.6.3  0: rindex re   1: end_with?  2: get literal 3: memo config 4: chk too big
                                       (240bf42)      (796f268)       (abed457)      (af9c496)      (fa68d48)
100  B of   0B literals     5.749k        7.238k         7.008k         10.330k        28.149k        37.705k i/s -    697.234k times in 121.273734s 96.335818s 99.488280s 67.493836s 24.769239s 18.491636s
  1KiB of   0B literals    208.643       702.495        698.019         996.627         2.850k         3.868k i/s -     25.597k times in 122.683392s 36.437274s 36.670915s 25.683642s 8.980777s 6.618460s
 10KiB of   0B literals      2.902        68.137         67.165          97.795        284.644        334.559 i/s -     337.000 times in 116.107522s 4.945953s 5.017512s 3.445969s 1.183937s 1.007297s
100KiB of   0B literals      0.031         3.775          3.791           7.824         14.033         11.805 i/s -       3.000 times in 95.495082s 0.794680s 0.791374s 0.383412s 0.213775s 0.254128s

Comparison:
             100  B of   0B literals
4: chk too big (fa68d48):     37705.4 i/s
3: memo config (af9c496):     28149.2 i/s - 1.34x  slower
2: get literal (abed457):     10330.3 i/s - 3.65x  slower
0: rindex re   (240bf42):      7237.5 i/s - 5.21x  slower
1: end_with?   (796f268):      7008.2 i/s - 5.38x  slower
                 v0.6.3:      5749.3 i/s - 6.56x  slower

               1KiB of   0B literals
4: chk too big (fa68d48):      3867.5 i/s
3: memo config (af9c496):      2850.2 i/s - 1.36x  slower
2: get literal (abed457):       996.6 i/s - 3.88x  slower
0: rindex re   (240bf42):       702.5 i/s - 5.51x  slower
1: end_with?   (796f268):       698.0 i/s - 5.54x  slower
                 v0.6.3:       208.6 i/s - 18.54x  slower

              10KiB of   0B literals
4: chk too big (fa68d48):       334.6 i/s
3: memo config (af9c496):       284.6 i/s - 1.18x  slower
2: get literal (abed457):        97.8 i/s - 3.42x  slower
0: rindex re   (240bf42):        68.1 i/s - 4.91x  slower
1: end_with?   (796f268):        67.2 i/s - 4.98x  slower
                 v0.6.3:         2.9 i/s - 115.27x  slower

             100KiB of   0B literals
3: memo config (af9c496):        14.0 i/s
4: chk too big (fa68d48):        11.8 i/s - 1.19x  slower
2: get literal (abed457):         7.8 i/s - 1.79x  slower
1: end_with?   (796f268):         3.8 i/s - 3.70x  slower
0: rindex re   (240bf42):         3.8 i/s - 3.72x  slower
                 v0.6.3:         0.0 i/s - 446.71x  slower

```
</details>

* `100  B: 37705.4 i/s vs 5749.3 i/s -   6.56x slower`
* `100KiB:    14.0 i/s vs    0.0 i/s - 446.71x slower`
