### PR TITLE
Pass an Exception to #raise

### DIFF
--- a/lib/net/imap/response_reader.rb
+++ b/lib/net/imap/response_reader.rb
@@ -70,11 +70,10 @@ module Net
         empty? ? 3 : done? ? 0 : (literal_size || 0) + 2
       end
 
-      def guard_response_too_large! = (raise exception if response_too_large?)
-
-      def exception(msg = nil)
-        ResponseTooLargeError.new(
-          msg, max_response_size:, bytes_read:, literal_size:,
+      def guard_response_too_large!
+        return unless response_too_large?
+        raise ResponseTooLargeError.new(
+          max_response_size:, bytes_read:, literal_size:,
         )
       end
 

--- a/lib/net/imap/response_reader.rb
+++ b/lib/net/imap/response_reader.rb
@@ -70,7 +70,7 @@ module Net
         empty? ? 3 : done? ? 0 : (literal_size || 0) + 2
       end
 
-      def guard_response_too_large! = (raise self if response_too_large?)
+      def guard_response_too_large! = (raise exception if response_too_large?)
 
       def exception(msg = nil)
         ResponseTooLargeError.new(

--- a/test/net/imap/fake_server/test_helper.rb
+++ b/test/net/imap/fake_server/test_helper.rb
@@ -16,6 +16,7 @@ module Net::IMAP::FakeServer::TestHelper
   def run_fake_server_in_thread(ignore_io_error: false,
                                 report_on_exception: true,
                                 timeout: 10, **opts)
+    timeout *= EnvUtil.timeout_scale || 1 if defined?(EnvUtil.timeout_scale)
     Timeout.timeout(timeout) do
       server = Net::IMAP::FakeServer.new(timeout: timeout, **opts)
       @threads << Thread.new do

--- a/test/net/imap/test_imap_max_response_size.rb
+++ b/test/net/imap/test_imap_max_response_size.rb
@@ -36,6 +36,7 @@ class IMAPMaxResponseSizeTest < Net::IMAP::TestCase
     Net::IMAP.config.max_response_size = 1<<20
     with_fake_server(preauth: false, ignore_io_error: true) do |server, client|
       client.max_response_size = 50
+      client.noop # will reset response_reader, so the above config takes effect
       server.on("NOOP") do |resp|
         resp.untagged("1 FETCH (BODY[] {1000}\r\n" + "a" * 1000 + ")")
       end


### PR DESCRIPTION
* Fixes `TypeError: exception class/object expected` on truffleruby because #raise with a non-Exception non-String is not supported currently on TruffleRuby.

Unfortunately it seems https://github.com/ruby/net-imap/pull/642 broke on TruffleRuby and because of https://github.com/ruby/test-unit-ruby-core/pull/23 it wasn't noticed.

In this PR I do an easy fix for [this failure](https://github.com/eregon/net-imap/actions/runs/24559483023/job/71804267846#step:5:38).
However after that the test suite still fails with a timeout.

I also tried increasing the timeout (from 10 to 100 [commit](https://github.com/ruby/net-imap/compare/master...eregon:net-imap:apply_timeout_scale)) but it did not help.
When that test is run in isolation (`bundle exec ruby -Itest/lib -rhelper test/net/imap/test_imap_max_response_size.rb`) it works fine though, so it sounds like there is some global state/side effect that makes the test fail somehow when run as part of the full test suite.

I don't have time to investigate more now, maybe I can take another look in the evening.