### PR TITLE
🧵 Fix deadlock in `#disconnect`

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -1190,22 +1190,24 @@ module Net
 
     # Disconnects from the server.
     #
-    # Waits for receiver thread to close before returning.  Slow or stuck
-    # response handlers can cause #disconnect to hang until they complete.
+    # Waits for receiver thread to close before returning, except when called
+    # from inside the connection mutex such as from a response handler.  Slow or
+    # stuck response handlers can cause #disconnect to hang until they complete.
     #
     # Related: #logout, #logout!
     def disconnect
       in_logout_state = try_state_logout?
       return if disconnected?
+      in_receiver_thread = Thread.current == @receiver_thread
       begin
         @sock.to_io.shutdown
       rescue Errno::ENOTCONN
         # ignore `Errno::ENOTCONN: Socket is not connected' on some platforms.
       rescue Exception => e
-        @receiver_thread.raise(e)
+        @receiver_thread.raise(e) unless in_receiver_thread
       end
       @sock.close
-      @receiver_thread.join
+      @receiver_thread.join unless mon_owned? || in_receiver_thread
       raise e if e
     ensure
       # Try again after shutting down the receiver thread.  With no reciever


### PR DESCRIPTION
`#disconnect` could deadlock when called inside the mutex, because the receiver thread could be signaling a condition variable and it would thus be unable to resume until the current thread releases its lock.

Also, `#disconnect` shouldn't raise `IO#shutdown` exceptions on the receiver thread prior to closing the socket, when it is being called from the receiver thread.  The exception is still raised, _after_ the socket is closed.