### PR TITLE
🥅 Ensure send_number_data input is an Integer

### DIFF
--- a/lib/net/imap/command_data.rb
+++ b/lib/net/imap/command_data.rb
@@ -119,8 +119,9 @@ module Net
          bytesize <= 4096 && (capable?("IMAP4rev2") || capable?("LITERAL-")))
     end
 
+    # NOTE: +num+ should already be an Integer
     def send_number_data(num)
-      put_string(num.to_s)
+      put_string(Integer(num).to_s)
     end
 
     def send_list_data(list, tag = nil)


### PR DESCRIPTION
`Net::IMAP#send_number_data` is a private method, and I intend to deprecate it (in its current form) soon anyway.  Internally, it is only ever called with Integer arguments.

Nevertheless, it's trivial to add this enforcement here.