### PR TITLE
✅  Improvements to tests' FakeServer

### DIFF
--- a/test/net/imap/fake_server/command_reader.rb
+++ b/test/net/imap/fake_server/command_reader.rb
@@ -6,10 +6,12 @@ class Net::IMAP::FakeServer
   CommandParseError = Class.new(RuntimeError)
 
   class CommandReader
+    attr_reader :config
     attr_reader :last_command
     attr_accessor :literal_acceptor
 
-    def initialize(socket)
+    def initialize(socket, config:)
+      @config = config
       @socket = socket
       @last_command = nil
       @literal_acceptor = proc {|buff, size| true }
@@ -35,8 +37,11 @@ class Net::IMAP::FakeServer
       end
       throw :eof if buf.empty?
       @last_command = parse(buf)
-    rescue CommandParseError => err
-      raise IOError, err.message if socket.eof? && !buf.end_with?("\r\n")
+    rescue CommandParseError
+      if config.ignore_abrupt_eof? && socket.eof? && !buf.end_with?("\r\n")
+        throw :eof
+      end
+      raise
     end
 
     private

--- a/test/net/imap/fake_server/command_reader.rb
+++ b/test/net/imap/fake_server/command_reader.rb
@@ -3,7 +3,7 @@
 require "net/imap"
 
 class Net::IMAP::FakeServer
-  CommandParseError = RuntimeError
+  CommandParseError = Class.new(RuntimeError)
 
   class CommandReader
     attr_reader :last_command
@@ -46,7 +46,7 @@ class Net::IMAP::FakeServer
     # TODO: convert bad command exception to tagged BAD response, when possible
     def parse(buf)
       /\A([^ ]+) ((?:UID )?\w+)(?: (.+))?\r\n\z/min =~ buf or
-        raise CommandParseError, "bad request: %p" [buf]
+        raise CommandParseError, "bad request: %p" % [buf]
       case $2.upcase
       when "LOGIN", "SELECT", "EXAMINE", "ENABLE", "AUTHENTICATE"
         Command.new $1, $2, scan_astrings($3), buf

--- a/test/net/imap/fake_server/configuration.rb
+++ b/test/net/imap/fake_server/configuration.rb
@@ -45,6 +45,8 @@ class Net::IMAP::FakeServer
       mailboxes: {
         "INBOX" => { name: "INBOX" }.freeze,
       }.freeze,
+
+      ignore_abrupt_eof: false,
     }
 
     def initialize(with_extensions: [], without_extensions: [], **opts, &block)
@@ -68,6 +70,7 @@ class Net::IMAP::FakeServer
     alias greeting_bye?          greeting_bye
     alias greeting_capabilities? greeting_capabilities
     alias sasl_ir?               sasl_ir
+    alias ignore_abrupt_eof?     ignore_abrupt_eof
 
     def on(event, &handler)
       handler or raise ArgumentError

--- a/test/net/imap/fake_server/connection.rb
+++ b/test/net/imap/fake_server/connection.rb
@@ -12,7 +12,7 @@ class Net::IMAP::FakeServer
       @config = server.config
       @socket = Socket.new tcp_socket, config: config
       @state  = ConnectionState.new socket: socket, config: config
-      @reader = CommandReader.new  socket
+      @reader = CommandReader.new  socket, config: config
       @writer = ResponseWriter.new socket, config: config, state: state
       @router = CommandRouter.new  writer, config: config, state: state
       @mutex  = Thread::Mutex.new

--- a/test/net/imap/fake_server/socket.rb
+++ b/test/net/imap/fake_server/socket.rb
@@ -18,10 +18,10 @@ class Net::IMAP::FakeServer
     def tls?; !!@tls_socket end
     def closed?; @closed end
 
-    def eof?;      socket.eof?       end
-    def gets(...)  socket.gets(...)  end
-    def read(...)  socket.read(...)  end
-    def print(...) socket.print(...) end
+    def eof?;      ignore_closed?(true) { socket.eof?       } end
+    def gets(...)  ignore_closed?(nil)  { socket.gets(...)  } end
+    def read(...)  ignore_closed?(nil)  { socket.read(...)  } end
+    def print(...) ignore_closed?(nil)  { socket.print(...) } end
 
     def use_tls
       @tls_socket ||= OpenSSL::SSL::SSLSocket.new(tcp_socket, ssl_ctx).tap do |s|
@@ -46,6 +46,14 @@ class Net::IMAP::FakeServer
         ctx.key  = OpenSSL::PKey::RSA.new         File.read config.tls.fetch :key
         ctx.cert = OpenSSL::X509::Certificate.new File.read config.tls.fetch :cert
       end
+    end
+
+    def ignore_closed?(fallback)
+      yield
+    rescue IOError => err
+      close if !closed? && (@tcp_socket.closed? || @tls_socket.closed?)
+      return fallback if err.message.match?(/stream closed|closed stream/i)
+      raise
     end
 
   end


### PR DESCRIPTION
* Fix CommandParseError: subclass RuntimeError, use correct error message
* Convert "stream closed" errors into behave like EOF
* Add config option for ignoring abrupt EOF (in the middle of a response)
  This is for tests that _expect_ a mid-response disconnect (so, it's not the default).