### PR TITLE
🔍 Add more detail to `Net::IMAP#inspect` TLS info

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -1160,14 +1160,27 @@ module Net
     #   imap.logout
     #   imap.inspect #=> "#<Net::IMAP imap.example.net:993 TLS logout>"
     #
+    #   imap = Net::IMAP.new(hostname, ssl: false)
+    #   imap.inspect #=> "#<Net::IMAP imap.example.net:143 PLAINTEXT not_authenticated>"
+    #
+    #   imap.starttls verify_mode: OpenSSL::SSL::VERIFY_NONE
+    #   imap.inspect #=> "#<Net::IMAP imap.example.net:993 TLS (NOT VERIFIED) not_authenticated>"
+    #
     def inspect
-      tls_state = tls_verified? ? "TLS" :
-        ssl_ctx ? "TLS (NOT VERIFIED)" :
-        "PLAINTEXT"
       conn_state = disconnected? ? "disconnected" : connection_state.to_sym
       "#<%s:0x%08x %s:%s %s %s>" % [
-        self.class.name, __id__, host, port, tls_state, conn_state
+        self.class.name, __id__, host, port, inspect_tls_state, conn_state
       ]
+    end
+
+    private def inspect_tls_state
+      if tls_verified?
+        "TLS"
+      elsif ssl_ctx && @sock.kind_of?(OpenSSL::SSL::SSLSocket)
+        "TLS (#{@sock.session ? "NOT VERIFIED" : "NOT ESTABLISHED"})"
+      else
+        "PLAINTEXT#{" (TLS NOT STARTED)" if ssl_ctx}"
+      end
     end
 
     # Returns true after the TLS negotiation has completed and the remote

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -128,7 +128,8 @@ class IMAPTest < Net::IMAP::TestCase
       assert_equal false, initial_verified
       assert_equal false, initial_params
       assert_equal nil,   initial_ctx
-      assert_equal true, imap.tls_verified?
+      assert_equal true,  imap.tls_verified?
+      assert_include imap.inspect, " TLS disconnected"
       assert_equal({ca_file: CA_FILE}, imap.ssl_ctx_params)
     rescue SystemCallError
       skip $!
@@ -164,6 +165,7 @@ class IMAPTest < Net::IMAP::TestCase
       end
 
       assert_equal false, imap.tls_verified?
+      assert_include imap.inspect, " PLAINTEXT (TLS NOT STARTED) "
       assert_equal({ca_file: CA_FILE},        imap.ssl_ctx_params)
       assert_equal(CA_FILE,                   imap.ssl_ctx.ca_file)
       assert_equal(OpenSSL::SSL::VERIFY_PEER, imap.ssl_ctx.verify_mode)
@@ -201,6 +203,7 @@ class IMAPTest < Net::IMAP::TestCase
         imap.disconnect if imap && !imap.disconnected?
       end
       assert_equal false, imap.tls_verified?
+      assert_include imap.inspect, " PLAINTEXT (TLS NOT STARTED) "
       assert_equal({ca_file: CA_FILE},        imap.ssl_ctx_params)
       assert_equal(CA_FILE,                   imap.ssl_ctx.ca_file)
       assert_equal(OpenSSL::SSL::VERIFY_PEER, imap.ssl_ctx.verify_mode)


### PR DESCRIPTION
Previously, the existence of `ssl_ctx` without `tls_verified?` would cause `TLS (NOT VERIFIED)` to be output.  But that isn't quite right: `ssl_ctx` is assigned immediately, before even sending the `STARTTLS` command, before calling `start_tls_session`, and before `start_tls_session` returns.  And those intermediate states are important distinctions for debugging TLS issues.

So this updates `Net::IMAP#inspect` with two new TLS/PLAINTEXT states:
* `PLAINTEXT (TLS NOT STARTED)`, when:
  * `#starttls` has been called (`@ssl_ctx` has been set),
  * but `#start_tls_session` hasn't (`@sock` is a `TCPSocket`).
* `TLS (NOT ESTABLISHED)`, when:
  * `#start_tls_session` was called (`@sock` is an `SSLSocket`),
  * but hasn't returned successfully (`@sock.session` isn't available).

Generally, users will only encounter these states in edge cases.  For example:
* the server responds to `STARTTLS` with `NO` or `BAD`, etc
* the TLS handshake fails
* during callbacks user may have added to their `ssl_ctx`