### PR TITLE
✅⚡ Faster tests

### DIFF
--- a/test/lib/helper.rb
+++ b/test/lib/helper.rb
@@ -38,10 +38,21 @@ Test::Unit::TestCase.include Test::Unit::CoreAssertions
 
 require "net/imap"
 class Net::IMAP::TestCase < Test::Unit::TestCase
+  SOCKET_SUPPORT_HAPPY_EYEBALLS = begin
+    Socket.tcp_fast_fallback
+    true
+  rescue NoMethodError
+    false
+  end
+
   def setup
     Net::IMAP.config.reset
     @do_not_reverse_lookup = Socket.do_not_reverse_lookup
     Socket.do_not_reverse_lookup = true
+    if SOCKET_SUPPORT_HAPPY_EYEBALLS
+      @tcp_fast_fallback = Socket.tcp_fast_fallback
+      Socket.tcp_fast_fallback = false
+    end
     @threads = []
   end
 
@@ -49,6 +60,9 @@ class Net::IMAP::TestCase < Test::Unit::TestCase
     assert_join_threads(@threads) unless @threads.empty?
   ensure
     Socket.do_not_reverse_lookup = @do_not_reverse_lookup
+    if SOCKET_SUPPORT_HAPPY_EYEBALLS
+      Socket.tcp_fast_fallback = @tcp_fast_fallback
+    end
   end
 
   def wait_for_response_count(imap, type:, count:,

--- a/test/net/imap/fake_server.rb
+++ b/test/net/imap/fake_server.rb
@@ -74,6 +74,7 @@ class Net::IMAP::FakeServer
     Timeout.timeout(config.timeout) do
       tcp_socket = tcp_server.accept
       tcp_socket.timeout = config.read_timeout if tcp_socket.respond_to? :timeout
+      tcp_socket.setsockopt(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, 1)
       @connection = Connection.new(self, tcp_socket: tcp_socket)
       @connection.run
     ensure

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -278,7 +278,7 @@ class IMAPTest < Net::IMAP::TestCase
       yield
     end
     @threads << th
-    sleep 0.1 until th.stop?
+    sleep 0.001 until th.stop?
   end
 
   def test_unexpected_eof
@@ -632,7 +632,7 @@ class IMAPTest < Net::IMAP::TestCase
         server.close
       end
     end
-    sleep 0.1 until started
+    sleep 0.001 until started
     threads << Thread.start do
       imap = Net::IMAP.new(server_addr, :port => port)
       begin
@@ -1264,7 +1264,7 @@ class IMAPTest < Net::IMAP::TestCase
         rescue OpenSSL::SSL::SSLError
         end
       end
-      sleep 0.1 until started
+      sleep 0.001 until started
       begin
         begin
           imap = yield(port)

--- a/test/run
+++ b/test/run
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+
+base_dir = File.expand_path("..", __dir__)
+$LOAD_PATH.unshift File.expand_path("test/lib", base_dir)
+$LOAD_PATH.unshift File.expand_path("lib",      base_dir)
+
+require_relative "lib/helper"
+
+exit Test::Unit::AutoRunner.run(true)


### PR DESCRIPTION
These changes allow the `test_imap*.rb` tests to run significantly faster.

On my laptop, they run over 60% faster, going from ~18 seconds down to ~11 seconds:
* over 1 second faster: Disable TCP fast fallback in tests  _(only affects ruby >= 3.4)_
* over 2 seconds faster: More aggressively poll test server thread readiness
* over 3 seconds faster: Use `TCP_NODELAY` in test server sockets