### PR TITLE
🔧 Disallow `config.max_non_synchronizing_literal = nil`

### DIFF
--- a/lib/net/imap/config.rb
+++ b/lib/net/imap/config.rb
@@ -310,7 +310,7 @@ module Net
       #
       # * original: +-1+ (_never_ send non-synchronizing literals)
       # * +0.6+: 16 KiB
-      attr_accessor :max_non_synchronizing_literal, type: Integer?, defaults: {
+      attr_accessor :max_non_synchronizing_literal, type: Integer, defaults: {
         0.0r => -1,
         0.6r => 16 << 16, # 16 KiB
       }


### PR DESCRIPTION
This was a copy/paste error.  Setting `max_non_synchronizing_literal` to `nil` will result in `send_literal` raising an exception.

As is already documented, non-synchronizing literals can be disabled by setting this config option to `-1`.