### PR TITLE
🐛 Use literal syntax for invalid UTF8 or non-UTF8 strings

### DIFF
--- a/lib/net/imap/command_data.rb
+++ b/lib/net/imap/command_data.rb
@@ -72,20 +72,21 @@ module Net
       if str.empty?
         # same as send_quoted_string(str), but incompatible encoding is allowed
         put_string('""')
-      elsif str.match?(UNQUOTABLE_CHARS)
-        send_literal(str, tag)
-      elsif !str.ascii_only?
-        if @utf8_strings
-          send_quoted_string(str)
-        else
-          send_literal(str, tag)
-        end
-      elsif str.match?(ASTRING_SPECIALS)
-        send_quoted_string(str)
-      else
+      elsif str.ascii_only? && !str.match?(ASTRING_SPECIALS)
         # valid +astring+ atom: non-empty, ASCII only, no ASTRING_SPECIALS
         put_string(str)
+      elsif text_encodable?(str) && !str.match?(UNQUOTABLE_CHARS)
+        send_quoted_string(str)
+      else
+        send_literal(str, tag)
       end
+    end
+
+    # Encodable as +text+ (which is a superset of +quoted+):
+    # * ASCII only (for any ASCII compatible encoding)
+    # * or UTF-8 has been enabled (TODO: validate UTF-8 strings)
+    def text_encodable?(str)
+      str.ascii_only? || @utf8_strings
     end
 
     def send_quoted_string(str) = QuotedString.new(data: str).send_data(self)

--- a/lib/net/imap/command_data.rb
+++ b/lib/net/imap/command_data.rb
@@ -84,9 +84,11 @@ module Net
 
     # Encodable as +text+ (which is a superset of +quoted+):
     # * ASCII only (for any ASCII compatible encoding)
-    # * or UTF-8 has been enabled (TODO: validate UTF-8 strings)
+    # * or valid UTF-8 (when the connection supports it)
     def text_encodable?(str)
-      str.ascii_only? || @utf8_strings
+      str.ascii_only? || (@utf8_strings &&
+                          str.encoding == Encoding::UTF_8 &&
+                          str.valid_encoding?)
     end
 
     def send_quoted_string(str) = QuotedString.new(data: str).send_data(self)

--- a/lib/net/imap/command_data.rb
+++ b/lib/net/imap/command_data.rb
@@ -58,8 +58,8 @@ module Net
       end
     end
 
-    UNQUOTABLE_CHARS = /\0\r\n/n
-    ASTRING_SPECIALS = /[(){ \x00-\x1f\x7f%*"\\]/n
+    UNQUOTABLE_CHARS = /\0\r\n/
+    ASTRING_SPECIALS = /[(){ \x00-\x1f\x7f%*"\\]/
     private_constant :UNQUOTABLE_CHARS, :ASTRING_SPECIALS
 
     # Sends generic strings formatted as +astring+:

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -994,10 +994,26 @@ class IMAPTest < Net::IMAP::TestCase
       assert_equal("sync-literal-utf8 ({10+}\r\nαβγδε)".b,
                    server.commands.pop.args)
 
+      imap.test_args "utf8-with-wrong-encoding", "αβγδε".b
+      assert_equal("utf8-with-wrong-encoding {10+}\r\nαβγδε".b,
+                   server.commands.pop.args)
+
+      imap.test_args "invalid-utf8", "\x80".b.force_encoding("UTF-8")
+      assert_equal("invalid-utf8 {1+}\r\n\x80".b,
+                   server.commands.pop.args)
+
       # Before enabling UTF-8 strings, without non-synchronizing literals
       imap.config.max_non_synchronizing_literal = -1
       imap.test_args "sync-literal-utf8", ["αβγδε"]
       assert_equal("sync-literal-utf8 ({10}\r\nαβγδε)".b,
+                   server.commands.pop.args)
+
+      imap.test_args "utf8-with-wrong-encoding", "αβγδε".b
+      assert_equal("utf8-with-wrong-encoding {10}\r\nαβγδε".b,
+                   server.commands.pop.args)
+
+      imap.test_args "invalid-utf8", "\x80".b.force_encoding("UTF-8")
+      assert_equal("invalid-utf8 {1}\r\n\x80".b,
                    server.commands.pop.args)
 
       # After enabling UTF-8 strings
@@ -1006,6 +1022,14 @@ class IMAPTest < Net::IMAP::TestCase
 
       imap.test_args "quoted-utf8", "αβγδε"
       assert_equal 'quoted-utf8 "αβγδε"'.b, server.commands.pop.args
+
+      imap.test_args "utf8-with-wrong-encoding", "αβγδε".b
+      assert_equal("utf8-with-wrong-encoding {10}\r\nαβγδε".b,
+                   server.commands.pop.args)
+
+      imap.test_args "invalid-utf8", "\x80".b.force_encoding("UTF-8")
+      assert_equal("invalid-utf8 {1}\r\n\x80".b,
+                   server.commands.pop.args)
     end
   end
 


### PR DESCRIPTION
Prior to this PR, when UTF-8 is enabled, non-ASCII strings are assumed to be valid UTF-8.  If they don't contain any CR or LF bytes, they will be sent as quoted strings even if they aren't valid UTF-8.

Also, similarly to #712, `send_string_data` could theoretically raise an encoding error if the regular expressions attempt to process an invalid string.