### PR TITLE
🐛 Less strict number string coercion, to match RFCs

### DIFF
--- a/lib/net/imap/data_encoding.rb
+++ b/lib/net/imap/data_encoding.rb
@@ -155,7 +155,8 @@ module Net
 
     # Common validators of number and nz_number types
     module NumValidator # :nodoc
-      NUMBER_RE = /\A(?:0|[1-9]\d*)\z/
+      NUMBER_RE = /\A\d+\z/
+      NZ_NUMBER_RE = /\A[1-9]\d*\z/
       module_function
 
       # Check if argument is a valid 'number' according to RFC 3501
@@ -251,7 +252,7 @@ module Net
       def coerce_number(num)
         case num
         when Integer   then ensure_number num
-        when NUMBER_RE then ensure_number Integer num
+        when NUMBER_RE then ensure_number num.to_i
         else
           raise DataFormatError, "%p is not a valid number" % [num]
         end
@@ -260,8 +261,8 @@ module Net
       # Like #ensure_nz_number, but usable with numeric String input.
       def coerce_nz_number(num)
         case num
-        when Integer   then ensure_nz_number num
-        when NUMBER_RE then ensure_nz_number Integer num
+        when Integer      then ensure_nz_number num
+        when NZ_NUMBER_RE then ensure_nz_number num.to_i
         else
           raise DataFormatError, "%p is not a valid nz-number" % [num]
         end
@@ -271,7 +272,7 @@ module Net
       def coerce_number64(num)
         case num
         when Integer   then ensure_number64 num
-        when NUMBER_RE then ensure_number64 Integer num
+        when NUMBER_RE then ensure_number64 num.to_i
         else
           raise DataFormatError, "%p is not a valid number64" % [num]
         end
@@ -280,8 +281,8 @@ module Net
       # Like #ensure_nz_number64, but usable with numeric String input.
       def coerce_nz_number64(num)
         case num
-        when Integer   then ensure_nz_number64 num
-        when NUMBER_RE then ensure_nz_number64 Integer num
+        when Integer      then ensure_nz_number64 num
+        when NZ_NUMBER_RE then ensure_nz_number64 num.to_i
         else
           raise DataFormatError, "%p is not a valid nz-number64" % [num]
         end
@@ -291,7 +292,7 @@ module Net
       def coerce_mod_sequence_value(num)
         case num
         when Integer   then ensure_mod_sequence_value num
-        when NUMBER_RE then ensure_mod_sequence_value Integer num
+        when NUMBER_RE then ensure_mod_sequence_value num.to_i
         else
           raise DataFormatError, "%p is not a valid mod-sequence-value" % [num]
         end
@@ -301,7 +302,7 @@ module Net
       def coerce_mod_sequence_valzer(num)
         case num
         when Integer   then ensure_mod_sequence_valzer num
-        when NUMBER_RE then ensure_mod_sequence_valzer Integer num
+        when NUMBER_RE then ensure_mod_sequence_valzer num.to_i
         else
           raise DataFormatError, "%p is not a valid mod-sequence-valzer" % [num]
         end

--- a/test/net/imap/test_num_validator.rb
+++ b/test/net/imap/test_num_validator.rb
@@ -24,11 +24,17 @@ class NumValidatorTest < Net::IMAP::TestCase
 
   TYPES = TEST_VALUES.values.flatten.uniq - [:invalid]
 
-  def self.each_test_value_for(type)
+  def self.each_integer_test_value_for(type)
     TEST_VALUES.each do |value, types|
-      label = value if value < 1
-      label ||= "0x" + ("%016x" % value).chars.each_slice(4).map(&:join).join(?_)
-      yield label, value, types.include?(type)
+      yield value, types.include?(type)
+    end
+  end
+
+  def self.each_coercible_test_value_for(type)
+    each_integer_test_value_for(type) do |value, valid|
+      [value, value.to_s].each do |input|
+        yield input, valid, value
+      end
     end
   end
 
@@ -39,44 +45,46 @@ class NumValidatorTest < Net::IMAP::TestCase
     end
   end
 
+  def self.test_method_invocation(method, input, result: nil, error: nil)
+    label = ->(value) {
+      case value
+      in String                     then value.dump
+      in true | false | nil         then value.to_s
+      in Integer if value.negative? then value.to_s
+      in Integer
+        "0x" + ("%016x" % value).chars.each_slice(4).map(&:join).join(?_)
+      end
+    }
+    if error
+      test "#%s(%s) raises %s" % [method, label[input], error.name] do
+        assert_raise error do NumValidator.public_send(method, input) end
+      end
+    else
+      test "#%s(%s) => %s" % [method, label[input], label.(result)] do
+        assert_equal result, NumValidator.public_send(method, input)
+      end
+    end
+  end
+
   # Test valid_{type}?(input), e.g:
   #   #ensure_nz_number(0x0000_0000_ffff_ffff) => true
   #   #ensure_nz_number(0x0000_0001_0000_0000) => false
-  def self.define_test_for_valid_predicate(method, label, value, valid)
-    test "#%s(%s) => %p" % [method, label, valid] do
-      assert_equal valid, NumValidator.public_send(method, value)
-    end
-  end
-
   each_num_validator_type_method(:valid, "?") do |type, method|
-    each_test_value_for type do |label, value, valid|
-      define_test_for_valid_predicate(method, label, value, valid)
-    end
-  end
-
-  def assert_format_error
-    assert_raise Net::IMAP::DataFormatError do
-      yield
+    each_integer_test_value_for type do |value, valid|
+      test_method_invocation(method, value, result: valid)
     end
   end
 
   # Test ensure_{type}(input), e.g:
   #   #ensure_nz_number(0x0000_0000_ffff_ffff) => 0x0000_0000_ffff_ffff
   #   #ensure_nz_number(0x0000_0001_0000_0000) raises DataFormatError
-  def self.define_test_for_ensure(method, label, value, valid)
-    result = valid ? "=> #{label}" : "raises DataFormatError"
-    test "#%s(%s) %s" % [method, label, result] do
-      if valid
-        assert_equal value, NumValidator.public_send(method, value)
-      else
-        assert_format_error do NumValidator.public_send(method, value) end
-      end
-    end
-  end
-
   each_num_validator_type_method(:ensure) do |type, method|
-    each_test_value_for type do |label, value, valid|
-      define_test_for_ensure(method, label, value, valid)
+    each_integer_test_value_for type do |value, valid|
+      if valid
+        test_method_invocation(method, value, result: value)
+      else
+        test_method_invocation(method, value, error: Net::IMAP::DataFormatError)
+      end
     end
   end
 
@@ -85,22 +93,13 @@ class NumValidatorTest < Net::IMAP::TestCase
   #   #coerce_number64("9223372036854775808") raises DataFormatError
   #   #coerce_number64(0x7fff_ffff_ffff_ffff) => 9223372036854775807
   #   #coerce_number64(0x8000_0000_0000_0000) raises DataFormatError
-  def self.define_test_for_coerce(method, label, value, valid)
-    result = valid ? "=> #{value}" : "raises DataFormatError"
-    [value, value.to_s].each do |input|
-      test "#%s(%p) %s" % [method, input, result] do
-        if valid
-          assert_equal value, NumValidator.public_send(method, input)
-        else
-          assert_format_error do NumValidator.public_send(method, input) end
-        end
-      end
-    end
-  end
-
   each_num_validator_type_method(:coerce) do |type, method|
-    each_test_value_for type do |label, value, valid|
-      define_test_for_coerce(method, label, value, valid)
+    each_coercible_test_value_for type do |value, valid, coerced|
+      if valid
+        test_method_invocation(method, value, result: coerced)
+      else
+        test_method_invocation(method, value, error: Net::IMAP::DataFormatError)
+      end
     end
   end
 

--- a/test/net/imap/test_num_validator.rb
+++ b/test/net/imap/test_num_validator.rb
@@ -22,7 +22,9 @@ class NumValidatorTest < Net::IMAP::TestCase
     0xffff_ffff_ffff_ffff => %i[invalid],
   }
 
-  def self.using_test_values_for(type)
+  TYPES = TEST_VALUES.values.flatten.uniq - [:invalid]
+
+  def self.each_test_value_for(type)
     TEST_VALUES.each do |value, types|
       label = value if value < 1
       label ||= "0x" + ("%016x" % value).chars.each_slice(4).map(&:join).join(?_)
@@ -30,39 +32,25 @@ class NumValidatorTest < Net::IMAP::TestCase
     end
   end
 
-  using_test_values_for :number do |label, value, valid|
-    test "#valid_number?(%s) => %p" % [label, valid] do
-      assert_equal valid, NumValidator.valid_number?(value)
+  def self.each_num_validator_type_method(prefix, suffix = "")
+    TYPES.each do |type|
+      method_name = "#{prefix}_#{type}#{suffix}".tr(?-, ?_)
+      yield type, method_name
     end
   end
 
-  using_test_values_for :"nz-number" do |label, value, valid|
-    test "#valid_nz_number?(%s) => %p" % [label, valid] do
-      assert_equal valid, NumValidator.valid_nz_number?(value)
+  # Test valid_{type}?(input), e.g:
+  #   #ensure_nz_number(0x0000_0000_ffff_ffff) => true
+  #   #ensure_nz_number(0x0000_0001_0000_0000) => false
+  def self.define_test_for_valid_predicate(method, label, value, valid)
+    test "#%s(%s) => %p" % [method, label, valid] do
+      assert_equal valid, NumValidator.public_send(method, value)
     end
   end
 
-  using_test_values_for :number64 do |label, value, valid|
-    test "#valid_number64?(%s) => %p" % [label, valid] do
-      assert_equal valid, NumValidator.valid_number64?(value)
-    end
-  end
-
-  using_test_values_for :"nz-number64" do |label, value, valid|
-    test "#valid_nz_number64?(%s) => %p" % [label, valid] do
-      assert_equal valid, NumValidator.valid_nz_number64?(value)
-    end
-  end
-
-  using_test_values_for :"mod-sequence-value" do |label, value, valid|
-    test "#valid_mod_sequence_value?(%s) => %p" % [label, valid] do
-      assert_equal valid, NumValidator.valid_mod_sequence_value?(value)
-    end
-  end
-
-  using_test_values_for :"mod-sequence-valzer" do |label, value, valid|
-    test "#valid_mod_sequence_valzer?(%s) => %p" % [label, valid] do
-      assert_equal valid, NumValidator.valid_mod_sequence_valzer?(value)
+  each_num_validator_type_method(:valid, "?") do |type, method|
+    each_test_value_for type do |label, value, valid|
+      define_test_for_valid_predicate(method, label, value, valid)
     end
   end
 
@@ -72,147 +60,47 @@ class NumValidatorTest < Net::IMAP::TestCase
     end
   end
 
-  using_test_values_for :number do |label, value, valid|
+  # Test ensure_{type}(input), e.g:
+  #   #ensure_nz_number(0x0000_0000_ffff_ffff) => 0x0000_0000_ffff_ffff
+  #   #ensure_nz_number(0x0000_0001_0000_0000) raises DataFormatError
+  def self.define_test_for_ensure(method, label, value, valid)
     result = valid ? "=> #{label}" : "raises DataFormatError"
-    test "#ensure_number(%s) %s" % [label, result] do
+    test "#%s(%s) %s" % [method, label, result] do
       if valid
-        assert_equal value, NumValidator.ensure_number(value)
+        assert_equal value, NumValidator.public_send(method, value)
       else
-        assert_format_error do NumValidator.ensure_number(value) end
+        assert_format_error do NumValidator.public_send(method, value) end
       end
     end
   end
 
-  using_test_values_for :"nz-number" do |label, value, valid|
-    result = valid ? "=> #{label}" : "raises DataFormatError"
-    test "#ensure_nz_number(%s) %s" % [label, result] do
-      if valid
-        assert_equal value, NumValidator.ensure_nz_number(value)
-      else
-        assert_format_error do NumValidator.ensure_nz_number(value) end
-      end
+  each_num_validator_type_method(:ensure) do |type, method|
+    each_test_value_for type do |label, value, valid|
+      define_test_for_ensure(method, label, value, valid)
     end
   end
 
-  using_test_values_for :number64 do |label, value, valid|
-    result = valid ? "=> #{label}" : "raises DataFormatError"
-    test "#ensure_number64(%s) %s" % [label, result] do
-      if valid
-        assert_equal value, NumValidator.ensure_number64(value)
-      else
-        assert_format_error do NumValidator.ensure_number64(value) end
-      end
-    end
-  end
-
-  using_test_values_for :"nz-number64" do |label, value, valid|
-    result = valid ? "=> #{label}" : "raises DataFormatError"
-    test "#ensure_nz_number64(%s) %s" % [label, result] do
-      if valid
-        assert_equal value, NumValidator.ensure_nz_number64(value)
-      else
-        assert_format_error do NumValidator.ensure_nz_number64(value) end
-      end
-    end
-  end
-
-  using_test_values_for :"mod-sequence-value" do |label, value, valid|
-    result = valid ? "=> #{label}" : "raises DataFormatError"
-    test "#ensure_mod_sequence_value(%s) %s" % [label, result] do
-      if valid
-        assert_equal value, NumValidator.ensure_mod_sequence_value(value)
-      else
-        assert_format_error do NumValidator.ensure_mod_sequence_value(value) end
-      end
-    end
-  end
-
-  using_test_values_for :"mod-sequence-valzer" do |label, value, valid|
-    result = valid ? "=> #{label}" : "raises DataFormatError"
-    test "#ensure_mod_sequence_valzer(%s) %s" % [label, result] do
-      if valid
-        assert_equal value, NumValidator.ensure_mod_sequence_valzer(value)
-      else
-        assert_format_error do NumValidator.ensure_mod_sequence_valzer(value) end
-      end
-    end
-  end
-
-  using_test_values_for :number do |label, value, valid|
+  # Test coerce_{type}(input), e.g:
+  #   #coerce_number64("9223372036854775807") => 9223372036854775807
+  #   #coerce_number64("9223372036854775808") raises DataFormatError
+  #   #coerce_number64(0x7fff_ffff_ffff_ffff) => 9223372036854775807
+  #   #coerce_number64(0x8000_0000_0000_0000) raises DataFormatError
+  def self.define_test_for_coerce(method, label, value, valid)
     result = valid ? "=> #{value}" : "raises DataFormatError"
     [value, value.to_s].each do |input|
-      test "#coerce_number(%p) %s" % [input, result] do
+      test "#%s(%p) %s" % [method, input, result] do
         if valid
-          assert_equal value, NumValidator.coerce_number(input)
+          assert_equal value, NumValidator.public_send(method, input)
         else
-          assert_format_error do NumValidator.coerce_number(input) end
+          assert_format_error do NumValidator.public_send(method, input) end
         end
       end
     end
   end
 
-  using_test_values_for :"nz-number" do |label, value, valid|
-    result = valid ? "=> #{value}" : "raises DataFormatError"
-    [value, value.to_s].each do |input|
-      test "#coerce_nz_number(%p) %s" % [input, result] do
-        if valid
-          assert_equal value, NumValidator.coerce_nz_number(input)
-        else
-          assert_format_error do NumValidator.coerce_nz_number(input) end
-        end
-      end
-    end
-  end
-
-  using_test_values_for :number64 do |label, value, valid|
-    result = valid ? "=> #{value}" : "raises DataFormatError"
-    [value, value.to_s].each do |input|
-      test "#coerce_number64(%p) %s" % [input, result] do
-        if valid
-          assert_equal value, NumValidator.coerce_number64(input)
-        else
-          assert_format_error do NumValidator.coerce_number64(input) end
-        end
-      end
-    end
-  end
-
-  using_test_values_for :"nz-number64" do |label, value, valid|
-    result = valid ? "=> #{value}" : "raises DataFormatError"
-    [value, value.to_s].each do |input|
-      test "#coerce_nz_number64(%p) %s" % [input, result] do
-        if valid
-          assert_equal value, NumValidator.coerce_nz_number64(input)
-        else
-          assert_format_error do NumValidator.coerce_nz_number64(input) end
-        end
-      end
-    end
-  end
-
-  using_test_values_for :"mod-sequence-value" do |label, value, valid|
-    result = valid ? "=> #{value}" : "raises DataFormatError"
-    [value, value.to_s].each do |input|
-      test "#coerce_mod_sequence_value(%p) %s" % [input, result] do
-        if valid
-          assert_equal value, NumValidator.coerce_mod_sequence_value(input)
-        else
-          assert_format_error do NumValidator.coerce_mod_sequence_value(input) end
-        end
-      end
-    end
-  end
-
-  using_test_values_for :"mod-sequence-valzer" do |label, value, valid|
-    result = valid ? "=> #{value}" : "raises DataFormatError"
-    [value, value.to_s].each do |input|
-      test "#coerce_mod_sequence_valzer(%p) %s" % [input, result] do
-        if valid
-          assert_equal value, NumValidator.coerce_mod_sequence_valzer(input)
-        else
-          assert_format_error do NumValidator.coerce_mod_sequence_valzer(input) end
-        end
-      end
+  each_num_validator_type_method(:coerce) do |type, method|
+    each_test_value_for type do |label, value, valid|
+      define_test_for_coerce(method, label, value, valid)
     end
   end
 

--- a/test/net/imap/test_num_validator.rb
+++ b/test/net/imap/test_num_validator.rb
@@ -9,6 +9,9 @@ class NumValidatorTest < Net::IMAP::TestCase
   TEST_VALUES = {
     -1          => %i[invalid],
 
+    {"000"=> 0} => %i[number           number64                                mod-sequence-valzer],
+    {"011"=>11} => %i[number           number64             mod-sequence-value mod-sequence-valzer],
+
     0           => %i[number           number64                                mod-sequence-valzer],
     1           => %i[number nz-number number64 nz-number64 mod-sequence-value mod-sequence-valzer],
     0x0000_ffff => %i[number nz-number number64 nz-number64 mod-sequence-value mod-sequence-valzer],
@@ -26,14 +29,20 @@ class NumValidatorTest < Net::IMAP::TestCase
 
   def self.each_integer_test_value_for(type)
     TEST_VALUES.each do |value, types|
-      yield value, types.include?(type)
+      yield value, types.include?(type) if Integer === value
     end
   end
 
   def self.each_coercible_test_value_for(type)
-    each_integer_test_value_for(type) do |value, valid|
-      [value, value.to_s].each do |input|
-        yield input, valid, value
+    TEST_VALUES.each do |value, types|
+      valid = types.include?(type)
+      case value
+      in Integer
+        [value, value.to_s].each do |input|
+          yield input, valid, value
+        end
+      in Hash if value.to_a in [[String => input, Integer => coerced]]
+        yield input, valid, coerced
       end
     end
   end


### PR DESCRIPTION
Convert most `NumValidator#coerce_{type}` methods to a simpler `/\A\d+\z/` regexp.

The formal syntax in the RFCs would appear to allow any of zero-able numbers to be zero-padded: i.e, not only `"0" => 0`, but also `"000" => 0` and `"012" => 12`!

[RFC9051](https://www.rfc-editor.org/rfc/rfc9051#name-formal-syntax):
```abnf
number          = 1*DIGIT
number64        = 1*DIGIT
nz-number       = digit-nz *DIGIT
nz-number64     = digit-nz *DIGIT
```

[RFC7162](https://www.rfc-editor.org/rfc/rfc7162.html#section-7):
```abnf
mod-sequence-value  = 1*DIGIT
mod-sequence-valzer = "0" / mod-sequence-value
```

I dont' like this.  I'd prefer that the specs for `number`, `number64`, and `mod-sequence-value` were stricter, like my original regexps:
```abnf
number              = "0" / nz-number
number64            = "0" / nz-number64
mod-sequence-valzer = "0" / mod-sequence-value
nz-number           = digit-nz *DIGIT
nz-number64         = digit-nz *DIGIT
mod-sequence-value  = digit-nz *DIGIT
```

... but they're not!

A future release may add an upper limit to how many prefix zeros can be added, to prohibit goofy numbers like `"0000000000000000000000000001"`.  But that's a lot more important for the regexps used by `ResponseReader` and `ResponseParser` than it is for the regexps used by `NumValidator`.
