### PR TITLE
⚡ Much faster ResponseReader performance (backports #642)

### DIFF
--- a/lib/net/imap/response_reader.rb
+++ b/lib/net/imap/response_reader.rb
@@ -32,7 +32,10 @@ module Net
       def empty?;           buff.empty?                           end
       def done?;            line_done? && !get_literal_size       end
       def line_done?;       buff.end_with?(CRLF)                  end
-      def get_literal_size; buff.rindex(/\{(\d+)\}\r\n\z/n) && $1.to_i end
+
+      def get_literal_size
+        buff.end_with?("}\r\n") && buff.rindex(/\{(\d+)\}\r\n\z/n) && $1.to_i
+      end
 
       def read_line
         buff << (@sock.gets(CRLF, read_limit) or throw :eof)

--- a/lib/net/imap/response_reader.rb
+++ b/lib/net/imap/response_reader.rb
@@ -8,6 +8,7 @@ module Net
 
       def initialize(client, sock)
         @client, @sock = client, sock
+        @buff = @literal_size = nil
       end
 
       def read_response_buffer
@@ -15,13 +16,13 @@ module Net
         catch :eof do
           while true
             read_line
-            break unless (@literal_size = get_literal_size)
+            break unless literal_size
             read_literal
           end
         end
         buff
       ensure
-        @buff = nil
+        @buff = @literal_size = nil
       end
 
       private
@@ -31,15 +32,18 @@ module Net
       def bytes_read;       buff.bytesize                         end
       def empty?;           buff.empty?                           end
       def done?;            line_done? && !get_literal_size       end
+      def done?;            line_done? && !literal_size           end
       def line_done?;       buff.end_with?(CRLF)                  end
 
-      def get_literal_size
+      def get_literal_size(buff)
         buff.end_with?("}\r\n") && buff.rindex(/\{(\d+)\}\r\n\z/n) && $1.to_i
       end
 
       def read_line
-        buff << (@sock.gets(CRLF, read_limit) or throw :eof)
+        line = (@sock.gets(CRLF, read_limit) or throw :eof)
+        buff << line
         max_response_remaining! unless line_done?
+        @literal_size = get_literal_size(line)
       end
 
       def read_literal

--- a/lib/net/imap/response_reader.rb
+++ b/lib/net/imap/response_reader.rb
@@ -32,7 +32,7 @@ module Net
       def empty?;           buff.empty?                           end
       def done?;            line_done? && !get_literal_size       end
       def line_done?;       buff.end_with?(CRLF)                  end
-      def get_literal_size; /\{(\d+)\}\r\n\z/n =~ buff && $1.to_i end
+      def get_literal_size; buff.rindex(/\{(\d+)\}\r\n\z/n) && $1.to_i end
 
       def read_line
         buff << (@sock.gets(CRLF, read_limit) or throw :eof)

--- a/test/net/imap/test_response_reader.rb
+++ b/test/net/imap/test_response_reader.rb
@@ -57,7 +57,7 @@ class ResponseReaderTest < Test::Unit::TestCase
     exact = "+ 345678\r\n"
     very_over     = "+ 3456789 #{?a * (16<<10)}}\r\n"
     slightly_over = "+ 34567890\r\n" # CRLF after the limit
-    io = StringIO.new([under, exact, very_over, slightly_over].join)
+    io = StringIO.new([under, exact, very_over, slightly_over].join, "rb")
     rcvr = Net::IMAP::ResponseReader.new(client, io)
     assert_equal under, rcvr.read_response_buffer.to_str
     assert_equal exact, rcvr.read_response_buffer.to_str
@@ -65,7 +65,7 @@ class ResponseReaderTest < Test::Unit::TestCase
       result = rcvr.read_response_buffer
       flunk "Got result: %p" % [result]
     end
-    io = StringIO.new(slightly_over)
+    io = StringIO.new(slightly_over, "rb")
     rcvr = Net::IMAP::ResponseReader.new(client, io)
     assert_raise Net::IMAP::ResponseTooLargeError do
       result = rcvr.read_response_buffer
@@ -77,7 +77,7 @@ class ResponseReaderTest < Test::Unit::TestCase
     barely_over = "+ 3456789\r\n"  # CRLF straddles the boundary
     client = FakeClient.new
     client.config.max_response_size = 10
-    io = StringIO.new(barely_over)
+    io = StringIO.new(barely_over, "rb")
     rcvr = Net::IMAP::ResponseReader.new(client, io)
     assert_raise Net::IMAP::ResponseTooLargeError do
       result = rcvr.read_response_buffer


### PR DESCRIPTION
This backports the first several commits from #642 to `v0.4-stable`.  While the other commits also improve performance, this is all that is needed to improve the algorithmic complexity from O(n²) to O(n).

Also the other commits add a minor breaking change.