### PR TITLE
🔒 Fix STARTTLS stripping vulnerability (backports #664, #395, #198)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,5 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake"
-gem "rdoc"
+gem "rdoc", "<7.2" # incompatible with ruby 2.6
 gem "test-unit"

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -2311,6 +2311,7 @@ module Net
           put_string(" ")
           send_data(i, tag)
         end
+        guard_against_tagged_response_skipping_handler!(tag)
         put_string(CRLF)
         if cmd == "LOGOUT"
           @logout_command_tag = tag
@@ -2326,6 +2327,17 @@ module Net
           end
         end
       end
+    rescue InvalidResponseError
+      disconnect
+      raise
+    end
+
+    def guard_against_tagged_response_skipping_handler!(tag)
+      return unless (resp = @tagged_responses[tag])&.name&.upcase == "OK"
+      raise(InvalidResponseError,
+            "Server sent tagged 'OK' before command was finished: %p. " \
+            "This could indicate a malicious server or client-side " \
+            "command injection. Disconnecting." % [resp.raw_data.chomp])
     end
 
     def generate_tag

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -1014,9 +1014,11 @@ module Net
     # unsolicited untagged response immeditely _after_ #starttls completes.
     #
     def starttls(options = {}, verify = true)
+      handled = false
       error = nil
       ok = send_command("STARTTLS") do |resp|
         if resp.kind_of?(TaggedResponse) && resp.name == "OK"
+          handled = true
           begin
             # for backward compatibility
             certs = options.to_str
@@ -1031,6 +1033,13 @@ module Net
       if error
         disconnect
         raise error
+      end
+      unless handled
+        disconnect
+        raise InvalidResponseError,
+              "STARTTLS handler was bypassed, although server responded %p" % [
+                ok.raw_data.chomp
+              ]
       end
       ok
     end

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -1014,7 +1014,8 @@ module Net
     # unsolicited untagged response immeditely _after_ #starttls completes.
     #
     def starttls(options = {}, verify = true)
-      send_command("STARTTLS") do |resp|
+      error = nil
+      ok = send_command("STARTTLS") do |resp|
         if resp.kind_of?(TaggedResponse) && resp.name == "OK"
           begin
             # for backward compatibility
@@ -1024,7 +1025,14 @@ module Net
           end
           start_tls_session(options)
         end
+      rescue Exception => error
+        raise # note that the error backtrace is in the receiver_thread
       end
+      if error
+        disconnect
+        raise error
+      end
+      ok
     end
 
     # :call-seq:

--- a/lib/net/imap/errors.rb
+++ b/lib/net/imap/errors.rb
@@ -81,7 +81,27 @@ module Net
     class ByeResponseError < ResponseError
     end
 
+    # Error raised when the server sends an invalid response.
+    #
+    # This is different from UnknownResponseError: the response has been
+    # rejected.  Although it may be parsable, the server is forbidden from
+    # sending it in the current context.  The client should automatically
+    # disconnect, abruptly (without logout).
+    #
+    # Note that InvalidResponseError does not inherit from ResponseError: it
+    # can be raised before the response is fully parsed.  A related
+    # ResponseParseError or ResponseError may be the #cause.
+    class InvalidResponseError < Error
+    end
+
     # Error raised upon an unknown response from the server.
+    #
+    # This is different from InvalidResponseError: the response may be a
+    # valid extension response and the server may be allowed to send it in
+    # this context, but Net::IMAP either does not know how to parse it or
+    # how to handle it.  This could result from enabling unknown or
+    # unhandled extensions.  The connection may still be usable,
+    # but—depending on context—it may be prudent to disconnect.
     class UnknownResponseError < ResponseError
     end
 

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -113,6 +113,40 @@ class IMAPTest < Test::Unit::TestCase
         imap
       end
     end
+
+    def test_starttls_stripping_ok_sent_before_response
+      # to coordinate between threads (better than sleep)
+      server_to_client, client_to_server = Queue.new, Queue.new
+      imap = nil
+      server = create_tcp_server
+      port = server.addr[1]
+      start_server do
+        sock = server.accept
+        begin
+          sock.print("* OK test server\r\n")
+          assert_equal :send_malicious_response, client_to_server.pop
+          sock.print("RUBY0001 OK hahaha, fooled you!\r\n")
+          server_to_client << :malicious_response_sent
+          sock.gets
+        ensure
+          sock.close
+          server.close
+        end
+      end
+      begin
+        imap = Net::IMAP.new("localhost", :port => port)
+        client_to_server << :send_malicious_response
+        assert_equal :malicious_response_sent, server_to_client.pop
+        sleep 0.010 # to be sure the network buffers have flushed, etc
+        assert_raise(Net::IMAP::InvalidResponseError) do
+          imap.starttls(:ca_file => CA_FILE)
+        end
+        assert imap.disconnected?
+      ensure
+        imap.disconnect if imap && !imap.disconnected?
+      end
+      assert imap.disconnected?
+    end
   end
 
   def start_server

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -75,6 +75,20 @@ class IMAPTest < Test::Unit::TestCase
   end
 
   if defined?(OpenSSL::SSL)
+    def test_starttls_unknown_ca
+      imap = nil
+      ex = nil
+      starttls_test do |port|
+        imap = Net::IMAP.new("localhost", port: port)
+        begin
+          imap.starttls
+        rescue => ex
+        end
+        imap
+      end
+      assert_kind_of(OpenSSL::SSL::SSLError, ex)
+    end
+
     def test_starttls
       imap = nil
       starttls_test do |port|
@@ -1004,6 +1018,7 @@ EOF
         sock.gets
         sock.print("* BYE terminating connection\r\n")
         sock.print("RUBY0002 OK LOGOUT completed\r\n")
+      rescue OpenSSL::SSL::SSLError
       ensure
         sock.close
         server.close


### PR DESCRIPTION
Also backports #395 to `v0.3-stable`. _This ensures `STARTTLS` handler errors in the receiver thread are re-raised in the client thread._

Partially backports #198 to `v0.3-stable`: This copies InvalidResponseError (and an rdoc update to UnknownResponseError).  The behavioral changes from that PR have _not_ been copied.

Backports #664 to `v0.5-stable`.  A couple of irrelevant commits were excluded.

> [!WARNING]
> Without this patch, a man-in-the-middle attacker can cause `Net::IMAP#starttls` to return "successfully", without starting TLS.

This ensures that `#starttls` either succeeds or raises an exception.

The following cases will raise an exception _and close the connection_:
* For `#starttls`, when another error wasn't raised (e.g: the response errors for `NO` or `BAD`) but the handler did not run.
* For _any_ command, if the server sends a tagged `OK` response for that command _before_ the command has been fully sent (before the command's own response handlers are added), an exception is raised and the connection is closed.