### PR TITLE
🥅 Validate that Atom and Flag are not empty

### DIFF
--- a/lib/net/imap/command_data.rb
+++ b/lib/net/imap/command_data.rb
@@ -257,6 +257,8 @@ module Net
           or raise DataFormatError, "#{self.class} must be ASCII only"
         data.match?(ResponseParser::Patterns::ATOM_SPECIALS) \
           and raise DataFormatError, "#{self.class} must not contain atom-specials"
+        data.empty? \
+          and raise DataFormatError, "#{self.class} must not be empty"
       end
 
       def send_data(imap, tag)

--- a/test/net/imap/test_command_data.rb
+++ b/test/net/imap/test_command_data.rb
@@ -85,6 +85,7 @@ class CommandDataTest < Net::IMAP::TestCase
       "with_quoted_specials\\",
       "with\rCR",
       "with\nLF",
+      "", # empty
     ].each do |symbol|
       assert_raise_with_message(Net::IMAP::DataFormatError, /\batom\b/i) do
         imap.send_data Atom[symbol]
@@ -116,6 +117,7 @@ class CommandDataTest < Net::IMAP::TestCase
       :"with_quoted_specials\\",
       :"with\rCR",
       :"with\nLF",
+      :"", # empty
     ].each do |symbol|
       assert_raise_with_message(Net::IMAP::DataFormatError, /\bflag\b/i) do
         imap.send_data Flag[symbol]


### PR DESCRIPTION
`Atom` and `Flag` have only been used for argument validation since v0.6.4 (as well as v0.5.14 and v0.4.24), and they validated for absense of `atom-specials`.  But they failed to check that the strings are not empty.

While this could be used to create syntax errors, I don't believe it amounts a security vulnerability.  The result would be no different from any other `BAD` server response, which an application must be prepared to handle.