### PR TITLE
🔒 Validate `#setquota` storage limit argument

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -1926,7 +1926,11 @@ module Net
     # Sends a {SETQUOTA command [RFC2087 §4.1]}[https://www.rfc-editor.org/rfc/rfc2087#section-4.1]
     # along with the specified +quota_root+ and +storage_limit+.  If
     # +storage_limit+ is +nil+, resource limits are unset for that quota root.
-    # Otherwise, it sets the +STORAGE+ resource limit.
+    # If +storage_limit+ is a number, it sets the +STORAGE+ resource limit.
+    #
+    #   imap.setquota "#user/alice", 100
+    #   imap.getquota "#user/alice"
+    #   # => [#<struct Net::IMAP::MailboxQuota mailbox="#user/alice" usage=54 quota=100>]
     #
     # Typically one needs to be logged in as a server admin for this to work.
     #
@@ -1942,11 +1946,11 @@ module Net
     # resource type.
     def setquota(quota_root, storage_limit)
       if storage_limit.nil?
-        list = '()'
+        list = []
       else
-        list = '(STORAGE ' + storage_limit.to_s + ')'
+        list = ["STORAGE", NumValidator.coerce_number64(storage_limit)]
       end
-      send_command("SETQUOTA", quota_root, RawData.new(list))
+      send_command("SETQUOTA", quota_root, list)
     end
 
     # Sends a {SETACL command [RFC4314 §3.1]}[https://www.rfc-editor.org/rfc/rfc4314#section-3.1]

--- a/test/net/imap/test_imap_quota.rb
+++ b/test/net/imap/test_imap_quota.rb
@@ -28,6 +28,15 @@ class IMAPQuotaTest < Net::IMAP::TestCase
       rcvd_cmd = server.commands.pop
       assert_equal "SETQUOTA",            rcvd_cmd.name
       assert_equal '"" ()',               rcvd_cmd.args
+
+      assert_raise_with_message(Net::IMAP::DataFormatError,
+                                "512.0 is not a valid number64") do
+        imap.setquota "INBOX", 512.0
+      end
+      assert_raise_with_message(Net::IMAP::DataFormatError,
+                                '"512 620" is not a valid number64') do
+        imap.setquota "INBOX", "512 620"
+      end
     end
   end
 end


### PR DESCRIPTION
> [!IMPORTANT]
> This fixes a CRLF/command/argument injection vulnerability for the `storage_limit` argument to `#setquota`.

There's no reason to use `RawData` for this.  We can use Net::IMAP's standard command argument formatting to send a parenthesized list.