### PR TITLE
♻️  Improve internal literal sending (partially backports #358, #616, #649)

### DIFF
--- a/lib/net/imap/command_data.rb
+++ b/lib/net/imap/command_data.rb
@@ -176,6 +176,21 @@ module Net
     end
 
     class Literal < CommandData # :nodoc:
+      def initialize(data:)
+        data = -String(data.to_str).b or
+          raise DataFormatError, "#{self.class} expects string input"
+        super
+        validate
+      end
+
+      def bytesize; data.bytesize end
+
+      def validate
+        if data.include?("\0")
+          raise DataFormatError, "NULL byte not allowed in #{self.class}."
+        end
+      end
+
       def send_data(imap, tag)
         imap.__send__(:send_literal, @data, tag)
       end

--- a/lib/net/imap/command_data.rb
+++ b/lib/net/imap/command_data.rb
@@ -77,12 +77,23 @@ module Net
       put_string('"' + str.gsub(/["\\]/, "\\\\\\&") + '"')
     end
 
-    def send_binary_literal(str, tag) send_literal(str, tag, binary: true) end
+    def send_binary_literal(*a, **kw) send_literal(*a, **kw, binary: true) end
 
-    def send_literal(str, tag = nil, binary: false)
+    # `non_sync` is an optional tri-state flag:
+    # * `true`  -> Force non-synchronizing `LITERAL+`/`LITERAL-` behavior.
+    #   TODO: raise or warn when capabilities don't allow non_sync.
+    # * `false` -> Force normal synchronizing literal behavior.
+    # * `nil`   -> (default) Currently behaves like `false` (will be dynamic).
+    #   TODO: Dynamic, based on capabilities and bytesize.
+    def send_literal(str, tag = nil, binary: false, non_sync: nil)
       synchronize do
         prefix = "~" if binary
-        put_string("#{prefix}{#{str.bytesize}}\r\n")
+        plus = "+" if non_sync
+        put_string("#{prefix}{#{str.bytesize}#{plus}}\r\n")
+        if non_sync
+          put_string(str)
+          return
+        end
         @continued_command_tag = tag
         @continuation_request_exception = nil
         begin
@@ -178,12 +189,32 @@ module Net
       end
     end
 
-    class Literal < CommandData # :nodoc:
-      def initialize(data:)
+    class Literal # :nodoc:
+      class << self
+        def new(_data = nil, _non_sync = nil, data: _data, non_sync: _non_sync)
+          super(data: data, non_sync: non_sync)
+        end
+        alias :[] :new
+      end
+
+      attr_reader :data, :non_sync
+
+      def to_h(&block) block ? to_h.to_h(&block) : { data: data, non_sync: non_sync } end
+      def ==(other)   self.class === other && to_h  ==  other.to_h  end
+      def eql?(other) self.class === other && to_h.eql?(other.to_h) end
+
+      def initialize(data:, non_sync: nil)
         data = -String(data.to_str).b or
           raise DataFormatError, "#{self.class} expects string input"
-        super
+        @data, @non_sync = data, non_sync
         validate
+        freeze
+      end
+
+      def self.validate(...)
+        data = new(...)
+        data.validate
+        data
       end
 
       def bytesize; data.bytesize end
@@ -196,7 +227,7 @@ module Net
       end
 
       def send_data(imap, tag)
-        imap.__send__(:send_literal, @data, tag)
+        imap.__send__(:send_literal, data, tag, non_sync: non_sync)
       end
     end
 
@@ -204,7 +235,7 @@ module Net
       def validate; nil end # all bytes are okay
 
       def send_data(imap, tag)
-        imap.__send__(:send_binary_literal, data, tag)
+        imap.__send__(:send_binary_literal, data, tag, non_sync: non_sync)
       end
     end
 

--- a/lib/net/imap/command_data.rb
+++ b/lib/net/imap/command_data.rb
@@ -119,33 +119,44 @@ module Net
       put_string("\\" + symbol.to_s)
     end
 
-    class RawData # :nodoc:
+    # simplistic emulation of CommandData = Data.define(:data)
+    class CommandData # :nodoc:
+      class << self
+        def new(arg = nil, data: arg) super(data: data) end
+        alias :[] :new
+      end
+
+      def initialize(data:)
+        @data = data
+        freeze
+      end
+
+      attr_reader :data
+
+      def to_h(&block) block ? to_h.to_h(&block) : { data: data } end
+      def ==(other)   self.class === other && to_h  ==  other.to_h  end
+      def eql?(other) self.class === other && to_h.eql?(other.to_h) end
+
+      # following class definition goes beyond the basic Data.define(:data)
+      ##
+
       def send_data(imap, tag)
-        imap.__send__(:put_string, @data)
+        raise NoMethodError, "#{self.class} must implement #{__method__}"
       end
 
       def validate
-      end
-
-      private
-
-      def initialize(data)
-        @data = data
       end
     end
 
-    class Atom # :nodoc:
+    class RawData < CommandData # :nodoc:
       def send_data(imap, tag)
         imap.__send__(:put_string, @data)
       end
+    end
 
-      def validate
-      end
-
-      private
-
-      def initialize(data)
-        @data = data
+    class Atom < CommandData # :nodoc:
+      def send_data(imap, tag)
+        imap.__send__(:put_string, @data)
       end
     end
 
@@ -164,18 +175,9 @@ module Net
       end
     end
 
-    class Literal # :nodoc:
+    class Literal < CommandData # :nodoc:
       def send_data(imap, tag)
         imap.__send__(:send_literal, @data, tag)
-      end
-
-      def validate
-      end
-
-      private
-
-      def initialize(data)
-        @data = data
       end
     end
 

--- a/lib/net/imap/command_data.rb
+++ b/lib/net/imap/command_data.rb
@@ -77,9 +77,12 @@ module Net
       put_string('"' + str.gsub(/["\\]/, "\\\\\\&") + '"')
     end
 
-    def send_literal(str, tag = nil)
+    def send_binary_literal(str, tag) send_literal(str, tag, binary: true) end
+
+    def send_literal(str, tag = nil, binary: false)
       synchronize do
-        put_string("{" + str.bytesize.to_s + "}" + CRLF)
+        prefix = "~" if binary
+        put_string("#{prefix}{#{str.bytesize}}\r\n")
         @continued_command_tag = tag
         @continuation_request_exception = nil
         begin
@@ -187,12 +190,21 @@ module Net
 
       def validate
         if data.include?("\0")
-          raise DataFormatError, "NULL byte not allowed in #{self.class}."
+          raise DataFormatError, "NULL byte not allowed in #{self.class}.  " \
+            "Use #{Literal8} or a null-safe encoding."
         end
       end
 
       def send_data(imap, tag)
         imap.__send__(:send_literal, @data, tag)
+      end
+    end
+
+    class Literal8 < Literal # :nodoc:
+      def validate; nil end # all bytes are okay
+
+      def send_data(imap, tag)
+        imap.__send__(:send_binary_literal, data, tag)
       end
     end
 

--- a/test/net/imap/fake_server.rb
+++ b/test/net/imap/fake_server.rb
@@ -103,6 +103,10 @@ class Net::IMAP::FakeServer
   # See CommandRouter#on
   def on(...) connection&.on(...) end
 
+  # See CommandRouter#literal_acceptor
+  def literal_acceptor;     connection&.literal_acceptor    end
+  def literal_acceptor=(v); connection.literal_acceptor = v end
+
   # See Connection#unsolicited
   def unsolicited(...) @mutex.synchronize { connection&.unsolicited(...) } end
 

--- a/test/net/imap/fake_server/command_reader.rb
+++ b/test/net/imap/fake_server/command_reader.rb
@@ -7,10 +7,12 @@ class Net::IMAP::FakeServer
 
   class CommandReader
     attr_reader :last_command
+    attr_accessor :literal_acceptor
 
     def initialize(socket)
       @socket = socket
-      @last_comma0 = nil
+      @last_command = nil
+      @literal_acceptor = proc {|buff, size| true }
     end
 
     def get_command
@@ -19,8 +21,17 @@ class Net::IMAP::FakeServer
         s = socket.gets("\r\n") or break
         buf << s
         break unless /\{(\d+)(\+)?\}\r\n\z/n =~ buf
-        $2 or socket.print "+ Continue\r\n"
-        buf << socket.read(Integer($1))
+        bytes = Integer($1)
+        if $2
+          buf << socket.read(bytes)
+        elsif literal_acceptor[buf, bytes]
+          socket.print "+ Continue\r\n"
+          buf << socket.read(bytes)
+        else
+          partial = partial_parse(buf)
+          socket.print "#{partial.tag} NO #{bytes} byte literal rejected\r\n"
+          buf = "".b
+        end
       end
       throw :eof if buf.empty?
       @last_command = parse(buf)
@@ -43,6 +54,7 @@ class Net::IMAP::FakeServer
         Command.new $1, $2, $3, buf # TODO...
       end
     end
+    alias partial_parse parse
 
     # TODO: this is not the correct regexp, and literals aren't handled either
     def scan_astrings(str)

--- a/test/net/imap/fake_server/connection.rb
+++ b/test/net/imap/fake_server/connection.rb
@@ -21,6 +21,9 @@ class Net::IMAP::FakeServer
     def on(...) router.on(...) end
     def unsolicited(...) writer.untagged(...) end
 
+    def literal_acceptor;    reader.literal_acceptor     end
+    def literal_acceptor=(v) reader.literal_acceptor = v end
+
     def run
       writer.greeting
       catch(:eof) do

--- a/test/net/imap/test_command_data.rb
+++ b/test/net/imap/test_command_data.rb
@@ -7,6 +7,7 @@ class CommandDataTest < Test::Unit::TestCase
   DataFormatError = Net::IMAP::DataFormatError
 
   Literal = Net::IMAP::Literal
+  Literal8 = Net::IMAP::Literal8
 
   # simplistic emulation of Output = Data.define(:name, :args)
   class Output
@@ -68,6 +69,7 @@ class CommandDataTest < Test::Unit::TestCase
     def_printer :send_date_data
     def_printer :send_quoted_string
     def_printer :send_literal
+    def_printer :send_binary_literal
   end
 
   test "Literal" do
@@ -82,6 +84,15 @@ class CommandDataTest < Test::Unit::TestCase
       imap.send_data Literal["contains NULL char: \0"]
     end
     assert_empty imap.output
+  end
+
+  test "Literal8" do
+    imap = FakeCommandWriter.new
+    imap.send_data Literal8["foo\r\nbar"], Literal8["foo\0bar"]
+    assert_equal [
+      Output.send_binary_literal("foo\r\nbar", TAG),
+      Output.send_binary_literal("foo\0bar", TAG),
+    ], imap.output
   end
 
 end

--- a/test/net/imap/test_command_data.rb
+++ b/test/net/imap/test_command_data.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "net/imap"
+require "test/unit"
+
+class CommandDataTest < Test::Unit::TestCase
+  DataFormatError = Net::IMAP::DataFormatError
+
+  Literal = Net::IMAP::Literal
+
+  # simplistic emulation of Output = Data.define(:name, :args)
+  class Output
+    class << self
+      def new(_name = nil, _args = nil, name: _name, args: _args)
+        raise ArgumentError, "missing name" unless name
+        raise ArgumentError, "missing args" unless args
+        super(name: name, args: args)
+      end
+      alias :[] :new
+    end
+
+    attr_reader :name, :args
+
+    def initialize(name:, args:)
+      @name, @args = name, args
+      freeze
+    end
+
+    def to_h(&block) block ? to_h.to_h(&block) : { name: name, args: args } end
+    def ==(other)   Output === other && to_h  ==  other.to_h  end
+    def eql?(other) Output === other && to_h.eql?(other.to_h) end
+  end
+
+  TAG = Module.new.freeze
+
+  class FakeCommandWriter
+    def self.def_printer(name)
+      unless Net::IMAP.instance_methods.include?(name) ||
+          Net::IMAP.private_instance_methods.include?(name)
+        raise NoMethodError, "#{name} is not a method on Net::IMAP"
+      end
+      define_method(name) do |*args|
+        output << Output[name, args]
+      end
+      Output.define_singleton_method(name) do |*args|
+        new(name, args)
+      end
+    end
+
+    attr_reader :output
+
+    def initialize
+      @output = []
+    end
+
+    def clear; @output.clear end
+    def validate(*data); data.each(&:validate) end
+    def send_data(*data, tag: TAG)
+      validate(*data)
+      data.each do _1.send_data(self, tag) end
+    end
+
+    def_printer :put_string
+    def_printer :send_string_data
+    def_printer :send_number_data
+    def_printer :send_list_data
+    def_printer :send_time_data
+    def_printer :send_date_data
+    def_printer :send_quoted_string
+    def_printer :send_literal
+  end
+
+  test "Literal" do
+    imap = FakeCommandWriter.new
+    imap.send_data Literal["foo\r\nbar"]
+    assert_equal [
+      Output.send_literal("foo\r\nbar", TAG),
+    ], imap.output
+
+    imap.clear
+    assert_raise_with_message(Net::IMAP::DataFormatError, /\bNULL byte\b/i) do
+      imap.send_data Literal["contains NULL char: \0"]
+    end
+    assert_empty imap.output
+  end
+
+end

--- a/test/net/imap/test_command_data.rb
+++ b/test/net/imap/test_command_data.rb
@@ -72,8 +72,13 @@ class CommandDataTest < Test::Unit::TestCase
     def_printer :send_binary_literal
   end
 
+  attr_reader :imap
+
+  setup do
+    @imap = FakeCommandWriter.new
+  end
+
   test "Literal" do
-    imap = FakeCommandWriter.new
     imap.send_data Literal["foo\r\nbar"]
     assert_equal [
       Output.send_literal("foo\r\nbar", TAG),
@@ -87,7 +92,6 @@ class CommandDataTest < Test::Unit::TestCase
   end
 
   test "Literal8" do
-    imap = FakeCommandWriter.new
     imap.send_data Literal8["foo\r\nbar"], Literal8["foo\0bar"]
     assert_equal [
       Output.send_binary_literal("foo\r\nbar", TAG),

--- a/test/net/imap/test_command_data.rb
+++ b/test/net/imap/test_command_data.rb
@@ -12,22 +12,24 @@ class CommandDataTest < Test::Unit::TestCase
   # simplistic emulation of Output = Data.define(:name, :args)
   class Output
     class << self
-      def new(_name = nil, _args = nil, name: _name, args: _args)
+      def new(_name = nil, _args = nil, _kw = nil, name: _name, args: _args, kwargs: _kw)
         raise ArgumentError, "missing name" unless name
         raise ArgumentError, "missing args" unless args
-        super(name: name, args: args)
+        super(name: name, args: args, kwargs: kwargs)
       end
       alias :[] :new
     end
 
-    attr_reader :name, :args
+    attr_reader :name, :args, :kwargs
 
-    def initialize(name:, args:)
-      @name, @args = name, args
+    def initialize(name:, args:, kwargs:)
+      @name, @args, @kwargs = name, args, kwargs
       freeze
     end
 
-    def to_h(&block) block ? to_h.to_h(&block) : { name: name, args: args } end
+    def to_h(&block)
+      block ? to_h.to_h(&block) : { name: name, args: args, kwargs: kwargs }
+    end
     def ==(other)   Output === other && to_h  ==  other.to_h  end
     def eql?(other) Output === other && to_h.eql?(other.to_h) end
   end
@@ -40,11 +42,15 @@ class CommandDataTest < Test::Unit::TestCase
           Net::IMAP.private_instance_methods.include?(name)
         raise NoMethodError, "#{name} is not a method on Net::IMAP"
       end
-      define_method(name) do |*args|
-        output << Output[name, args]
+      define_method(name) do |*args, **kwargs|
+        kwargs = kwargs.compact
+        kwargs = nil if kwargs.empty?
+        output << Output[name: name, args: args, kwargs: kwargs]
       end
-      Output.define_singleton_method(name) do |*args|
-        new(name, args)
+      Output.define_singleton_method(name) do |*args, **kwargs|
+        kwargs = kwargs.compact
+        kwargs = nil if kwargs.empty?
+        new(name: name, args: args, kwargs: kwargs)
       end
     end
 
@@ -80,8 +86,12 @@ class CommandDataTest < Test::Unit::TestCase
 
   test "Literal" do
     imap.send_data Literal["foo\r\nbar"]
+    imap.send_data Literal["foo\r\nbar", false]
+    imap.send_data Literal["foo\r\nbar", true]
     assert_equal [
       Output.send_literal("foo\r\nbar", TAG),
+      Output.send_literal("foo\r\nbar", TAG, non_sync: false),
+      Output.send_literal("foo\r\nbar", TAG, non_sync: true),
     ], imap.output
 
     imap.clear
@@ -93,9 +103,13 @@ class CommandDataTest < Test::Unit::TestCase
 
   test "Literal8" do
     imap.send_data Literal8["foo\r\nbar"], Literal8["foo\0bar"]
+    imap.send_data Literal8["foo\0bar", false]
+    imap.send_data Literal8["foo\0bar", true]
     assert_equal [
       Output.send_binary_literal("foo\r\nbar", TAG),
       Output.send_binary_literal("foo\0bar", TAG),
+      Output.send_binary_literal("foo\0bar", TAG, non_sync: false),
+      Output.send_binary_literal("foo\0bar", TAG, non_sync: true),
     ], imap.output
   end
 

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -675,13 +675,30 @@ class IMAPTest < Test::Unit::TestCase
       assert_equal "{10}\r\n\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01",
         server.commands.pop.args
 
-      send_args.call("literal",   Net::IMAP::Literal["\r"],
-                     "literal8",  Net::IMAP::Literal8["\0" * 6],
+      buff = bytes = nil
+      server.literal_acceptor = proc { buff, bytes = _1, _2; false }
+      send_args.call("nonsync",
+                     Net::IMAP::Literal[data: "\x01\x02\x03", non_sync: true])
+      assert_equal "nonsync {3+}\r\n\x01\x02\03".b, server.commands.pop.args
+      assert_nil buff
+      assert_nil bytes
+
+      server.literal_acceptor = proc { true }
+      send_args.call("literal",   Net::IMAP::Literal["\r",       false],
+                     "literal",   Net::IMAP::Literal["αβγδε",      nil],
+                     "literal+",  Net::IMAP::Literal["αβγδε",     true],
+                     "literal8",  Net::IMAP::Literal8["\0",      false],
+                     "literal8",  Net::IMAP::Literal8["\0" * 6,    nil],
+                     "literal8+", Net::IMAP::Literal8["\0" * 8,   true],
                      "done")
       assert_equal("literal"   " {1}\r\n\r "                 \
+                   "literal"   " {10}\r\nαβγδε "             \
+                   "literal+"  " {10+}\r\nαβγδε "            \
+                   "literal8"  " ~{1}\r\n\0 "                \
                    "literal8"  " ~{6}\r\n\0\0\0\0\0\0 "      \
-                    "done".b,
-                    server.commands.pop.args)
+                   "literal8+" " ~{8+}\r\n\0\0\0\0\0\0\0\0 " \
+                   "done".b,
+                   server.commands.pop.args)
     end
   end
 

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -652,40 +652,36 @@ class IMAPTest < Test::Unit::TestCase
     end
   end
 
-  def test_send_literal
-    server = create_tcp_server
-    port = server.addr[1]
-    requests = []
-    literal = nil
-    start_server do
-      sock = server.accept
-      begin
-        sock.print("* OK test server\r\n")
-        line = sock.gets
-        requests.push(line)
-        size = line.slice(/{(\d+)}\r\n/, 1).to_i
-        sock.print("+ Ready for literal data\r\n")
-        literal = sock.read(size)
-        requests.push(sock.gets)
-        sock.print("RUBY0001 OK TEST completed\r\n")
-        sock.gets
-        sock.print("* BYE terminating connection\r\n")
-        sock.print("RUBY0002 OK LOGOUT completed\r\n")
-      ensure
-        sock.close
-        server.close
+  test("send literal args") do
+    with_fake_server do |server, imap|
+      server.on "TEST", &:done_ok
+      send_args = ->(*args) do
+        imap.__send__(:send_command, "TEST", *args)
       end
-    end
-    begin
-      imap = Net::IMAP.new(server_addr, :port => port)
-      imap.__send__(:send_command, "TEST", ["\xDE\xAD\xBE\xEF".b])
-      assert_equal(2, requests.length)
-      assert_equal("RUBY0001 TEST ({4}\r\n", requests[0])
-      assert_equal("\xDE\xAD\xBE\xEF".b, literal)
-      assert_equal(")\r\n", requests[1])
-      imap.logout
-    ensure
-      imap.disconnect
+      send_args.call ["\xDE\xAD\xBE\xEF".b]
+      assert_equal "({4}\r\n\xDE\xAD\xBE\xEF)".b, server.commands.pop.args
+
+      buff = bytes = nil
+      server.literal_acceptor = proc { buff, bytes = _1, _2; false }
+      assert_raise(Net::IMAP::NoResponseError) do
+        send_args.call Net::IMAP::Literal["\x01" * 10]
+      end
+      assert_match(/TEST \{10\}\r\n\z/, buff)
+      assert_equal 10, bytes
+      assert_empty server.commands
+
+      server.literal_acceptor = proc { true }
+      send_args.call Net::IMAP::Literal["\x01" * 10]
+      assert_equal "{10}\r\n\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01",
+        server.commands.pop.args
+
+      send_args.call("literal",   Net::IMAP::Literal["\r"],
+                     "literal8",  Net::IMAP::Literal8["\0" * 6],
+                     "done")
+      assert_equal("literal"   " {1}\r\n\r "                 \
+                   "literal8"  " ~{6}\r\n\0\0\0\0\0\0 "      \
+                    "done".b,
+                    server.commands.pop.args)
     end
   end
 


### PR DESCRIPTION
This partially backports:
* #358
* #616 
* #649 

It backports most of the internal code and tests.  However, it does _not_ actually add `BINARY` support to `#append`, nor does it automatically send non-synchronizing literals.  But it _does_ add `Literal8`, and it adds a `non_sync` option to both `Literal` and `Literal8`.