### PR TITLE
🧵 Refactor thread synchronization for sending commands

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3679,10 +3679,10 @@ module Net
         ensure
           remove_response_handler(block) if block
         end
+      rescue InvalidResponseError
+        disconnect
+        raise
       end
-    rescue InvalidResponseError
-      disconnect
-      raise
     end
 
     # NOTE: This must be synchronized with sending the command's final CRLF and

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3661,10 +3661,8 @@ module Net
     end
 
     def send_command(cmd, *args, &block)
+      args.each do validate_data _1 end
       synchronize do
-        args.each do |i|
-          validate_data(i)
-        end
         tag = generate_tag
         command = Command[tag:, name: cmd]
         put_string(tag + " " + cmd)


### PR DESCRIPTION
Related to #693, but that handles code that executes in the receiver thread and this handles code that executes in client threads.  (Also, this PR is significantly simpler than that one.)

Sending a command must be synchronized:
* so multiple threads aren't sending simultaneously
* so sending the command is correctly interleaved with response handlers

But the command's arguments are presumed to be non-shared (or thread-safe), and this validation does not reference any connection state.  Also, now that the deadlock condition in `#disconnect` has been fixed (#686), it's better to handle the invalid response error before releasing the lock.

So, this updates argument validation to run prior to locking and invalid response error handling to run inside the lock.