### PR TITLE
🥅 Validate response literal byte size format

### DIFF
--- a/lib/net/imap/response_parser.rb
+++ b/lib/net/imap/response_parser.rb
@@ -2212,10 +2212,7 @@ module Net
             if $1
               return Token.new(T_SPACE, $+)
             elsif $2
-              len = $+.to_i
-              val = @str[@pos, len]
-              @pos += len
-              return Token.new(T_LITERAL8, val)
+              literal_token($+, T_LITERAL8)
             elsif $3 && $7
               # greedily match ATOM, prefixed with NUMBER, NIL, or PLUS.
               return Token.new(T_ATOM, $3)
@@ -2243,10 +2240,7 @@ module Net
             elsif $15
               return Token.new(T_RBRA, $+)
             elsif $16
-              len = $+.to_i
-              val = @str[@pos, len]
-              @pos += len
-              return Token.new(T_LITERAL, val)
+              literal_token($+)
             elsif $17
               return Token.new(T_PERCENT, $+)
             elsif $18
@@ -2272,10 +2266,7 @@ module Net
             elsif $4
               return Token.new(T_QUOTED, Patterns.unescape_quoted($+))
             elsif $5
-              len = $+.to_i
-              val = @str[@pos, len]
-              @pos += len
-              return Token.new(T_LITERAL, val)
+              literal_token($+)
             elsif $6
               return Token.new(T_LPAR, $+)
             elsif $7
@@ -2290,6 +2281,15 @@ module Net
         else
           parse_error("invalid @lex_state - %s", @lex_state.inspect)
         end
+      rescue DataFormatError => error
+        parse_error error.message
+      end
+
+      def literal_token(len, type = T_LITERAL)
+        len = NumValidator.coerce_number64 len
+        val = @str[@pos, len]
+        @pos += len
+        Token.new(type, val)
       end
 
     end

--- a/lib/net/imap/response_reader.rb
+++ b/lib/net/imap/response_reader.rb
@@ -4,6 +4,8 @@ module Net
   class IMAP
     # See https://www.rfc-editor.org/rfc/rfc9051#section-2.2.2
     class ResponseReader # :nodoc:
+      include NumValidator
+
       attr_reader :client
 
       def initialize(client, sock)
@@ -46,7 +48,10 @@ module Net
       def line_done?          = buff.end_with?(CRLF)
 
       def get_literal_size(buff)
-        buff.end_with?("}\r\n") && buff.rindex(/\{(\d+)\}\r\n\z/n) && $1.to_i
+        buff.end_with?("}\r\n") && buff.rindex(/\{(\d+)\}\r\n\z/n) &&
+          coerce_number64($1)
+      rescue DataFormatError
+        raise DataFormatError, format("invalid response literal size (%s)", $1)
       end
 
       def read_line

--- a/test/net/imap/fixtures/response_parser/quirky_behaviors.yml
+++ b/test/net/imap/fixtures/response_parser/quirky_behaviors.yml
@@ -7,6 +7,22 @@
       data:
       raw_data: "* NOOP\r\n"
 
+  "literal numeric formatted with zero-prefix":
+    :response: "* 20367 FETCH (BODY[HEADER.FIELDS (Foo)] {012}\r\nFoo: bar\r\n\r\n)\r\n"
+    :expected: !ruby/struct:Net::IMAP::UntaggedResponse
+      name: FETCH
+      data: !ruby/struct:Net::IMAP::FetchData
+        seqno: 20367
+        attr:
+          BODY[HEADER.FIELDS (Foo)]: "Foo: bar\r\n\r\n"
+      raw_data: "* 20367 FETCH (BODY[HEADER.FIELDS (Foo)] {012}\r\nFoo: bar\r\n\r\n)\r\n"
+
+  "invalid literal numeric format (too large)":
+    :test_type: :assert_parse_failure
+    :message: "number64 must be unsigned 63-bit integer: 99999999999999999999"
+    :response:
+      "* 20367 FETCH (BODY[] {99999999999999999999}\r\nwon't parse this)\r\n"
+
   test_invalid_noop_response_with_unparseable_data:
     :response: "* NOOP froopy snood\r\n"
     :expected: !ruby/struct:Net::IMAP::IgnoredResponse

--- a/test/net/imap/test_response_reader.rb
+++ b/test/net/imap/test_response_reader.rb
@@ -25,6 +25,8 @@ class ResponseReaderTest < Net::IMAP::TestCase
     zero_literal = "tag ok #{literal ""} #{literal ""}\r\n"
     illegal_crs  = "tag ok #{many_crs} #{many_crs}\r\n"
     illegal_lfs  = "tag ok #{literal "\r"}\n#{literal "\r"}\n\r\n"
+    zero_padded  = "+ {010}\r\n1234567890\r\n" # NOTE: it's decimal, not octal!
+    goofy_zero   = "+ {000}\r\n\r\n"
     io = StringIO.new([
       simple,
       long_line,
@@ -33,6 +35,8 @@ class ResponseReaderTest < Net::IMAP::TestCase
       zero_literal,
       illegal_crs,
       illegal_lfs,
+      zero_padded,
+      goofy_zero,
       simple,
     ].join)
     rcvr = Net::IMAP::ResponseReader.new(client, io)
@@ -43,6 +47,8 @@ class ResponseReaderTest < Net::IMAP::TestCase
     assert_equal zero_literal, rcvr.read_response_buffer.to_str
     assert_equal illegal_crs,  rcvr.read_response_buffer.to_str
     assert_equal illegal_lfs,  rcvr.read_response_buffer.to_str
+    assert_equal zero_padded,  rcvr.read_response_buffer.to_str
+    assert_equal goofy_zero,   rcvr.read_response_buffer.to_str
     assert_equal simple,       rcvr.read_response_buffer.to_str
     assert_equal "",           rcvr.read_response_buffer.to_str
   end
@@ -80,6 +86,21 @@ class ResponseReaderTest < Net::IMAP::TestCase
       result = rcvr.read_response_buffer
       flunk "Got result: %p" % [result]
     end
+  end
+
+  data(
+    bad_int64: "+ {99999999999999999999}\r\ndon't even try to read this...",
+  )
+  test "#read_response_buffer with invalid literal size" do |invalid|
+    client  = FakeClient.new
+    client.config.max_response_size = nil # any size is allowed!
+    io = StringIO.new(invalid, "rb")
+    rcvr = Net::IMAP::ResponseReader.new(client, io)
+    assert_raise Net::IMAP::DataFormatError do
+      result = rcvr.read_response_buffer
+      flunk "Got result: %p" % [result]
+    end
+    # assert io.closed?
   end
 
   test "linear performance detecting literal continuation" do


### PR DESCRIPTION
This guards against numbers like `99999999999999999999`.

This isn't a security issue (unless `max_response_size` is set to `nil`).  But it's reasonable to block too large numbers in both the response reader and the response parser, regardless of that config setting.

Note also that this still _allows_ strings like `000000000000000001`. This is goofy, but it's how the RFCs are written!  (See #680.)