### PR TITLE
🔒️ Validate and send STORE `attr` as an `atom`

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3786,7 +3786,7 @@ module Net
     end
 
     def store_internal(cmd, set, attr, flags, unchangedsince: nil)
-      attr = RawData.new(attr) if attr.instance_of?(String)
+      attr = Atom.new(attr) if attr.instance_of?(String)
       args = [SequenceSet.new(set)]
       args << ["UNCHANGEDSINCE", Integer(unchangedsince)] if unchangedsince
       args << attr << flags

--- a/test/net/imap/test_imap_store.rb
+++ b/test/net/imap/test_imap_store.rb
@@ -72,9 +72,9 @@ class IMAPStoreTest < Net::IMAP::TestCase
   test "#uid_store with changedsince" do
     with_fake_server select: "inbox" do |server, imap|
       server.on("UID STORE", &:done_ok)
-      imap.uid_store 1..-1, "FLAGS", %i[Deleted], unchangedsince: 987
+      imap.uid_store 1..-1, "+FLAGS.SILENT", %i[Deleted], unchangedsince: 987
       assert_equal(
-        "RUBY0002 UID STORE 1:* (UNCHANGEDSINCE 987) FLAGS (\\Deleted)",
+        "RUBY0002 UID STORE 1:* (UNCHANGEDSINCE 987) +FLAGS.SILENT (\\Deleted)",
         server.commands.pop.raw.strip
       )
     end


### PR DESCRIPTION
> [!IMPORTANT]
> This fixes a CRLF/command/argument injection vulnerability for the `attr` argument to `#store`/`#uid_store`.

Previously, `#store` and `#uid_store` wrapped `attr` with `RawData`. But that's completely unnecessary.  `+`, `-`, and `.` are atom chars, and every STORE "message data item" defined in any RFC is an `atom`:

```
 FLAGS      FLAGS.SILENT
+FLAGS     +FLAGS.SILENT
-FLAGS     -FLAGS.SILENT
ANNOTATION ANNOTATION.SILENT
```

We can revisit this in the future, if some new extension uses a non-atom for its STORE "message data item", but that seems unlikely.

Note also that `Atom` is only applied to `String` arguments.