### PR TITLE
🥅 Validate `#enable` arguments are all atoms

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -3154,10 +3154,11 @@ module Net
       capabilities = capabilities
         .flatten
         .map {|e| ENABLE_ALIASES[e] || e }
+        .flat_map { _1.is_a?(String) && !_1.empty? ? _1.split(/ /, -1) : [_1] }
         .uniq
-        .join(' ')
+        .map { Atom[_1] }
       synchronize do
-        send_command("ENABLE #{capabilities}")
+        send_command("ENABLE", *capabilities)
         result = clear_responses("ENABLED").last || []
         @utf8_strings ||= result.include? "UTF8=ACCEPT"
         @utf8_strings ||= result.include? "IMAP4REV2"

--- a/test/net/imap/test_imap_enable.rb
+++ b/test/net/imap/test_imap_enable.rb
@@ -27,6 +27,14 @@ class IMAPEnableTest < Net::IMAP::TestCase
       assert_equal %w[CONDSTORE],   result1
       assert_equal %w[UTF8=ACCEPT], result2
       assert_equal [],              result3
+
+      assert_raise(Net::IMAP::DataFormatError) do
+        imap.enable "injection\r\ninjected logout"
+      end
+      assert_empty cmdq
+      assert_raise(Net::IMAP::DataFormatError) do
+        imap.enable "foo", "", "bar"
+      end
     end
   end
 


### PR DESCRIPTION
This still allows the argument to be a single string with multiple space-delimited arguments.  It splits the string first, and validates the substrings.

Without this patch, `Net::IMAP#enable` is vulnerable to the same type of CRLF injection issues as in CVE-2026-42258 (GHSA-75xq-5h9v-w6px) and CVE-2026-42257 (GHSA-hm49-wcqc-g2xg).

Please note: `Net::IMAP#enable` **should be _never_ be called with untrusted input**!  The documentation clearly states that use of any unknown extensions may result in undefined behavior.  _Any application that sends untrusted input with `#enable` will still have a security vulnerability, even after this PR._  Nevertheless, CRLF command injection can and should be prevented!