### PR TITLE
🧵🥅 Reraise receiver thread errors with caller's backtrace

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3710,7 +3710,14 @@ module Net
     def reraise(exception)
       return unless exception
       copy = exception.dup
-      copy.set_backtrace nil
+      # NOTE: set_backtrace(caller_locations) doesn't work for CRuby <= 3.3.
+      #   and set_backtrace(nil) doesn't work for TruffleRuby 34.0.0:
+      #   https://github.com/truffleruby/truffleruby/issues/4296
+      if RUBY_ENGINE == "truffleruby"
+        copy.set_backtrace caller_locations
+      else
+        copy.set_backtrace nil
+      end
       if exception.cause || exception.backtrace
         raise copy, cause: exception
       else

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3587,34 +3587,6 @@ module Net
       state_logout!
     end
 
-    def get_tagged_response(tag, cmd, timeout = nil)
-      if timeout
-        deadline = Time.now + timeout
-      end
-      until @tagged_responses.key?(tag)
-        raise @exception if @exception
-        if timeout
-          timeout = deadline - Time.now
-          if timeout <= 0
-            return nil
-          end
-        end
-        @tagged_response_arrival.wait(timeout)
-      end
-      resp = @tagged_responses.delete(tag)
-      case resp.name
-      when /\A(?:OK)\z/ni
-        return resp
-      when /\A(?:NO)\z/ni
-        raise NoResponseError, resp
-      when /\A(?:BAD)\z/ni
-        raise BadResponseError, resp
-      else
-        disconnect
-        raise InvalidResponseError, "invalid tagged resp: %p" % [resp.raw_data.chomp]
-      end
-    end
-
     def get_response
       buff = @reader.read_response_buffer
       return nil if buff.length == 0
@@ -3690,6 +3662,34 @@ module Net
     def finish_sending_command(command)
       if (response = @tagged_responses[command.tag])&.name&.casecmp?("OK")
         raise InvalidTaggedResponseError.new(:incomplete, command:, response:)
+      end
+    end
+
+    def get_tagged_response(tag, cmd, timeout = nil)
+      if timeout
+        deadline = Time.now + timeout
+      end
+      until @tagged_responses.key?(tag)
+        raise @exception if @exception
+        if timeout
+          timeout = deadline - Time.now
+          if timeout <= 0
+            return nil
+          end
+        end
+        @tagged_response_arrival.wait(timeout)
+      end
+      resp = @tagged_responses.delete(tag)
+      case resp.name
+      when /\A(?:OK)\z/ni
+        return resp
+      when /\A(?:NO)\z/ni
+        raise NoResponseError, resp
+      when /\A(?:BAD)\z/ni
+        raise BadResponseError, resp
+      else
+        disconnect
+        raise InvalidResponseError, "invalid tagged resp: %p" % [resp.raw_data.chomp]
       end
     end
 

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3212,7 +3212,7 @@ module Net
           @idle_done_cond.wait(timeout)
           @idle_done_cond = nil
           if @receiver_thread_terminating
-            raise @exception || Net::IMAP::Error.new("connection closed")
+            reraise @exception || Net::IMAP::Error.new("connection closed")
           end
         ensure
           remove_response_handler(response_handler)
@@ -3670,7 +3670,7 @@ module Net
         deadline = Time.now + timeout
       end
       until @tagged_responses.key?(tag)
-        raise @exception if @exception
+        reraise @exception
         if timeout
           timeout = deadline - Time.now
           if timeout <= 0
@@ -3690,6 +3690,31 @@ module Net
       else
         disconnect
         raise InvalidResponseError, "invalid tagged resp: %p" % [resp.raw_data.chomp]
+      end
+    end
+
+    # Raises a copy of +exception+ with an updated +backtrace+ and +cause+, or
+    # returns +nil+ when +exception+ is falsey.
+    #
+    # +backtrace+ is set to reflect the current caller.
+    #
+    # +cause+ is set to the original exception, _if_ the original has its own
+    # backtrace or cause.  Otherwise, the original was never raised and the
+    # default cause is used.
+    #
+    # This is meant for exceptions that may have been created by another thread.
+    # Raising them directly gives a misleading backtrace, making it hard to
+    # discover where the errors originate.  Although it is sometimes more
+    # appropriate to raise a wrapping exception, that changes the API and forces
+    # updates to users' `rescue` pattern matching.
+    def reraise(exception)
+      return unless exception
+      copy = exception.dup
+      copy.set_backtrace nil
+      if exception.cause || exception.backtrace
+        raise copy, cause: exception
+      else
+        raise copy
       end
     end
 

--- a/lib/net/imap/command_data.rb
+++ b/lib/net/imap/command_data.rb
@@ -102,8 +102,7 @@ module Net
         @continuation_request_exception = nil
         begin
           @continuation_request_arrival.wait
-          e = @continuation_request_exception || @exception
-          raise e if e
+          reraise @continuation_request_exception || @exception
           put_string(str)
         ensure
           @continued_command_tag = nil

--- a/test/lib/helper.rb
+++ b/test/lib/helper.rb
@@ -216,7 +216,7 @@ class Net::IMAP::TestCase < Test::Unit::TestCase
       assert_raise(expected, &block)
     end
     stack = caller
-    assert_equal stack, error.backtrace.last(stack.size)
+    assert_equal stack, error.backtrace&.last(stack.size)
     error
   end
 

--- a/test/lib/helper.rb
+++ b/test/lib/helper.rb
@@ -62,6 +62,17 @@ class Net::IMAP::TestCase < Test::Unit::TestCase
     end
   end
 
+  def wait_for_receiver_thread_terminating(imap, timeout: 0.5, interval: 0.001)
+    deadline = Time.now + timeout
+    loop do
+      break if imap.instance_exec {
+        synchronize { @receiver_thread_terminating }
+      }
+      break :deadline if deadline < Time.now
+      sleep interval
+    end
+  end
+
   # assert_linear_performance didn't fail reliably until "n" was far too high,
   # even though the problem was very obvious at lower "n" values, by looking at
   # the mean (plus stddev) rather than the max (plus variance-based "safety
@@ -185,9 +196,43 @@ class Net::IMAP::TestCase < Test::Unit::TestCase
   end
 
   def assert_stream_closed_error
-    assert_raise_with_message(IOError, /\A(?:stream closed|closed stream)\z/) do
+    assert_local_raise(IOError, /\A(?:stream closed|closed stream)\z/) do
       yield
     end
+  end
+
+  # Combines +assert_raise+ and +assert_raise_with_message+ with an assertion
+  # that the backtrace matches the caller.
+  def assert_local_raise(expected, message = nil)
+    error = nil
+    block = -> do
+      yield
+    rescue expected => error
+      raise
+    end
+    if message
+      assert_raise_with_message(expected, message, &block)
+    else
+      assert_raise(expected, &block)
+    end
+    stack = caller
+    assert_equal stack, error.backtrace.last(stack.size)
+    error
+  end
+
+  # Combines +assert_local_raise+ with an assertion that the exception's cause
+  # is in the receiver thread.
+  #
+  # Must be called at least once while the receiver_thread is still running, so
+  # it can capture the top of the stacktrace.  After that, it'll continue to use
+  # the same stacktrace.
+  def assert_reraised(*args, imap: nil, &block)
+    @rcvr_thread_trace ||= imap.instance_variable_get(:@receiver_thread)
+      &.backtrace&.last(2)
+    error = assert_local_raise(*args, &block)
+    refute_nil @rcvr_thread_trace, "receiver thread not running?"
+    size = @rcvr_thread_trace.size
+    assert_equal @rcvr_thread_trace, error.cause&.backtrace.last(size)
   end
 
   def pend_if(condition, *args, &block)

--- a/test/net/imap/fake_server/command_reader.rb
+++ b/test/net/imap/fake_server/command_reader.rb
@@ -42,6 +42,9 @@ class Net::IMAP::FakeServer
         throw :eof
       end
       raise
+    rescue Errno::EPIPE, Errno::ECONNRESET
+      throw :eof if config.ignore_abrupt_eof?
+      raise
     end
 
     private

--- a/test/net/imap/fake_server/connection.rb
+++ b/test/net/imap/fake_server/connection.rb
@@ -42,6 +42,8 @@ class Net::IMAP::FakeServer
         end
         socket&.close unless socket&.closed?
       end
+    rescue Errno::EPIPE, Errno::ECONNRESET
+      raise unless config.ignore_abrupt_eof?
     end
 
     private

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -13,7 +13,7 @@ class IMAPTest < Net::IMAP::TestCase
 
   if defined?(OpenSSL::SSL::SSLError)
     def test_imaps_unknown_ca
-      assert_raise(OpenSSL::SSL::SSLError) do
+      assert_local_raise(OpenSSL::SSL::SSLError) do
         imaps_test do |port|
           begin
             Net::IMAP.new("localhost",
@@ -81,7 +81,7 @@ class IMAPTest < Net::IMAP::TestCase
     end
 
     def test_imaps_post_connection_check
-      assert_raise(OpenSSL::SSL::SSLError) do
+      assert_local_raise(OpenSSL::SSL::SSLError) do
         imaps_test do |port|
           # server_addr is different from the hostname in the certificate,
           # so the following code should raise a SSLError.
@@ -156,7 +156,7 @@ class IMAPTest < Net::IMAP::TestCase
       end
       begin
         imap = Net::IMAP.new("localhost", :port => port)
-        assert_raise(Net::IMAP::InvalidResponseError) do
+        assert_reraised(Net::IMAP::InvalidResponseError, imap:) do
           imap.starttls(:ca_file => CA_FILE)
         end
         assert imap.disconnected?
@@ -195,7 +195,7 @@ class IMAPTest < Net::IMAP::TestCase
         client_to_server << :send_malicious_response
         assert_equal :malicious_response_sent, server_to_client.pop
         sleep 0.010 # to be sure the network buffers have flushed, etc
-        assert_raise(Net::IMAP::InvalidTaggedResponseError) do
+        assert_local_raise(Net::IMAP::InvalidTaggedResponseError) do
           imap.starttls(:ca_file => CA_FILE)
         end
         assert imap.disconnected?
@@ -250,7 +250,9 @@ class IMAPTest < Net::IMAP::TestCase
         assert_equal :sent_malicious_responses, server_to_client.pop
         assert_equal [1, 2, 3], 3.times.map { rcvr_to_client.pop }
         # should respond this way for _any_ command
-        assert_raise(Net::IMAP::InvalidTaggedResponseError) do cmd.(imap) end
+        assert_local_raise(Net::IMAP::InvalidTaggedResponseError) do
+          cmd.(imap)
+        end
         assert imap.disconnected?
         assert_stream_closed_error do cmd.(imap) end
         assert_stream_closed_error do cmd.(imap) end
@@ -286,11 +288,73 @@ class IMAPTest < Net::IMAP::TestCase
     end
     begin
       imap = Net::IMAP.new(server_addr, :port => port)
-      assert_raise(EOFError) do
+      assert_local_raise EOFError do
         imap.logout
       end
     ensure
       imap.disconnect if imap
+    end
+  end
+
+  BrokenResponseReaderTestError = Class.new(StandardError)
+
+  test "exception from response reader" do
+    with_fake_server ignore_io_error: true, ignore_abrupt_eof: true do |server, imap|
+      handler = imap.add_response_handler do
+        imap.instance_exec do
+          def @reader.read_response_buffer
+            raise BrokenResponseReaderTestError, "testing"
+          end
+        end
+        imap.remove_response_handler handler
+      end
+      server.unsolicited "OK [ALERT] trigger read_response_buffer switcheroo"
+      server.unsolicited "OK [ALERT] trigger reader error"
+      # NOTE: closing the socket happens in the receiver thread, creating a race
+      # condition if a client thread issues a command right *here*.
+      #
+      # If a command is called here, it may run before or after the response
+      # reader error closes the connection.  If it runs before, then
+      # `get_tagged_response` should return the BrokenResponseReaderTestError
+      # exception.  If it runs after, we'll see the "stream closed" IOError.
+      #
+      # The distinction between these errors is not considered important enough
+      # to justify delaying for the "correct" error or complex tests to capture
+      # each possible case.
+      #
+      # By waiting for the receiver thread to close, this test ensures a stable
+      # result: the socket will be closed and `@exception` will be assigned...
+      # But, since `send_command` doesn't currently check this before attempting
+      # to send, it simply raises the "stream closed" IOError.
+      wait_for_receiver_thread_terminating(imap)
+
+      assert imap.disconnected?
+      assert_stream_closed_error do
+        imap.noop
+      end
+      assert imap.disconnected?
+    end
+  end
+
+  test "exception from response parser" do
+    with_fake_server ignore_io_error: true, ignore_abrupt_eof: true do |server, imap|
+      server.on "NOOP" do |resp|
+        resp.puts "#{resp.tag} NOPE [SERVERBUG] this ain't right!"
+      end
+      assert_reraised(Net::IMAP::InvalidResponseError, /bad.*NOPE/, imap:) do
+        imap.noop
+      end
+      assert imap.disconnected?
+    end
+    with_fake_server ignore_abrupt_eof: true do |server, imap|
+      server.on "FETCH" do |resp|
+        resp.untagged '1 FETCH (BODY[] ")'
+        resp.done_ok
+      end
+      assert_reraised(Net::IMAP::ResponseParseError, imap:) do
+        imap.fetch 1, "FAST"
+      end
+      assert imap.disconnected?
     end
   end
 
@@ -420,7 +484,7 @@ class IMAPTest < Net::IMAP::TestCase
     end
     begin
       imap = Net::IMAP.new(server_addr, :port => port)
-      assert_raise(Net::IMAP::Error) do
+      assert_local_raise(Net::IMAP::Error) do
         imap.idle_done
       end
     ensure
@@ -501,7 +565,7 @@ class IMAPTest < Net::IMAP::TestCase
     end
     begin
       imap = Net::IMAP.new(server_addr, :port => port)
-      assert_raise(Net::IMAP::ByeResponseError) do
+      assert_local_raise(Net::IMAP::ByeResponseError) do
         imap.login("user", "password")
       end
     end
@@ -533,7 +597,7 @@ class IMAPTest < Net::IMAP::TestCase
       end
       imap.logout
     ensure
-      assert_raise(RuntimeError) do
+      assert_local_raise(RuntimeError) do
         imap.disconnect
       end
     end
@@ -578,7 +642,7 @@ class IMAPTest < Net::IMAP::TestCase
             c.signal
           end
         end
-        assert_raise(EOFError) do
+        assert_local_raise(EOFError) do
           imap.idle do |res|
             m.synchronize do
               in_idle = true
@@ -654,7 +718,7 @@ class IMAPTest < Net::IMAP::TestCase
         server.close
       end
     end
-    assert_raise(Net::IMAP::Error) do
+    assert_local_raise(Net::IMAP::Error) do
       #Net::IMAP.new(server_addr, :port => port)
       if true
           net_imap.new(server_addr, :port => port)
@@ -873,7 +937,7 @@ class IMAPTest < Net::IMAP::TestCase
 
       # limited automatic non-synchronizing literals
       imap.config.max_non_synchronizing_literal = 5
-      assert_raise(Net::IMAP::NoResponseError) do
+      assert_local_raise(Net::IMAP::NoResponseError) do
         send_args.call [
           Net::IMAP::Literal["\rhi\r"],
           Net::IMAP::Literal["\x01" * 10],
@@ -1026,6 +1090,7 @@ class IMAPTest < Net::IMAP::TestCase
             sock.close
           end
         rescue Errno::EPIPE, Errno::ECONNRESET, Errno::ECONNABORTED
+        rescue OpenSSL::SSL::SSLError
         end
       end
       sleep 0.1 until started

--- a/test/net/imap/test_imap_authenticate.rb
+++ b/test/net/imap/test_imap_authenticate.rb
@@ -209,7 +209,7 @@ class IMAPAuthenticateTest < Net::IMAP::TestCase
         server.state.authenticate(server.config.user)
         cmd.done_ok
       end
-      assert_raise(Net::IMAP::SASL::AuthenticationIncomplete) do
+      assert_local_raise(Net::IMAP::SASL::AuthenticationIncomplete) do
         imap.authenticate("DIGEST-MD5", "test_user", "test-password",
                           warn_deprecation: false)
       end

--- a/test/net/imap/test_imap_max_response_size.rb
+++ b/test/net/imap/test_imap_max_response_size.rb
@@ -22,7 +22,7 @@ class IMAPMaxResponseSizeTest < Net::IMAP::TestCase
   test "#max_response_size closes connection for too long line" do
     Net::IMAP.config.max_response_size = 10
     run_fake_server_in_thread(preauth: false, ignore_io_error: true) do |server|
-      assert_raise_with_message(
+      assert_local_raise(
         Net::IMAP::ResponseTooLargeError, /exceeds max_response_size .*\b10B\b/
       ) do
         with_client("localhost", port: server.port) do
@@ -40,9 +40,10 @@ class IMAPMaxResponseSizeTest < Net::IMAP::TestCase
       server.on("NOOP") do |resp|
         resp.untagged("1 FETCH (BODY[] {1000}\r\n" + "a" * 1000 + ")")
       end
-      assert_raise_with_message(
+      assert_reraised(
         Net::IMAP::ResponseTooLargeError,
-        /\d+B read \+ 1000B literal.* exceeds max_response_size .*\b50B\b/
+        /\d+B read \+ 1000B literal.* exceeds max_response_size .*\b50B\b/,
+        imap: client
       ) do
         client.noop
         fail "should not get here (FETCH literal longer than max_response_size)"

--- a/test/net/imap/test_imap_response_handlers.rb
+++ b/test/net/imap/test_imap_response_handlers.rb
@@ -72,4 +72,16 @@ class IMAPResponseHandlersTest < Net::IMAP::TestCase
     end
   end
 
+  test "error raised in response handler blocks later handlers" do
+    with_fake_server do |server, imap|
+      seen = []
+      imap.add_response_handler do seen << {first: _1.name} end
+      imap.add_response_handler do raise "ohno" end
+      imap.add_response_handler do seen << {last: _1.name} end
+
+      imap.noop
+      assert_equal [{first: "OK"}], seen
+    end
+  end
+
 end


### PR DESCRIPTION
Previously, when the receiver thread sent an exception to the client thread, it would be raised with the receiver thread's backtrace, which wasn't very useful.

Now a copy of the exception will be raised, and it will use the current thread's `backtrace`.  If the original has a backtrace or a cause, the original exception will be set as the copy's `cause`.

---

There's other work that should be done to normalize receiver thread exception propagation to client threads.  But that can wait for another PR (in another release).