### PR TITLE
✨ Remember set of enabled server capabilities

### DIFF
--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -328,6 +328,8 @@ module Net
   #   +CAPABILITY+ command to the server.</em>
   # - #enable: Enables backwards incompatible server extensions.
   #   <em>Requires the +ENABLE+ or +IMAP4rev2+ capability.</em>
+  # - #enabled: Returns a set of enabled server extensions.
+  # - #enabled?: Returns whether a server extension has been enabled.
   # - #utf8_enabled?: Returns whether UTF-8 string encoding has been enabled.
   #
   # === Handling server responses
@@ -825,6 +827,11 @@ module Net
       "UTF8=ONLY" => "UTF8=ACCEPT",
     }.freeze
 
+    # Aliases for supported capabilities, to be used with #enabled?.
+    ENABLED_ALIASES = {
+      utf8: Set.new(%w[UTF8=ACCEPT IMAP4REV2]).freeze,
+    }.freeze
+
     dir = File.expand_path("imap", __dir__)
     autoload :ConnectionState,        "#{dir}/connection_state"
     autoload :ResponseReader,         "#{dir}/response_reader"
@@ -1114,11 +1121,11 @@ module Net
       @ssl_ctx_params, @ssl_ctx = build_ssl_ctx(ssl)
 
       # Basic Client State
-      @utf8_strings = false
       @debug_output_bol = true
       @exception = nil
       @greeting = nil
       @capabilities = nil
+      @enabled = Set.new
       @tls_verified = false
       @connection_state = ConnectionState::NotAuthenticated.new
 
@@ -3165,16 +3172,47 @@ module Net
       synchronize do
         send_command("ENABLE", *capabilities)
         result = clear_responses("ENABLED").last || []
-        @utf8_strings ||= result.include? "UTF8=ACCEPT"
-        @utf8_strings ||= result.include? "IMAP4REV2"
+        @enabled.merge(result.map(&:upcase))
         result
       end
     end
 
     # Returns whether UTF-8 string encoding has been enabled for the connection.
     #
-    # See #enable.
-    def utf8_enabled?; @utf8_strings end
+    # This is currently identical to calling #enabled? with +:utf8+.
+    #
+    # See #enable and #enabled?.
+    def utf8_enabled?; enabled?(:utf8) end
+
+    # Returns whether +capability+ is in the set of #enabled capabilities,
+    # matched case-insensitively.
+    #
+    # When +capability+ is +:utf8+, it matches if _either_
+    # <tt>"UTF8=ACCEPT"</tt> or <tt>"IMAP4REV2"</tt> is enabled.
+    #
+    # See #enable and #utf8_enabled?.
+    def enabled?(capability)
+      case capability
+      in String
+        capability = capability.upcase
+        synchronize { @enabled.include?(capability) }
+      in Symbol
+        capabilities = ENABLED_ALIASES[capability] or
+          raise ArgumentError, "unknown capability alias: #{capability}"
+        synchronize { @enabled.intersect?(capabilities) }
+      else
+        raise TypeError, "expected capability to be String or Symbol, " \
+                         "got %s" % [capability.class]
+      end
+    end
+
+    # Returns a set of enabled capabilities for the connection, as upper-cased
+    # strings.
+    #
+    # See #enable and #enabled?.
+    def enabled
+      synchronize { @enabled.dup }
+    end
 
     # Sends an {IDLE command [RFC2177 §3]}[https://www.rfc-editor.org/rfc/rfc6851#section-3]
     # {[IMAP4rev2 §6.3.13]}[https://www.rfc-editor.org/rfc/rfc9051#section-6.3.13]

--- a/lib/net/imap.rb
+++ b/lib/net/imap.rb
@@ -326,6 +326,9 @@ module Net
   #
   #   <em>In general, #capable? should be used rather than explicitly sending a
   #   +CAPABILITY+ command to the server.</em>
+  # - #enable: Enables backwards incompatible server extensions.
+  #   <em>Requires the +ENABLE+ or +IMAP4rev2+ capability.</em>
+  # - #utf8_enabled?: Returns whether UTF-8 string encoding has been enabled.
   #
   # === Handling server responses
   #
@@ -552,6 +555,7 @@ module Net
   # ==== RFC6855: <tt>UTF8=ACCEPT</tt>, <tt>UTF8=ONLY</tt>
   #
   # - See #enable for information about support for UTF-8 string encoding.
+  # - #utf8_enabled?: Returns whether UTF-8 string encoding has been enabled.
   #
   # ==== RFC7162: +CONDSTORE+
   #
@@ -3166,6 +3170,11 @@ module Net
         result
       end
     end
+
+    # Returns whether UTF-8 string encoding has been enabled for the connection.
+    #
+    # See #enable.
+    def utf8_enabled?; @utf8_strings end
 
     # Sends an {IDLE command [RFC2177 §3]}[https://www.rfc-editor.org/rfc/rfc6851#section-3]
     # {[IMAP4rev2 §6.3.13]}[https://www.rfc-editor.org/rfc/rfc9051#section-6.3.13]

--- a/lib/net/imap/command_data.rb
+++ b/lib/net/imap/command_data.rb
@@ -86,7 +86,7 @@ module Net
     # * ASCII only (for any ASCII compatible encoding)
     # * or valid UTF-8 (when the connection supports it)
     def text_encodable?(str)
-      str.ascii_only? || (@utf8_strings &&
+      str.ascii_only? || (utf8_enabled? &&
                           str.encoding == Encoding::UTF_8 &&
                           str.valid_encoding?)
     end

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -1018,6 +1018,7 @@ class IMAPTest < Net::IMAP::TestCase
 
       # After enabling UTF-8 strings
       imap.enable(:utf8)
+      assert imap.utf8_enabled?
       server.commands.pop.args => ["UTF8=ACCEPT"]
 
       imap.test_args "quoted-utf8", "αβγδε"

--- a/test/net/imap/test_imap_enable.rb
+++ b/test/net/imap/test_imap_enable.rb
@@ -14,14 +14,18 @@ class IMAPEnableTest < Net::IMAP::TestCase
     ) do |server, imap|
       cmdq = server.commands
 
+      refute imap.utf8_enabled?
+
       enabled = imap.enable(%w[CONDSTORE x-pig-latin])
       assert_equal "RUBY0001 ENABLE CONDSTORE x-pig-latin", cmdq.pop.raw.strip
       assert_equal %w[CONDSTORE], enabled
+      refute imap.utf8_enabled?
 
       enabled = imap.enable(:utf8, "condstore QResync")
       assert_equal("RUBY0002 ENABLE UTF8=ACCEPT condstore QResync",
                    cmdq.pop.raw.strip)
       assert_equal %w[UTF8=ACCEPT], enabled
+      assert imap.utf8_enabled?
 
       assert_empty cmdq
 
@@ -32,6 +36,21 @@ class IMAPEnableTest < Net::IMAP::TestCase
       assert_raise(Net::IMAP::DataFormatError) do
         imap.enable "foo", "", "bar"
       end
+    end
+  end
+
+  test("enable IMAP4rev2") do
+    with_fake_server(
+      with_extensions: %i[ENABLE CONDSTORE IMAP4rev2 UTF8=ACCEPT],
+      capabilities_enablable: %w[CONDSTORE UTF8=ACCEPT IMAP4rev2]
+    ) do |server, imap|
+      cmdq = server.commands
+
+      enabled = imap.enable("IMAP4rev2")
+      assert_equal "RUBY0001 ENABLE IMAP4rev2", cmdq.pop.raw.strip
+      assert imap.utf8_enabled?
+
+      assert_empty cmdq
     end
   end
 

--- a/test/net/imap/test_imap_enable.rb
+++ b/test/net/imap/test_imap_enable.rb
@@ -14,19 +14,16 @@ class IMAPEnableTest < Net::IMAP::TestCase
     ) do |server, imap|
       cmdq = server.commands
 
-      result1 = imap.enable(%w[CONDSTORE x-pig-latin])
-      result2 = imap.enable(:utf8, "condstore QResync")
-      result3 = imap.enable(:utf8, "UTF8=ACCEPT", "UTF8=ONLY")
-      cmd1, cmd2, cmd3 = Array.new(3) { cmdq.pop.raw.strip }
+      enabled = imap.enable(%w[CONDSTORE x-pig-latin])
+      assert_equal "RUBY0001 ENABLE CONDSTORE x-pig-latin", cmdq.pop.raw.strip
+      assert_equal %w[CONDSTORE], enabled
 
-      assert_equal "RUBY0001 ENABLE CONDSTORE x-pig-latin",         cmd1
-      assert_equal "RUBY0002 ENABLE UTF8=ACCEPT condstore QResync", cmd2
-      assert_equal "RUBY0003 ENABLE UTF8=ACCEPT",                   cmd3
+      enabled = imap.enable(:utf8, "condstore QResync")
+      assert_equal("RUBY0002 ENABLE UTF8=ACCEPT condstore QResync",
+                   cmdq.pop.raw.strip)
+      assert_equal %w[UTF8=ACCEPT], enabled
+
       assert_empty cmdq
-
-      assert_equal %w[CONDSTORE],   result1
-      assert_equal %w[UTF8=ACCEPT], result2
-      assert_equal [],              result3
 
       assert_raise(Net::IMAP::DataFormatError) do
         imap.enable "injection\r\ninjected logout"

--- a/test/net/imap/test_imap_enable.rb
+++ b/test/net/imap/test_imap_enable.rb
@@ -14,17 +14,29 @@ class IMAPEnableTest < Net::IMAP::TestCase
     ) do |server, imap|
       cmdq = server.commands
 
+      assert_equal Set.new, imap.enabled
+      refute imap.enabled?("condstore")
+      refute imap.enabled?(:utf8)
       refute imap.utf8_enabled?
 
       enabled = imap.enable(%w[CONDSTORE x-pig-latin])
       assert_equal "RUBY0001 ENABLE CONDSTORE x-pig-latin", cmdq.pop.raw.strip
       assert_equal %w[CONDSTORE], enabled
+      assert_equal Set.new(%w[CONDSTORE]), imap.enabled
+      assert imap.enabled?("condstore")
+      assert imap.enabled?("CondStore")
+      refute imap.enabled?("x-pig-latin")
+      refute imap.enabled?(:utf8)
       refute imap.utf8_enabled?
 
       enabled = imap.enable(:utf8, "condstore QResync")
       assert_equal("RUBY0002 ENABLE UTF8=ACCEPT condstore QResync",
                    cmdq.pop.raw.strip)
       assert_equal %w[UTF8=ACCEPT], enabled
+      assert_equal Set.new(%w[CONDSTORE UTF8=ACCEPT]), imap.enabled
+      assert imap.enabled?(:utf8)
+      assert imap.enabled?("UTF8=accept")
+      refute imap.enabled?("IMAP4rev2")
       assert imap.utf8_enabled?
 
       assert_empty cmdq
@@ -48,6 +60,8 @@ class IMAPEnableTest < Net::IMAP::TestCase
 
       enabled = imap.enable("IMAP4rev2")
       assert_equal "RUBY0001 ENABLE IMAP4rev2", cmdq.pop.raw.strip
+      assert_equal %w[IMAP4REV2], enabled
+      assert_equal Set.new(%w[IMAP4REV2]), imap.enabled
       assert imap.utf8_enabled?
 
       assert_empty cmdq


### PR DESCRIPTION
* Add `#enabled` method to return a (thread-safe) duplicate of the set
* Add `#enabled?` predicate for case-insensitive queries
* Re-implements `#utf_enabled?` to use enabled set, rather than special cased ivar.