### PR TITLE
Remove dead code resulting from cherry-pick of 6f82e28.

### DIFF
--- a/lib/net/imap/response_reader.rb
+++ b/lib/net/imap/response_reader.rb
@@ -31,7 +31,6 @@ module Net
 
       def bytes_read;       buff.bytesize                         end
       def empty?;           buff.empty?                           end
-      def done?;            line_done? && !get_literal_size       end
       def done?;            line_done? && !literal_size           end
       def line_done?;       buff.end_with?(CRLF)                  end
 


### PR DESCRIPTION
Cherry-pick of https://github.com/ruby/net-imap/commit/6f82e28f714ecced2396144bce0155e2cdb0256e seems to have added instead of replaced the `done?` method in the commit bfdae21.