### PR TITLE
🐛 Fix empty `SearchResult#to_sequence_set`

### DIFF
--- a/lib/net/imap/search_result.rb
+++ b/lib/net/imap/search_result.rb
@@ -123,6 +123,10 @@ module Net
       #     Net::IMAP::SearchResult[9, 1, 2, 4, 10, 12, 3, modseq: 123_456]
       #       .to_sequence_set
       #     # => Net::IMAP::SequenceSet["1:4,9:10,12"]
+      #
+      # >>>
+      #   *NOTE:* +SORT+ order is not preserved.  The result will be sorted.
+      #
       def to_sequence_set; empty? ? SequenceSet.empty : SequenceSet[to_a] end
 
       def pretty_print(pp)

--- a/lib/net/imap/search_result.rb
+++ b/lib/net/imap/search_result.rb
@@ -123,7 +123,7 @@ module Net
       #     Net::IMAP::SearchResult[9, 1, 2, 4, 10, 12, 3, modseq: 123_456]
       #       .to_sequence_set
       #     # => Net::IMAP::SequenceSet["1:4,9:10,12"]
-      def to_sequence_set; SequenceSet[*self] end
+      def to_sequence_set; empty? ? SequenceSet.empty : SequenceSet[to_a] end
 
       def pretty_print(pp)
         return super if modseq.nil?

--- a/test/net/imap/test_search_result.rb
+++ b/test/net/imap/test_search_result.rb
@@ -89,4 +89,21 @@ class SearchDataTests < Net::IMAP::TestCase
     assert_equal("99 111 44 (MODSEQ 999)",
                  Net::IMAP::SearchResult[99, 111, 44, modseq: 999].to_s(nil))
   end
+
+  test "#to_sequence_set" do
+    assert_equal("1,3", Net::IMAP::SearchResult[1, 3].to_sequence_set.to_s)
+    assert Net::IMAP::SearchResult[1, 3].to_sequence_set.frozen?
+    assert_equal("1:3", Net::IMAP::SearchResult[1, 2, 3].to_sequence_set.to_s)
+    assert_equal(
+      "44,99,111",
+      Net::IMAP::SearchResult[99, 111, 44, modseq: 999].to_sequence_set.to_s
+    )
+    assert_equal(
+      "1:4,9:10,12",
+      Net::IMAP::SearchResult[9, 1, 2, 3, 4, 10, 12].to_sequence_set.to_s
+    )
+    assert_equal(Net::IMAP::SequenceSet.empty,
+                 Net::IMAP::SearchResult[].to_sequence_set)
+    assert Net::IMAP::SearchResult[].to_sequence_set.frozen?
+  end
 end


### PR DESCRIPTION
This provides the same behavior as `ESearchResult` (except it still doesn't preserve `SORT` order).

Fixes #641.