### PR TITLE
🧵🥅 Reraise `#starttls` receiver thread errors with caller's backtrace

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -1470,7 +1470,7 @@ module Net
       end
       if error
         disconnect
-        raise error
+        reraise error
       end
       unless handled
         disconnect

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -108,6 +108,7 @@ class IMAPTest < Net::IMAP::TestCase
         imap
       end
       assert_kind_of(OpenSSL::SSL::SSLError, ex)
+      assert_equal (stack = caller), ex.backtrace&.last(stack.size)
       assert_equal false, imap.tls_verified?
       assert_equal({}, imap.ssl_ctx_params)
       assert_equal(nil, imap.ssl_ctx.ca_file)


### PR DESCRIPTION
An addendum to #691: when `STARTTLS` re-raises a response handler error, that should be raised with the caller thread's backtrace.  The original exception will be the cause of the raised exception.