### PR TITLE
🧵Refactor receive responses thread sync

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3517,9 +3517,6 @@ module Net
     def receive_responses
       connection_closed = false
       until connection_closed
-        synchronize do
-          @exception = nil
-        end
         begin
           resp = get_response
         rescue Exception => e
@@ -3570,6 +3567,8 @@ module Net
             @exception = e
             @tagged_response_arrival.broadcast
             @continuation_request_arrival.broadcast
+          ensure
+            @exception = nil unless connection_closed
           end
         end
       end

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3518,18 +3518,12 @@ module Net
       connection_closed = false
       until connection_closed
         begin
-          resp = get_response
+          resp = get_response or raise EOFError, "end of file reached"
         rescue Exception => e
           synchronize do
             state_logout!
             @sock.close
             @exception = e
-          end
-          break
-        end
-        unless resp
-          synchronize do
-            @exception = EOFError.new("end of file reached")
           end
           break
         end

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3566,9 +3566,7 @@ module Net
             @response_handlers.each do |handler|
               handler.call(resp)
             end
-          end
-        rescue Exception => e
-          synchronize do
+          rescue Exception => e
             @exception = e
             @tagged_response_arrival.broadcast
             @continuation_request_arrival.broadcast

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3568,8 +3568,8 @@ module Net
             end
           end
         rescue Exception => e
-          @exception = e
           synchronize do
+            @exception = e
             @tagged_response_arrival.broadcast
             @continuation_request_arrival.broadcast
           end

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3574,13 +3574,13 @@ module Net
       end
     ensure
       synchronize do
+        state_logout!
         @receiver_thread_terminating = true
         @tagged_response_arrival.broadcast
         @continuation_request_arrival.broadcast
         if @idle_done_cond
           @idle_done_cond.signal
         end
-        state_logout!
       end
     end
 

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3573,6 +3573,7 @@ module Net
           end
         end
       end
+    ensure
       synchronize do
         @receiver_thread_terminating = true
         @tagged_response_arrival.broadcast
@@ -3580,9 +3581,8 @@ module Net
         if @idle_done_cond
           @idle_done_cond.signal
         end
+        state_logout!
       end
-    ensure
-      state_logout!
     end
 
     def get_response

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3515,18 +3515,10 @@ module Net
     end
 
     def receive_responses
+      exception = nil
       connection_closed = false
       until connection_closed
-        begin
-          resp = get_response or raise EOFError, "end of file reached"
-        rescue Exception => e
-          synchronize do
-            state_logout!
-            @sock.close
-            @exception = e
-          end
-          break
-        end
+        resp = get_response or raise EOFError, "end of file reached"
         begin
           synchronize do
             case resp
@@ -3566,8 +3558,22 @@ module Net
           end
         end
       end
+    rescue Exception => exception
+      # NOTE: this rescue clause is only capturing the exception for the ensure
+      # clause.  Using `$!` in the ensure clause seems to trigger a weird
+      # TruffleRuby bug: https://github.com/truffleruby/truffleruby/issues/4308
+      #
+      # We don't assign @exception directly here, because we want that to be
+      # atomically synchronized with all of the other changes in `ensure`.
+      raise
     ensure
       synchronize do
+        if exception
+          # Handling exceptions here, not in a rescue clause, so the lock isn't
+          # released and reacquired between rescue and ensure clauses.
+          @exception ||= exception
+          @sock.close
+        end
         state_logout!
         @receiver_thread_terminating = true
         @tagged_response_arrival.broadcast


### PR DESCRIPTION
Related to #692, but that handles code that executes in client thread(s) and this handles code that executes in the receiver thread.

Notable changes:
* The receiver loop only calls `synchronize` once per loop, to handle the response.
  * Various exception handlers and cleanup code is moved into adjacent synchronize blocks.
  * Resetting `@exception` at the start is moved to the end (`unless connection_closed`).
* The logout state is now entered _before_ signaling the conditional variables for the last time.  This is less surprising than doing it afterward, and it also makes some of the other `state_logout!` calls redundant.  `connection_state` is relatively new, and it is not expected that this difference should impact much code anyway.
* An `EOFError` may be assigned a receiver thread backtrace, similarly to other exceptions that are raised by response reading or parsing.  This is significantly improved by #691.
* Simplified exception handling by simply letting the response reader and response parser exceptions bubble up, which allows us to assign `@exception` in the synchronize block inside the ensure clause.  This makes the loop much simpler to understand, and now we don't release and immediately re-acquire the lock (with slightly inconsistent state in the middle).

  _NOTE:_ This is slightly more complex than how #693 handles it, because it uses a workaround to avoid triggering this TruffleRuby bug: https://github.com/truffleruby/truffleruby/issues/4308.