### PR TITLE
Fix flaky test_starttls_stripping_ok_sent_before_response

### DIFF
--- a/test/net/imap/fake_server/socket.rb
+++ b/test/net/imap/fake_server/socket.rb
@@ -51,7 +51,7 @@ class Net::IMAP::FakeServer
     def ignore_closed?(fallback)
       yield
     rescue IOError => err
-      close if !closed? && (@tcp_socket.closed? || @tls_socket.closed?)
+      close if !closed? && (@tcp_socket.closed? || @tls_socket&.closed?)
       return fallback if err.message.match?(/stream closed|closed stream/i)
       raise
     end

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -174,6 +174,7 @@ class IMAPTest < Net::IMAP::TestCase
     def test_starttls_stripping_ok_sent_before_response
       # to coordinate between threads (better than sleep)
       server_to_client, client_to_server = Queue.new, Queue.new
+      rcvr_to_client = Queue.new
       imap = nil
       server = create_tcp_server
       port = server.addr[1]
@@ -190,15 +191,23 @@ class IMAPTest < Net::IMAP::TestCase
           server.close
         end
       end
+      timeout = 5
+      timeout *= EnvUtil.timeout_scale || 1 if defined?(EnvUtil.timeout_scale)
       begin
-        imap = Net::IMAP.new("localhost", :port => port)
-        client_to_server << :send_malicious_response
-        assert_equal :malicious_response_sent, server_to_client.pop
-        sleep 0.010 # to be sure the network buffers have flushed, etc
-        assert_local_raise(Net::IMAP::InvalidTaggedResponseError) do
-          imap.starttls(:ca_file => CA_FILE)
+        Timeout.timeout(timeout) do
+          imap = Net::IMAP.new("localhost", :port => port)
+          imap.add_response_handler do |resp| rcvr_to_client << resp end
+          client_to_server << :send_malicious_response
+          assert_equal :malicious_response_sent, server_to_client.pop
+          # Wait until the receive thread has parsed the injected response and
+          # stored it in @tagged_responses, so finish_sending_command can see it.
+          # (handle_response stores the tagged response before calling handlers.)
+          rcvr_to_client.pop
+          assert_local_raise(Net::IMAP::InvalidTaggedResponseError) do
+            imap.starttls(:ca_file => CA_FILE)
+          end
+          assert imap.disconnected?
         end
-        assert imap.disconnected?
       ensure
         imap.disconnect if imap && !imap.disconnected?
       end


### PR DESCRIPTION
`test_starttls_stripping_ok_sent_before_response` is failing intermittently on the `Windows 2025-vs2026 (test-bundled-gems)` runner in ruby/ruby CI. The test expects `Net::IMAP::InvalidTaggedResponseError` but instead gets `Errno::ECONNABORTED (SSL_connect)`.

These are real, reproducing failures against net-imap 0.6.4.1 bundled in ruby/ruby:

https://github.com/ruby/ruby/actions/runs/28358709394/job/84007854240
https://github.com/ruby/ruby/actions/runs/28339193097/job/83950550687

In the first run the same test failed on both the initial attempt and the retry on the same VM, so it is not a one-off hiccup. Windows 2022 and other runners pass, which points to a timing-dependent flake specific to the slower VS2026 runner.

The test verifies the defense against a STARTTLS response-injection attack. The server sends `RUBY0001 OK ...` before STARTTLS is negotiated, and `finish_sending_command` must notice the already-stored tagged response and raise `InvalidTaggedResponseError` before entering `start_tls_session`. For that check to fire, the receive thread must have parsed and stored the injected response in `@tagged_responses` first.

The old code only waited with `sleep 0.010`, which confirms the server flushed the bytes but not that the client's receive thread finished recording the response. On the VS2026 runner the storage does not complete within 10ms, so the check is bypassed, the command proceeds to `SSL_connect`, and the non-TLS test server closes the socket, raising ECONNABORTED.

This replaces the fixed sleep with an `add_response_handler` plus `Queue` synchronization, the same pattern already used by the adjacent "premature tagged OK response" test. `handle_response` stores the tagged response before invoking response handlers, so waiting for the handler to fire guarantees the value is in `@tagged_responses` before `starttls` runs. The wait is wrapped in `Timeout` so a regression that prevents the response from arriving fails fast instead of hanging.

Verified locally by running the test 50+ times without a failure; the full `test_imap.rb` suite (34 tests) also passes.
