### PR TITLE
🥅 Validate `ID` values contain only valid bytes

### DIFF
--- a/lib/net/imap/command_data.rb
+++ b/lib/net/imap/command_data.rb
@@ -156,36 +156,38 @@ module Net
       end
     end
 
-    # Represents IMAP +text+ data, which may contain any 7-bit ASCII character,
-    # except for +NULL+, +CR+, or +LF+.  +text+ is extended to allow any
-    # multibyte +UTF-8+ character when either +UTF8=ACCEPT+ or +IMAP4rev2+ have
-    # been enabled, or when the server supports only +IMAP4rev2+ and not earlier
-    # IMAP revisions, or when the server advertises +UTF8=ONLY+.
+    # Represents IMAP +text+ data, which covers everything in the IMAP grammar,
+    # except for +literal+, +literal8+, and the concluding +CRLF+.
     #
-    # NOTE: The current implementation does not validate whether the connection
-    # currently supports UTF-8.  Future versions may change.
+    # +data+ may contain any 7-bit ASCII character except +NULL+, +CR+, or +LF+.
+    # Any multibyte +UTF-8+ character is also allowed when the connection
+    # supports UTF8: either +UTF8=ACCEPT+ or +IMAP4rev2+ have been enabled, or
+    # the server supports only +IMAP4rev2+ and not earlier IMAP revisions, or
+    # the server advertises +UTF8=ONLY+.
+    #
+    # NOTE: This does not verify whether the connection supports UTF-8, but that
+    # may change in future versions.
     #
     # The string's bytes must be valid ASCII or valid UTF-8.  The string's
     # reported encoding is ignored, but the string is _not_ transcoded.
     class RawText < CommandData # :nodoc:
       def initialize(data:)
         data = String(data.to_str)
-        data = if data.encoding in Encoding::ASCII | Encoding::UTF_8
-          -data
-        elsif data.ascii_only?
-          -(data.dup.force_encoding("ASCII"))
-        else
-          -(data.dup.force_encoding("UTF-8"))
+        unless data.encoding in Encoding::ASCII | Encoding::UTF_8
+          data = data.dup.force_encoding(data.ascii_only? ? "ASCII" : "UTF-8")
         end
+        data = -data
         super
         validate
       end
 
       def validate
-        if data.include?("\0")
-          raise DataFormatError, "NULL byte must be binary literal encoded"
+        if !(data.encoding in Encoding::ASCII | Encoding::UTF_8)
+          raise DataFormatError, "must use ASCII or UTF-8 encoding"
         elsif !data.valid_encoding?
           raise DataFormatError, "invalid UTF-8 must be literal encoded"
+        elsif data.include?("\0")
+          raise DataFormatError, "NULL byte must be binary literal encoded"
         elsif /[\r\n]/.match?(data)
           raise DataFormatError, "CR and LF bytes must be literal encoded"
         end

--- a/lib/net/imap/command_data.rb
+++ b/lib/net/imap/command_data.rb
@@ -156,8 +156,8 @@ module Net
       end
     end
 
-    # Represents IMAP +text+ data, which covers everything in the IMAP grammar,
-    # except for +literal+, +literal8+, and the concluding +CRLF+.
+    # Represents IMAP +text+ or +quoted+ data, which share the same
+    # validations of decoded #data, and differ only in how they are formatted.
     #
     # +data+ may contain any 7-bit ASCII character except +NULL+, +CR+, or +LF+.
     # Any multibyte +UTF-8+ character is also allowed when the connection
@@ -170,7 +170,7 @@ module Net
     #
     # The string's bytes must be valid ASCII or valid UTF-8.  The string's
     # reported encoding is ignored, but the string is _not_ transcoded.
-    class RawText < CommandData # :nodoc:
+    class ValidNonLiteralData < CommandData
       def initialize(data:)
         data = String(data.to_str)
         unless data.encoding in Encoding::ASCII | Encoding::UTF_8
@@ -195,7 +195,17 @@ module Net
 
       def ascii_only? = data.ascii_only?
 
-      def send_data(imap, tag) = imap.__send__(:put_string, data)
+      def send_data(imap, tag = nil) = imap.__send__(:put_string, formatted)
+    end
+
+    # Represents IMAP +text+ data, which covers everything in the IMAP grammar,
+    # except for +literal+, +literal8+, and the concluding +CRLF+.
+    #
+    # NOTE: The current implementation does not verify that the connection
+    # supports UTF-8.  Future versions may validate this.
+    class RawText < ValidNonLiteralData # :nodoc:
+      # raw: no formatting necessary
+      alias formatted data
     end
 
     class RawData < CommandData # :nodoc:
@@ -274,10 +284,13 @@ module Net
       end
     end
 
-    class QuotedString < CommandData # :nodoc:
-      def send_data(imap, tag)
-        imap.__send__(:send_quoted_string, data)
-      end
+    # Represents a IMAP +quoted+ string, which can encode any valid ASCII or
+    # UTF-8 string, unless it contains any +CR+, +LF+, or +NULL+ bytes.
+    #
+    # NOTE: The current implementation does not verify that the connection
+    # supports UTF-8.  Future versions may validate this.
+    class QuotedString < ValidNonLiteralData # :nodoc:
+      def formatted = %("#{data.gsub(/["\\]/, "\\\\\\&")}")
     end
 
     class Literal < Data.define(:data, :non_sync) # :nodoc:

--- a/lib/net/imap/command_data.rb
+++ b/lib/net/imap/command_data.rb
@@ -77,9 +77,7 @@ module Net
       end
     end
 
-    def send_quoted_string(str)
-      put_string('"' + str.gsub(/["\\]/, "\\\\\\&") + '"')
-    end
+    def send_quoted_string(str) = QuotedString.new(data: str).send_data(self)
 
     def send_binary_literal(*, **) = send_literal(*, **, binary: true)
 

--- a/test/net/imap/test_command_data.rb
+++ b/test/net/imap/test_command_data.rb
@@ -167,19 +167,53 @@ class CommandDataTest < Net::IMAP::TestCase
   end
 
   class RawTextTest < CommandDataTest
-    test "basic ASCII string" do
-      imap.send_data RawText.new('foo "bar" (baz)')
-      assert_equal [Output.put_string('foo "bar" (baz)')], imap.output
+    test "allows ASCII strings with no specials" do
+      imap.send_data(
+        RawText["INBOX"],
+        RawText["etc"]
+      )
+      assert_equal [
+        Output.put_string("INBOX"),
+        Output.put_string("etc"),
+      ], imap.output
+      imap.clear
     end
 
-    test "allows IMAP atom-special symbols" do
-      imap.send_data RawText.new('foo "bar" (baz)')
-      imap.send_data RawText.new("(){}[]%*\"\\")
-      imap.send_data RawText.new("(((((((((((((((( unbalanced ]]]]]]]]]]]]]")
+    test "allows atom specials" do
+      [
+        "  with  spaces  in  string  ",
+        "with_parens()",
+        "with_list_wildcards*",
+        "with_list_wildcards%",
+        "with_resp_special]",
+        "with\x7fcontrol_char",
+        %{(){}[]%*'},
+      ].each do |string|
+        imap.send_data RawText[string]
+      end
       assert_equal [
-        Output.put_string('foo "bar" (baz)'),
-        Output.put_string("(){}[]%*\"\\"),
-        Output.put_string("(((((((((((((((( unbalanced ]]]]]]]]]]]]]"),
+        Output.put_string("  with  spaces  in  string  "),
+        Output.put_string("with_parens()"),
+        Output.put_string("with_list_wildcards*"),
+        Output.put_string("with_list_wildcards%"),
+        Output.put_string("with_resp_special]"),
+        Output.put_string("with\x7fcontrol_char"),
+        Output.put_string(%{(){}[]%*'}),
+      ], imap.output
+    end
+
+    test "allows quoted specials" do
+      [
+        '"with" "quoted" "specials"',
+        '\\with\\quoted\\specials\\',
+        %{(){}[]%*"'\\},
+      ].each do |string|
+        imap.send_data RawText[string]
+      end
+      assert_equal [
+        Output.put_string('"with" "quoted" "specials"'),
+        Output.put_string('\\with\\quoted\\specials\\'),
+        Output.put_string(%{(){}[]%*"'\\}),
       ], imap.output
     end
 
@@ -195,6 +229,15 @@ class CommandDataTest < Net::IMAP::TestCase
       imap.send_data text
       assert_equal [
         Output.put_string("beep\b beep\b escape!\e delete this:\x1f"),
+      ], imap.output
+    end
+
+    test "allows valid UTF-8 multibyte chars" do
+      imap.send_data RawText.new("föó bär")
+      imap.send_data RawText.new("ほげ ふが ぴよ")
+      assert_equal [
+        Output.put_string("föó bär"),
+        Output.put_string("ほげ ふが ぴよ"),
       ], imap.output
     end
 

--- a/test/net/imap/test_command_data.rb
+++ b/test/net/imap/test_command_data.rb
@@ -8,6 +8,7 @@ class CommandDataTest < Net::IMAP::TestCase
 
   Atom = Net::IMAP::Atom
   Flag = Net::IMAP::Flag
+  QuotedString = Net::IMAP::QuotedString
   Literal = Net::IMAP::Literal
   Literal8 = Net::IMAP::Literal8
   RawText = Net::IMAP::RawText
@@ -166,6 +167,83 @@ class CommandDataTest < Net::IMAP::TestCase
     end
   end
 
+  class QuotedStringTest < CommandDataTest
+    test "quotes ASCII strings (no specials)" do
+      assert_equal '"INBOX"', QuotedString["INBOX"].formatted
+      imap.send_data(
+        QuotedString["INBOX"],
+        QuotedString["etc"]
+      )
+      assert_equal [
+        Output.put_string('"INBOX"'),
+        Output.put_string('"etc"'),
+      ], imap.output
+      imap.clear
+    end
+
+    test "quotes ASCII strings (atom specials)" do
+      [
+        "  with  spaces  in  string  ",
+        "with_parens()",
+        "with_list_wildcards*",
+        "with_list_wildcards%",
+        "with_resp_special]",
+        "with\x7fcontrol_char",
+        %{(){}[]%*'},
+      ].each do |string|
+        imap.send_data QuotedString[string]
+      end
+      assert_equal [
+        Output.put_string('"  with  spaces  in  string  "'),
+        Output.put_string('"with_parens()"'),
+        Output.put_string('"with_list_wildcards*"'),
+        Output.put_string('"with_list_wildcards%"'),
+        Output.put_string('"with_resp_special]"'),
+        Output.put_string(%{"with\x7fcontrol_char"}),
+        Output.put_string(%Q{"(){}[]%*'"}),
+      ], imap.output
+    end
+
+    test "escapes quoted specials" do
+      [
+        '"with" "quoted" "specials"',
+        "\\with\\quoted\\specials\\",
+        %{(){}[]%*"'\\},
+      ].each do |string|
+        imap.send_data QuotedString[string]
+      end
+      assert_equal [
+        Output.put_string('"\"with\" \"quoted\" \"specials\""'),
+        Output.put_string('"\\\\with\\\\quoted\\\\specials\\\\"'),
+        Output.put_string(%q{"(){}[]%*\"'\\\\"}),
+      ], imap.output
+    end
+
+    test "ASCII compatible string with another encodings" do
+      imap.send_data QuotedString.new("foo bar".encode("cp1252"))
+      assert_equal [
+        Output.put_string('"foo bar"'),
+      ], imap.output
+    end
+
+    test "allows ASCII control chars" do
+      text = QuotedString.new("beep\b beep\b escape!\e delete this:\x1f")
+      imap.send_data text
+      assert_equal [
+        Output.put_string(%{"beep\b beep\b escape!\e delete this:\x1f"}),
+      ], imap.output
+    end
+
+    test "quotes valid UTF-8 multibyte chars" do
+      imap.send_data QuotedString.new("föó bär")
+      imap.send_data QuotedString.new("ほげ ふが ぴよ")
+      assert_equal [
+        Output.put_string('"föó bär"'),
+        Output.put_string('"ほげ ふが ぴよ"'),
+      ], imap.output
+    end
+  end
+
   class RawTextTest < CommandDataTest
     test "allows ASCII strings with no specials" do
       imap.send_data(
@@ -240,14 +318,20 @@ class CommandDataTest < Net::IMAP::TestCase
         Output.put_string("ほげ ふが ぴよ"),
       ], imap.output
     end
+  end
 
+  SharedValidNonLiteralDataTests = ->(data_type) do
     data(
       "NULL" => ["with \0 NULL", /NULL\b.+\bbyte/i],
       "CR"   => ["with \r CR",   /CR\b.+\bbyte/i],
       "LF"   => ["with \n LF",   /LF\b.+\bbyte/i],
     )
     test "invalid ASCII byte" do |(text, error_message)|
-      try_multiple_encodings(error_message, text)
+      with_multiple_encodings(text) do |encoded|
+        assert_raise_with_message(DataFormatError, error_message) do
+          data_type[encoded]
+        end
+      end
     end
 
     # See Table 3-7, Well-Formed UTF-8 Byte Sequences, in The Unicode Standard:
@@ -264,7 +348,11 @@ class CommandDataTest < Net::IMAP::TestCase
       "windows-1252"               => "åêïõü".encode("windows-1252"),
     )
     test "invalid UTF-8" do |text|
-      try_multiple_encodings(/invalid UTF-8/i, text)
+      with_multiple_encodings(text) do |encoded|
+        assert_raise_with_message(DataFormatError, /invalid UTF-8/i) do
+          data_type[encoded]
+        end
+      end
     end
 
     def with_multiple_encodings(data)
@@ -273,15 +361,9 @@ class CommandDataTest < Net::IMAP::TestCase
       yield data.dup.force_encoding("UTF-8")
       yield data.dup.force_encoding("cp1252")
     end
-
-    def try_multiple_encodings(error_message, data)
-      with_multiple_encodings(data) do |encoded|
-        assert_raise_with_message(DataFormatError, error_message) do
-          RawText[encoded]
-        end
-      end
-    end
   end
+  QuotedStringTest.class_exec QuotedString, &SharedValidNonLiteralDataTests
+  RawTextTest     .class_exec RawText,      &SharedValidNonLiteralDataTests
 
   class RawDataTest < CommandDataTest
     test "simple raw text" do


### PR DESCRIPTION
This shares most of the validation implementation with `RawText`, via an extracted shared superclass.

In currently released versions of `net-imap`, `QuotedString` is _not_ used to quote regular string arguments.  It's currently only used by `Net::IMAP#id` (the `ID` extension).  This PR reverses the dependency, so that `send_string_data` calls `QuotedString`, rather than vice versa.

Without this patch, `Net::IMAP#id` is vulnerable to the same type of CRLF injection issues as in CVE-2026-42258 (GHSA-75xq-5h9v-w6px) and CVE-2026-42257 (GHSA-hm49-wcqc-g2xg).  The string will be quoted, which imposes some limits on what command arguments can be injected, but many destructive commands will work fine without any quoted specials.

Presumably, `Net::IMAP#id` should be very unlikely to be called with untrusted input, making this less likely to be exploitable.  Nevertheless, CRLF injection should be prevented!