### PR TITLE
🧵 Add thread join timeout to `#disconnect`

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -1193,9 +1193,10 @@ module Net
     # Waits for receiver thread to close before returning, except when called
     # from inside the connection mutex such as from a response handler.  Slow or
     # stuck response handlers can cause #disconnect to hang until they complete.
+    # Use +timeout+ to limit how long to wait for the receiver thread to exit.
     #
     # Related: #logout, #logout!
-    def disconnect
+    def disconnect(timeout: nil)
       in_logout_state = try_state_logout?
       return if disconnected?
       in_receiver_thread = Thread.current == @receiver_thread
@@ -1207,7 +1208,7 @@ module Net
         @receiver_thread.raise(e) unless in_receiver_thread
       end
       @sock.close
-      @receiver_thread.join unless mon_owned? || in_receiver_thread
+      @receiver_thread.join(timeout) unless mon_owned? || in_receiver_thread
       raise e if e
     ensure
       # Try again after shutting down the receiver thread.  With no reciever


### PR DESCRIPTION
Since `#disconnect` joins the receiver thread, it may hang until slow response handlers complete.  This allows the user to provide a timeout.