### PR TITLE
♻️ Improve `RawData.new`, Add `RawData.split`

### DIFF
--- a/lib/net/imap/command_data.rb
+++ b/lib/net/imap/command_data.rb
@@ -199,7 +199,7 @@ module Net
     class RawData < CommandData # :nodoc:
       def initialize(data:)
         case data
-        in String then data = split_parts(data)
+        in String then data = self.class.split(data)
         in Array  if   data.all? { _1 in RawText | Literal }
         else
           raise TypeError, "expected String or Array[#{RawText} | #{Literal}]"
@@ -217,9 +217,11 @@ module Net
         end
       end
 
-      private
-
-      def split_parts(data)
+      # Splits an input +string+ into an array of RawText and Literal/Literal8.
+      #
+      # NOTE: unlike RawData#validate, this does not prevent the final RawText
+      # from ending with a literal prefix.
+      def self.split(data)
         data = data.b # dups and ensures BINARY encoding
         parts = []
         while data.match(/(~)?\{(0|[1-9]\d*)(\+)?\}\r\n/n)
@@ -233,7 +235,7 @@ module Net
         parts
       end
 
-      def extract_literal(data, binary:, bytesize:, non_sync:)
+      def self.extract_literal(data, binary:, bytesize:, non_sync:)
         if data.bytesize < bytesize
           raise DataFormatError, "Too few bytes in string for literal, " \
             "expected: %s, remaining: %s" % [bytesize, data.bytesize]
@@ -241,6 +243,7 @@ module Net
         literal = data.byteslice(0, bytesize)
         (binary ? Literal8 : Literal).new(data: literal, non_sync:)
       end
+      private_class_method :extract_literal
     end
 
     class Atom < CommandData # :nodoc:

--- a/lib/net/imap/command_data.rb
+++ b/lib/net/imap/command_data.rb
@@ -198,7 +198,12 @@ module Net
 
     class RawData < CommandData # :nodoc:
       def initialize(data:)
-        data = split_parts(data)
+        case data
+        in String then data = split_parts(data)
+        in Array  if   data.all? { _1 in RawText | Literal }
+        else
+          raise TypeError, "expected String or Array[#{RawText} | #{Literal}]"
+        end
         super
         validate
       end

--- a/test/net/imap/test_command_data.rb
+++ b/test/net/imap/test_command_data.rb
@@ -365,6 +365,23 @@ class CommandDataTest < Net::IMAP::TestCase
       raw = RawData.new(data: " {123} ")
       assert_equal [RawText[" {123} "]], raw.data
     end
+
+    data(
+      "simple raw text"     => 'hello "world"',
+      "text, literal, text" => "OK {5}\r\nhello {5}\r\nworld",
+      "empty literals"      => "{0}\r\n{0+}\r\n~{0}\r\n~{0+}\r\n",
+      "binary and regular"  => "foo ~{7}\r\n\0bar\r\nbaz {4}\r\nquux",
+    )
+    test ".split" do |string|
+      assert_equal(RawData[string].data, RawData.split(string))
+    end
+
+    test ".split allows final literal prefix" do
+      assert_equal [RawText["text {123}"]],     RawData.split("text {123}")
+      assert_equal [RawText["text+ {123+}"]],   RawData.split("text+ {123+}")
+      assert_equal [RawText["~text ~{123}"]],   RawData.split("~text ~{123}")
+      assert_equal [RawText["~text+ ~{123+}"]], RawData.split("~text+ ~{123+}")
+    end
   end
 
 end


### PR DESCRIPTION
Note that `RawData` is still undocumented and considered to be an internal API, so I'm not classifying this PR as an "Added" feature.

* Allow `RawData.new` to directly set parts array.  While it's convenient that `RawData` can be initialized with string, it's composed of parts (an `Array` of strings).  So it's surprising, IMO, to _require_ the `data` parameter be a string, when the `data` member is an array.
* Extract `RawData.split` to convert a string into an array of `RawText` and `Literal`/`Literal8`.
  **NOTE:** Unlike `RawData#validate`, this does _**not**_ prevent the final RawText from ending with a literal prefix.