### PR TITLE
✨ Support `LITERAL+` and `LITERAL-` non-synchronizing literals (RFC7888)

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -450,8 +450,8 @@ module Net
   #
   # Although IMAP4rev2[https://www.rfc-editor.org/rfc/rfc9051] is not supported
   # yet, Net::IMAP supports several extensions that have been folded into it:
-  # +ENABLE+, +IDLE+, +MOVE+, +NAMESPACE+, +SASL-IR+, +UIDPLUS+, +UNSELECT+,
-  # <tt>STATUS=SIZE</tt>, and the fetch side of +BINARY+.
+  # +ENABLE+, +IDLE+, +LITERAL-+, +MOVE+, +NAMESPACE+, +SASL-IR+, +UIDPLUS+,
+  # +UNSELECT+, <tt>STATUS=SIZE</tt>, and the fetch side of +BINARY+.
   # Commands for these extensions are listed with the {Core IMAP
   # commands}[rdoc-ref:Net::IMAP@Core+IMAP+commands], above.
   #
@@ -459,7 +459,7 @@ module Net
   #   <em>The following are folded into +IMAP4rev2+ but are currently
   #   unsupported or incompletely supported by</em> Net::IMAP<em>: RFC4466
   #   extensions, +SEARCHRES+, +LIST-EXTENDED+, +LIST-STATUS+,
-  #   +LITERAL-+, and +SPECIAL-USE+.</em>
+  #   and +SPECIAL-USE+.</em>
   #
   # ==== RFC2087: +QUOTA+
   # +NOTE:+ Only the +STORAGE+ quota resource type is currently supported.
@@ -568,6 +568,15 @@ module Net
   #   +MODSEQ+ FetchData attribute.
   # - Updates #store and #uid_store with the +unchangedsince+ modifier and adds
   #   the +MODIFIED+ ResponseCode to the tagged response.
+  #
+  # ==== RFC7888: <tt>LITERAL+</tt>
+  # - Literal strings smaller than Config#max_non_synchronizing_literal bytes
+  #   are sent without waiting for the server's continuation request.
+  #
+  # ==== RFC7888: +LITERAL-+
+  # - Literal strings smaller than 4096 bytes or
+  #   Config#max_non_synchronizing_literal (whichever is smaller)
+  #   are sent without waiting for the server's continuation request.
   #
   # ==== RFC8438: <tt>STATUS=SIZE</tt>
   # - Updates #status with the +SIZE+ status attribute.

--- a/lib/net/imap/command_data.rb
+++ b/lib/net/imap/command_data.rb
@@ -4,6 +4,8 @@ require "date"
 
 require_relative "errors"
 
+# :enddoc:
+
 module Net
   class IMAP < Protocol
 

--- a/lib/net/imap/command_data.rb
+++ b/lib/net/imap/command_data.rb
@@ -86,9 +86,9 @@ module Net
     #   TODO: raise or warn when capabilities don't allow non_sync.
     # * `false` -> Force normal synchronizing literal behavior.
     # * `nil`   -> (default) Currently behaves like `false` (will be dynamic).
-    #   TODO: Dynamic, based on capabilities and bytesize.
     def send_literal(str, tag = nil, binary: false, non_sync: nil)
       synchronize do
+        non_sync = non_sync_literal?(str.bytesize) if non_sync.nil?
         prefix = "~" if binary
         plus = "+" if non_sync
         put_string("#{prefix}{#{str.bytesize}#{plus}}\r\n")
@@ -108,6 +108,13 @@ module Net
           @continuation_request_exception = nil
         end
       end
+    end
+
+    def non_sync_literal?(bytesize)
+      capabilities_cached? &&
+        bytesize <= config.max_non_synchronizing_literal &&
+        (capable?("LITERAL+") ||
+         bytesize <= 4096 && (capable?("IMAP4rev2") || capable?("LITERAL-")))
     end
 
     def send_number_data(num)

--- a/lib/net/imap/command_data.rb
+++ b/lib/net/imap/command_data.rb
@@ -77,12 +77,23 @@ module Net
       put_string('"' + str.gsub(/["\\]/, "\\\\\\&") + '"')
     end
 
-    def send_binary_literal(str, tag) = send_literal(str, tag, binary: true)
+    def send_binary_literal(*, **) = send_literal(*, **, binary: true)
 
-    def send_literal(str, tag = nil, binary: false)
+    # `non_sync` is an optional tri-state flag:
+    # * `true`  -> Force non-synchronizing `LITERAL+`/`LITERAL-` behavior.
+    #   TODO: raise or warn when capabilities don't allow non_sync.
+    # * `false` -> Force normal synchronizing literal behavior.
+    # * `nil`   -> (default) Currently behaves like `false` (will be dynamic).
+    #   TODO: Dynamic, based on capabilities and bytesize.
+    def send_literal(str, tag = nil, binary: false, non_sync: nil)
       synchronize do
         prefix = "~" if binary
-        put_string("#{prefix}{#{str.bytesize}}\r\n")
+        plus = "+" if non_sync
+        put_string("#{prefix}{#{str.bytesize}#{plus}}\r\n")
+        if non_sync
+          put_string(str)
+          return
+        end
         @continued_command_tag = tag
         @continuation_request_exception = nil
         begin
@@ -149,8 +160,14 @@ module Net
       end
     end
 
-    class Literal < CommandData # :nodoc:
-      def initialize(data:)
+    class Literal < Data.define(:data, :non_sync) # :nodoc:
+      def self.validate(...)
+        data = new(...)
+        data.validate
+        data
+      end
+
+      def initialize(data:, non_sync: nil)
         data = -String(data.to_str).b or
           raise DataFormatError, "#{self.class} expects string input"
         super
@@ -167,7 +184,7 @@ module Net
       end
 
       def send_data(imap, tag)
-        imap.__send__(:send_literal, data, tag)
+        imap.__send__(:send_literal, data, tag, non_sync:)
       end
     end
 
@@ -175,7 +192,7 @@ module Net
       def validate = nil # all bytes are okay
 
       def send_data(imap, tag)
-        imap.__send__(:send_binary_literal, data, tag)
+        imap.__send__(:send_binary_literal, data, tag, non_sync:)
       end
     end
 

--- a/lib/net/imap/config.rb
+++ b/lib/net/imap/config.rb
@@ -281,6 +281,40 @@ module Net
         0.5r => true,
       }
 
+      # The maximum bytesize for sending non-synchronizing literals, when the
+      # server supports them.  To disable non-synchronizing literals, set the
+      # value to +-1+.
+      #
+      # Non-synchronizing literals are only sent when the server's
+      # capabilities[rdoc-ref:IMAP#capabilities] have been
+      # cached[rdoc-ref:IMAP#capabilities_cached?] and include either
+      # <tt>LITERAL+</tt> [RFC7888[https://www.rfc-editor.org/rfc/rfc7888]],
+      # <tt>LITERAL-</tt> [RFC7888[https://www.rfc-editor.org/rfc/rfc7888]], or
+      # +IMAP4rev2+ [RFC9051[https://www.rfc-editor.org/rfc/rfc9051]].
+      #
+      # For <tt>LITERAL+</tt>, this value is the only limit on whether a literal
+      # value is sent as non-synchronizing literals.  For <tt>LITERAL-</tt> and
+      # <tt>IMAP4rev2</tt>, non-synchronizing literals must also be smaller than
+      # +4096+ bytes.
+      #
+      # Non-synchronizing literals avoid the latency of waiting for the server
+      # to allow continuation.  However, if a client sends a non-synchronizing
+      # literal that is too large for the server, the server may need to close
+      # the connection.  Because <tt>LITERAL+</tt> does not directly indicate
+      # the server's limits, it's best to avoid sending very large
+      # non-synchronized literals.
+      #
+      # ==== Versioned Defaults
+      #
+      # max_non_synchronizing_literal <em>was added in +v0.6.4+.</em>
+      #
+      # * original: +-1+ (_never_ send non-synchronizing literals)
+      # * +0.6+: 16 KiB
+      attr_accessor :max_non_synchronizing_literal, type: Integer?, defaults: {
+        0.0r => -1,
+        0.6r => 16 << 16, # 16 KiB
+      }
+
       # The maximum allowed server response size.  When +nil+, there is no limit
       # on response size.
       #

--- a/test/net/imap/fake_server.rb
+++ b/test/net/imap/fake_server.rb
@@ -103,6 +103,10 @@ class Net::IMAP::FakeServer
   # See CommandRouter#on
   def on(...) connection&.on(...) end
 
+  # See CommandRouter#literal_acceptor
+  def literal_acceptor = connection&.literal_acceptor
+  def literal_acceptor=(v); connection.literal_acceptor = v end
+
   # See Connection#unsolicited
   def unsolicited(...) @mutex.synchronize { connection&.unsolicited(...) } end
 

--- a/test/net/imap/fake_server/command_reader.rb
+++ b/test/net/imap/fake_server/command_reader.rb
@@ -7,10 +7,12 @@ class Net::IMAP::FakeServer
 
   class CommandReader
     attr_reader :last_command
+    attr_accessor :literal_acceptor
 
     def initialize(socket)
       @socket = socket
       @last_command = nil
+      @literal_acceptor = proc {|buff, size| true }
     end
 
     def get_command
@@ -19,8 +21,17 @@ class Net::IMAP::FakeServer
         s = socket.gets("\r\n") or break
         buf << s
         break unless /\{(\d+)(\+)?\}\r\n\z/n =~ buf
-        $2 or socket.print "+ Continue\r\n"
-        buf << socket.read(Integer($1))
+        bytes = Integer($1)
+        if $2
+          buf << socket.read(bytes)
+        elsif literal_acceptor[buf, bytes]
+          socket.print "+ Continue\r\n"
+          buf << socket.read(bytes)
+        else
+          partial = partial_parse(buf)
+          socket.print "#{partial.tag} NO #{bytes} byte literal rejected\r\n"
+          buf = "".b
+        end
       end
       throw :eof if buf.empty?
       @last_command = parse(buf)
@@ -43,6 +54,7 @@ class Net::IMAP::FakeServer
         Command.new $1, $2, $3, buf # TODO...
       end
     end
+    alias partial_parse parse
 
     # TODO: this is not the correct regexp, and literals aren't handled either
     def scan_astrings(str)

--- a/test/net/imap/fake_server/connection.rb
+++ b/test/net/imap/fake_server/connection.rb
@@ -22,6 +22,9 @@ class Net::IMAP::FakeServer
     def on(...) router.on(...) end
     def unsolicited(...) writer.untagged(...) end
 
+    def literal_acceptor =   reader.literal_acceptor
+    def literal_acceptor=(v) reader.literal_acceptor = v end
+
     def run
       writer.greeting
       catch(:eof) do

--- a/test/net/imap/test_command_data.rb
+++ b/test/net/imap/test_command_data.rb
@@ -9,7 +9,7 @@ class CommandDataTest < Net::IMAP::TestCase
   Literal = Net::IMAP::Literal
   Literal8 = Net::IMAP::Literal8
 
-  Output = Data.define(:name, :args)
+  Output = Data.define(:name, :args, :kwargs)
   TAG = Module.new.freeze
 
   class FakeCommandWriter
@@ -18,11 +18,15 @@ class CommandDataTest < Net::IMAP::TestCase
           Net::IMAP.private_instance_methods.include?(name)
         raise NoMethodError, "#{name} is not a method on Net::IMAP"
       end
-      define_method(name) do |*args|
-        output << Output[name:, args:]
+      define_method(name) do |*args, **kwargs|
+        kwargs = kwargs.compact
+        kwargs = nil if kwargs.empty?
+        output << Output[name:, args:, kwargs:]
       end
-      Output.define_singleton_method(name) do |*args|
-        new(name:, args:)
+      Output.define_singleton_method(name) do |*args, **kwargs|
+        kwargs = kwargs.compact
+        kwargs = nil if kwargs.empty?
+        new(name:, args:, kwargs:)
       end
     end
 
@@ -58,8 +62,12 @@ class CommandDataTest < Net::IMAP::TestCase
 
   test "Literal" do
     imap.send_data Literal["foo\r\nbar"]
+    imap.send_data Literal["foo\r\nbar", false]
+    imap.send_data Literal["foo\r\nbar", true]
     assert_equal [
       Output.send_literal("foo\r\nbar", TAG),
+      Output.send_literal("foo\r\nbar", TAG, non_sync: false),
+      Output.send_literal("foo\r\nbar", TAG, non_sync: true),
     ], imap.output
 
     imap.clear
@@ -71,9 +79,13 @@ class CommandDataTest < Net::IMAP::TestCase
 
   test "Literal8" do
     imap.send_data Literal8["foo\r\nbar"], Literal8["foo\0bar"]
+    imap.send_data Literal8["foo\0bar", false]
+    imap.send_data Literal8["foo\0bar", true]
     assert_equal [
       Output.send_binary_literal("foo\r\nbar", TAG),
       Output.send_binary_literal("foo\0bar", TAG),
+      Output.send_binary_literal("foo\0bar", TAG, non_sync: false),
+      Output.send_binary_literal("foo\0bar", TAG, non_sync: true),
     ], imap.output
   end
 

--- a/test/net/imap/test_command_data.rb
+++ b/test/net/imap/test_command_data.rb
@@ -50,8 +50,13 @@ class CommandDataTest < Net::IMAP::TestCase
     def_printer :send_binary_literal
   end
 
+  attr_reader :imap
+
+  setup do
+    @imap = FakeCommandWriter.new
+  end
+
   test "Literal" do
-    imap = FakeCommandWriter.new
     imap.send_data Literal["foo\r\nbar"]
     assert_equal [
       Output.send_literal("foo\r\nbar", TAG),
@@ -65,7 +70,6 @@ class CommandDataTest < Net::IMAP::TestCase
   end
 
   test "Literal8" do
-    imap = FakeCommandWriter.new
     imap.send_data Literal8["foo\r\nbar"], Literal8["foo\0bar"]
     assert_equal [
       Output.send_binary_literal("foo\r\nbar", TAG),

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -672,40 +672,36 @@ class IMAPTest < Net::IMAP::TestCase
     end
   end
 
-  def test_send_literal
-    server = create_tcp_server
-    port = server.addr[1]
-    requests = []
-    literal = nil
-    start_server do
-      sock = server.accept
-      begin
-        sock.print("* OK test server\r\n")
-        line = sock.gets
-        requests.push(line)
-        size = line.slice(/{(\d+)}\r\n/, 1).to_i
-        sock.print("+ Ready for literal data\r\n")
-        literal = sock.read(size)
-        requests.push(sock.gets)
-        sock.print("RUBY0001 OK TEST completed\r\n")
-        sock.gets
-        sock.print("* BYE terminating connection\r\n")
-        sock.print("RUBY0002 OK LOGOUT completed\r\n")
-      ensure
-        sock.close
-        server.close
+  test("send literal args") do
+    with_fake_server do |server, imap|
+      server.on "TEST", &:done_ok
+      send_args = ->(*args) do
+        imap.__send__(:send_command, "TEST", *args)
       end
-    end
-    begin
-      imap = Net::IMAP.new(server_addr, :port => port)
-      imap.__send__(:send_command, "TEST", ["\xDE\xAD\xBE\xEF".b])
-      assert_equal(2, requests.length)
-      assert_equal("RUBY0001 TEST ({4}\r\n", requests[0])
-      assert_equal("\xDE\xAD\xBE\xEF".b, literal)
-      assert_equal(")\r\n", requests[1])
-      imap.logout
-    ensure
-      imap.disconnect
+      send_args.call ["\xDE\xAD\xBE\xEF".b]
+      assert_equal "({4}\r\n\xDE\xAD\xBE\xEF)".b, server.commands.pop.args
+
+      buff = bytes = nil
+      server.literal_acceptor = proc { buff, bytes = _1, _2; false }
+      assert_raise(Net::IMAP::NoResponseError) do
+        send_args.call Net::IMAP::Literal["\x01" * 10]
+      end
+      assert_match(/TEST \{10\}\r\n\z/, buff)
+      assert_equal 10, bytes
+      assert_empty server.commands
+
+      server.literal_acceptor = proc { true }
+      send_args.call Net::IMAP::Literal["\x01" * 10]
+      assert_equal "{10}\r\n\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01",
+        server.commands.pop.args
+
+      send_args.call("literal",   Net::IMAP::Literal["\r"],
+                     "literal8",  Net::IMAP::Literal8["\0" * 6],
+                     "done")
+      assert_equal("literal"   " {1}\r\n\r "                 \
+                   "literal8"  " ~{6}\r\n\0\0\0\0\0\0 "      \
+                    "done".b,
+                    server.commands.pop.args)
     end
   end
 

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -673,7 +673,9 @@ class IMAPTest < Net::IMAP::TestCase
   end
 
   test("send literal args") do
-    with_fake_server do |server, imap|
+    with_fake_server(with_extensions: %w[LITERAL-]) do |server, imap|
+      # disable automatic non-synchronizing literals
+      imap.config.max_non_synchronizing_literal = -1
       server.on "TEST", &:done_ok
       send_args = ->(*args) do
         imap.__send__(:send_command, "TEST", *args)
@@ -681,12 +683,28 @@ class IMAPTest < Net::IMAP::TestCase
       send_args.call ["\xDE\xAD\xBE\xEF".b]
       assert_equal "({4}\r\n\xDE\xAD\xBE\xEF)".b, server.commands.pop.args
 
+      # enable automatic non-synchronizing literals
+      imap.config.max_non_synchronizing_literal = 1024
       buff = bytes = nil
       server.literal_acceptor = proc { buff, bytes = _1, _2; false }
-      assert_raise(Net::IMAP::NoResponseError) do
-        send_args.call Net::IMAP::Literal["\x01" * 10]
+      server.on "TEST", &:done_ok
+      send_args = ->(*args) do
+        imap.__send__(:send_command, "TEST", *args)
       end
-      assert_match(/TEST \{10\}\r\n\z/, buff)
+      send_args.call ["\xDE\xAD\xBE\xEF".b]
+      assert_equal "({4+}\r\n\xDE\xAD\xBE\xEF)".b, server.commands.pop.args
+      assert_nil buff
+      assert_nil bytes
+
+      # limited automatic non-synchronizing literals
+      imap.config.max_non_synchronizing_literal = 5
+      assert_raise(Net::IMAP::NoResponseError) do
+        send_args.call [
+          Net::IMAP::Literal["\rhi\r"],
+          Net::IMAP::Literal["\x01" * 10],
+        ]
+      end
+      assert_match(/TEST \(\{4\+\}\r\n\rhi\r \{10\}\r\n\z/, buff)
       assert_equal 10, bytes
       assert_empty server.commands
 
@@ -703,18 +721,23 @@ class IMAPTest < Net::IMAP::TestCase
       assert_nil buff
       assert_nil bytes
 
+      imap.config.max_non_synchronizing_literal = 5
       server.literal_acceptor = proc { true }
       send_args.call("literal",   Net::IMAP::Literal["\r",       false],
+                     "literal",   Net::IMAP::Literal["αβ",         nil],
                      "literal",   Net::IMAP::Literal["αβγδε",      nil],
                      "literal+",  Net::IMAP::Literal["αβγδε",     true],
                      "literal8",  Net::IMAP::Literal8["\0",      false],
+                     "literal8+", Net::IMAP::Literal8["\0" * 2,    nil],
                      "literal8",  Net::IMAP::Literal8["\0" * 6,    nil],
                      "literal8+", Net::IMAP::Literal8["\0" * 8,   true],
                      "done")
       assert_equal("literal"   " {1}\r\n\r "                 \
+                   "literal"   " {4+}\r\nαβ "                \
                    "literal"   " {10}\r\nαβγδε "             \
                    "literal+"  " {10+}\r\nαβγδε "            \
                    "literal8"  " ~{1}\r\n\0 "                \
+                   "literal8+" " ~{2+}\r\n\0\0 "             \
                    "literal8"  " ~{6}\r\n\0\0\0\0\0\0 "      \
                    "literal8+" " ~{8+}\r\n\0\0\0\0\0\0\0\0 " \
                    "done".b,

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -695,13 +695,30 @@ class IMAPTest < Net::IMAP::TestCase
       assert_equal "{10}\r\n\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01",
         server.commands.pop.args
 
-      send_args.call("literal",   Net::IMAP::Literal["\r"],
-                     "literal8",  Net::IMAP::Literal8["\0" * 6],
+      buff = bytes = nil
+      server.literal_acceptor = proc { buff, bytes = _1, _2; false }
+      send_args.call("nonsync",
+                     Net::IMAP::Literal[data: "\x01\x02\x03", non_sync: true])
+      assert_equal "nonsync {3+}\r\n\x01\x02\03".b, server.commands.pop.args
+      assert_nil buff
+      assert_nil bytes
+
+      server.literal_acceptor = proc { true }
+      send_args.call("literal",   Net::IMAP::Literal["\r",       false],
+                     "literal",   Net::IMAP::Literal["αβγδε",      nil],
+                     "literal+",  Net::IMAP::Literal["αβγδε",     true],
+                     "literal8",  Net::IMAP::Literal8["\0",      false],
+                     "literal8",  Net::IMAP::Literal8["\0" * 6,    nil],
+                     "literal8+", Net::IMAP::Literal8["\0" * 8,   true],
                      "done")
       assert_equal("literal"   " {1}\r\n\r "                 \
+                   "literal"   " {10}\r\nαβγδε "             \
+                   "literal+"  " {10+}\r\nαβγδε "            \
+                   "literal8"  " ~{1}\r\n\0 "                \
                    "literal8"  " ~{6}\r\n\0\0\0\0\0\0 "      \
-                    "done".b,
-                    server.commands.pop.args)
+                   "literal8+" " ~{8+}\r\n\0\0\0\0\0\0\0\0 " \
+                   "done".b,
+                   server.commands.pop.args)
     end
   end
 


### PR DESCRIPTION
Non-synchronizing literals avoid the latency of waiting for the server to allow continuation.  Non-synchronizing literals are only sent when the server's capabilities have been already been cached and include either `LITERAL+` [[RFC7888](https://www.rfc-editor.org/rfc/rfc7888)], `LITERAL-` [[RFC7888](https://www.rfc-editor.org/rfc/rfc7888)], or `IMAP4rev2` [[RFC9051](https://www.rfc-editor.org/rfc/rfc9051)].

However, if a client sends a non-synchronizing literal that is too large for the server, the server may need to close the connection.  Because `LITERAL+` does not directly indicate the server's limits, it's best to avoid sending very large non-synchronized literals.  This also adds `Config#max_non_synchronizing_literal`: the maximum bytesize for non-synchronizing literals.  To disable non-synchronizing literals, set the value to `-1`.

For `LITERAL+`, `config.max_non_synchronizing_literal` is the only limit on whether a literal value is sent as a non-synchronizing literal.  For `LITERAL-` and `IMAP4rev2`, non-synchronizing literals must also be smaller than `4096` bytes.

By default, `config.max_non_synchronizing_literal` is set to 16 KiB.  But servers are much more likely to support `LITERAL-` than `LITERAL+`, so the practical limit will be 4096.
