### PR TITLE
🏷 Allow 64-bit Integer arguments

### DIFF
--- a/lib/net/imap/command_data.rb
+++ b/lib/net/imap/command_data.rb
@@ -16,14 +16,15 @@ module Net
       when nil
       when String
       when Integer
-        NumValidator.ensure_number(data)
+        # Covers modseq-valzer, which is the largest valid IMAP integer
+        if data.negative?
+          raise DataFormatError, "Integer argument must be unsigned: #{data}"
+        elsif 0xffff_ffff_ffff_ffff < data
+          raise DataFormatError, "Integer argument must fit in 64 bits: #{data}"
+        end
       when Array
-        if data[0] == 'CHANGEDSINCE'
-          NumValidator.ensure_mod_sequence_value(data[1])
-        else
-          data.each do |i|
-            validate_data(i)
-          end
+        data.each do |i|
+          validate_data(i)
         end
       when Time, Date, DateTime
       when Symbol

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -634,7 +634,7 @@ class IMAPTest < Net::IMAP::TestCase
     assert_equal(993, Net::IMAP.default_imaps_port)
   end
 
-  def test_send_invalid_number
+  def test_send_integer
     with_fake_server do |server, imap|
       server.on "TEST", &:done_ok
 
@@ -650,10 +650,22 @@ class IMAPTest < Net::IMAP::TestCase
       imap.__send__(:send_command, "TEST", 2**32 - 1)
       assert_equal (2**32 - 1).to_s, server.commands.pop.args
 
+      imap.__send__(:send_command, "TEST", 2**32)
+      assert_equal (2**32).to_s, server.commands.pop.args
+
+      imap.__send__(:send_command, "TEST", 2**64 - 1)
+      assert_equal (2**64 - 1).to_s, server.commands.pop.args
+
       assert_raise(Net::IMAP::DataFormatError) do
-        imap.__send__(:send_command, "TEST", 2**32)
+        imap.__send__(:send_command, "TEST", 2**64)
       end
       assert_empty server.commands
+    end
+  end
+
+  def test_send_sequence_set
+    with_fake_server do |server, imap|
+      server.on "TEST", &:done_ok
 
       # SequenceSet numbers may be non-zero uint3, and -1 is translated to *
       imap.__send__(:send_command, "TEST", Net::IMAP::SequenceSet.new(-1))


### PR DESCRIPTION
Previously, integer arguments had to be 32-bit unsigned, and a special case exception was made for the number in a `["CHANGEDSINCE", number]` array.  But several other command arguments can be larger: `UNCHANGEDSINCE`, quota `resource-limit`, and `tagged-ext-simple`.

So, generic Integer arguments should allow 64 bit numbers.  We can add specific argument validation where it makes sense to do so.

Note: I didn't use `ensure_mod_sequence_valzer` because I wanted more appropriate error messages for the generic argument case.