### PR TITLE
🥅 Guard against tagged responses sent too soon

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3738,7 +3738,6 @@ module Net
       when /\A(?:BAD)\z/ni
         raise BadResponseError, resp
       else
-        disconnect
         raise InvalidResponseError, "invalid tagged resp: %p" % [resp.raw_data.chomp]
       end
     end

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3252,8 +3252,8 @@ module Net
       response = nil
 
       synchronize do
-        tag = Thread.current[:net_imap_tag] = generate_tag
-        command = Command[tag:, name: "IDLE"]
+        command = start_command(name: "IDLE")
+        tag = Thread.current[:net_imap_tag] = command.tag # TODO: remove this
         put_string("#{tag} IDLE#{CRLF}")
         finish_sending_command(command)
 
@@ -3687,8 +3687,8 @@ module Net
     def send_command(cmd, *args, &block)
       args.each do validate_data _1 end
       synchronize do
-        tag = generate_tag
-        command = Command[tag:, name: cmd]
+        command = start_command(name: cmd)
+        tag = command.tag
         put_string(tag + " " + cmd)
         args.each do |i|
           put_string(" ")
@@ -3708,6 +3708,15 @@ module Net
         disconnect
         raise
       end
+    end
+
+    def start_command(**)
+      raise IOError, "closed stream" if disconnected?
+      command = Command.new(**, tag: generate_tag)
+      if (response = @tagged_responses[command.tag])
+        raise InvalidTaggedResponseError.new(:unstarted, command:, response:)
+      end
+      command
     end
 
     # NOTE: This must be synchronized with sending the command's final CRLF and

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -1479,15 +1479,18 @@ module Net
       rescue Exception => error
         raise # note that the error backtrace is in the receiver_thread
       end
-      if error
+      begin
+        if error
+          reraise error
+        elsif !handled
+          raise InvalidResponseError,
+                "STARTTLS handler was bypassed, although server responded %p" % [
+                  ok.raw_data.chomp
+                ]
+        end
+      rescue Exception => error
         disconnect
-        reraise error
-      elsif !handled
-        disconnect
-        raise InvalidResponseError,
-              "STARTTLS handler was bypassed, although server responded %p" % [
-                ok.raw_data.chomp
-              ]
+        raise
       end
       ok
     end

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -1479,7 +1479,7 @@ module Net
       rescue Exception => error
         raise # note that the error backtrace is in the receiver_thread
       end
-      begin
+      synchronize do
         if error
           reraise error
         elsif !handled
@@ -1489,6 +1489,7 @@ module Net
                 ]
         end
       rescue Exception => error
+        @client_disconnect_error ||= error
         disconnect
         raise
       end
@@ -3271,7 +3272,8 @@ module Net
             response = get_tagged_response(tag, "IDLE", idle_response_timeout)
           end
         end
-      rescue InvalidResponseError
+      rescue InvalidResponseError => error
+        @client_disconnect_error ||= error
         disconnect
         raise
       end
@@ -3701,7 +3703,8 @@ module Net
         ensure
           remove_response_handler(block) if block
         end
-      rescue InvalidResponseError
+      rescue InvalidResponseError => error
+        @client_disconnect_error ||= error
         disconnect
         raise
       end

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -1482,8 +1482,7 @@ module Net
       if error
         disconnect
         reraise error
-      end
-      unless handled
+      elsif !handled
         disconnect
         raise InvalidResponseError,
               "STARTTLS handler was bypassed, although server responded %p" % [

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -220,13 +220,16 @@ class IMAPTest < Net::IMAP::TestCase
     end
   end
 
-  # Similar to STARTTLS stripping test, but checks other commands too
+  # Similar to STARTTLS stripping test, but checks other commands and statuses
   data(
-    "IDLE"   => ->imap do imap.idle(1) do end end,
-    "NOOP"   => ->imap do imap.noop end,
-    "SELECT" => ->imap do imap.select("inbox") end,
+    "OK for IDLE"    => ["OK",  ->imap do imap.idle(1) do end end],
+    "OK for NOOP"    => ["OK",  ->imap do imap.noop end],
+    "NO for IDLE"    => ["NO",  ->imap do imap.idle(1) do end end],
+    "NO for EXAMINE" => ["NO",  ->imap do imap.examine("inbox") end],
+    "BAD for IDLE"   => ["BAD", ->imap do imap.idle(1) do end end],
+    "BAD for SELECT" => ["BAD", ->imap do imap.select("inbox") end],
   )
-  test "premature tagged OK response" do |cmd|
+  test "premature tagged response" do |(status, cmd)|
     timeout = 5
     timeout *= EnvUtil.timeout_scale || 1 if defined?(EnvUtil.timeout_scale)
     Timeout.timeout(timeout) do
@@ -240,9 +243,9 @@ class IMAPTest < Net::IMAP::TestCase
         begin
           sock.print("* OK test server\r\n")
           assert_equal :send_malicious_responses, client_to_server.pop
-          sock.print("RUBY0001 OK invalid\r\n")
-          sock.print("RUBY0002 OK false\r\n")
-          sock.print("RUBY0003 OK tricky\r\n")
+          sock.print("RUBY0001 #{status} invalid\r\n")
+          sock.print("RUBY0002 #{status} false\r\n")
+          sock.print("RUBY0003 #{status} tricky\r\n")
           server_to_client << :sent_malicious_responses
           sock.gets
         ensure
@@ -260,7 +263,9 @@ class IMAPTest < Net::IMAP::TestCase
         assert_equal :sent_malicious_responses, server_to_client.pop
         assert_equal [1, 2, 3], 3.times.map { rcvr_to_client.pop }
         # should respond this way for _any_ command
-        assert_local_raise(Net::IMAP::InvalidTaggedResponseError) do
+        assert_local_raise(
+          Net::IMAP::InvalidTaggedResponseError, / unstarted .*tag=RUBY0001/
+        ) do
           cmd.(imap)
         end
         assert imap.disconnected?


### PR DESCRIPTION
The premature tagged response guard that was added for #644 only checked for premature `OK`, not for premature `BAD` or `NO`.  When those are detected prior to the tag being sent, this treats those cases as the same sort of error.

Note that this explicitly raises a "closed stream" IOError when disconnected.  This is the error that would be raised anyway, if `send_command` were allowed to write to the connection.  But, if we can test that the socket is already closed, we can raise the error directly. There's no need to attempt to format and send data.  A future version will probably change this to raise a different error (subclass of `Net::IMAP::Error`) instead.