### PR TITLE
🐛 Prevent trailing `{0}` in RawData validation

### DIFF
--- a/lib/net/imap/command_data.rb
+++ b/lib/net/imap/command_data.rb
@@ -212,7 +212,7 @@ module Net
 
       def validate
         return unless data.last in RawText(data: text)
-        if text.rindex(/~?\{[1-9]\d*\+?\}\z/n)
+        if text.rindex(/\{\d+\+?\}\z/n)
           raise DataFormatError, "RawData cannot end with literal continuation"
         end
       end

--- a/test/net/imap/test_command_data.rb
+++ b/test/net/imap/test_command_data.rb
@@ -366,6 +366,13 @@ class CommandDataTest < Net::IMAP::TestCase
       assert_raise(DataFormatError) do RawData.new(data: "~literal+ ~{123+}") end
       raw = RawData.new(data: " {123} ")
       assert_equal [RawText[" {123} "]], raw.data
+
+      assert_raise(DataFormatError) do RawData.new(data: "literal {0}") end
+      assert_raise(DataFormatError) do RawData.new(data: "literal+ {0+}") end
+      assert_raise(DataFormatError) do RawData.new(data: "~literal ~{0}") end
+      assert_raise(DataFormatError) do RawData.new(data: "~literal+ ~{0+}") end
+      raw = RawData.new(data: " {0} ")
+      assert_equal [RawText[" {0} "]], raw.data
     end
 
     data(


### PR DESCRIPTION
As part of the `RawData` validation that was added to `v0.6.4`, raw data was checked to ensure it doesn't end with a literal continuation.  However the regexp was too strict.  Zero-length literals are explicitly allowed by the RFCs, so this did not catch text that ends with `{0}` or `{0+}`.  This leaves RawData able to absorb the `CRLF` that ends the command, and thus absorb the following command into itself.

Ultimately, we don't care if the `number64` is encoded correctly  nor whether it claims to be a binary literal.  So I've simplified the regexp by dropping `~?` and using `\d+` for the number.  (See also #680: the RFCs aren't strict about leading zeros for `number64` anyway.)

Exploiting this will result in unexpected crashes and timeouts, which could be used to create a simple denial of service attack. This attack will present very similarly to common network issues or server issues which also result in commands hanging or unexpectedly raising exceptions.  By itself, _this does **not** allow command injection_.  But the confusion caused by these errors could lead to other downstream issues, especially in a multi-threaded environment.