### PR TITLE
✅ Fix issues with simplecov v1.0 upgrade

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,11 +37,8 @@ jobs:
       run: bundle exec rake test
       timeout-minutes: 5 # _should_ finish in under a minute
 
-    - uses: joshmfrankel/simplecov-check-action@main
+    - name: Report coverage
       if: ${{ matrix.os == 'ubuntu-latest' && github.event_name != 'pull_request' &&
         !startsWith(matrix.ruby, 'truffleruby') && !startsWith(matrix.ruby, 'jruby') }}
-      with:
-        check_job_name: "SimpleCov - ${{ matrix.ruby }}"
-        minimum_suite_coverage: 90
-        minimum_file_coverage: 40 # TODO: increase this after switching to SASL::AuthenticationExchange
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+      run: bundle exec rake coverage:report
+      timeout-minutes: 1 # _should_ finish in under a second

--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+SimpleCov.formatters = [
+  SimpleCov::Formatter::HTMLFormatter,
+  SimpleCov::Formatter::JSONFormatter,
+]
+
+SimpleCov.configure do
+  enable_coverage  :branch
+  primary_coverage :branch
+  enable_coverage_for_eval
+
+  add_filter "/test/"
+  add_filter "/rakelib/"
+
+  add_group "Parser", %w[lib/net/imap/response_parser.rb
+                        lib/net/imap/response_parser]
+  add_group "Config", %w[lib/net/imap/config.rb
+                        lib/net/imap/config]
+  add_group "SASL", %w[lib/net/imap/sasl.rb
+                      lib/net/imap/sasl
+                      lib/net/imap/authenticators.rb]
+  add_group "StringPrep", %w[lib/net/imap/stringprep.rb
+                            lib/net/imap/stringprep]
+end

--- a/.simplecov
+++ b/.simplecov
@@ -1,25 +1,22 @@
 # frozen_string_literal: true
 
-SimpleCov.formatters = [
-  SimpleCov::Formatter::HTMLFormatter,
-  SimpleCov::Formatter::JSONFormatter,
-]
-
 SimpleCov.configure do
+  formatter SimpleCov::Formatter::HTMLFormatter
+
   enable_coverage  :branch
-  primary_coverage :branch
-  enable_coverage_for_eval
+  enable_coverage  :eval
 
-  add_filter "/test/"
-  add_filter "/rakelib/"
+  skip "/test/"
+  skip "/rakelib/"
+  cover "lib/**/*.rb"
 
-  add_group "Parser", %w[lib/net/imap/response_parser.rb
-                        lib/net/imap/response_parser]
-  add_group "Config", %w[lib/net/imap/config.rb
-                        lib/net/imap/config]
-  add_group "SASL", %w[lib/net/imap/sasl.rb
-                      lib/net/imap/sasl
-                      lib/net/imap/authenticators.rb]
-  add_group "StringPrep", %w[lib/net/imap/stringprep.rb
-                            lib/net/imap/stringprep]
+  group "Parser",     %w[lib/net/imap/response_parser.rb
+                         lib/net/imap/response_parser]
+  group "Config",     %w[lib/net/imap/config.rb
+                         lib/net/imap/config]
+  group "SASL",       %w[lib/net/imap/sasl.rb
+                         lib/net/imap/sasl
+                         lib/net/imap/authenticators.rb]
+  group "StringPrep", %w[lib/net/imap/stringprep.rb
+                         lib/net/imap/stringprep]
 end

--- a/.simplecov
+++ b/.simplecov
@@ -4,6 +4,7 @@ SimpleCov.configure do
   formatter SimpleCov::Formatter::HTMLFormatter
 
   enable_coverage  :branch
+  enable_coverage  :method
   enable_coverage  :eval
 
   skip "/test/"
@@ -12,11 +13,27 @@ SimpleCov.configure do
 
   group "Parser",     %w[lib/net/imap/response_parser.rb
                          lib/net/imap/response_parser]
+
+  group "Client",     %w[lib/net/imap.rb
+                         lib/net/imap/connection_state.rb
+                         lib/net/imap/deprecated_client_options.rb
+                         lib/net/imap/errors.rb
+                         lib/net/imap/response_reader.rb]
+
   group "Config",     %w[lib/net/imap/config.rb
                          lib/net/imap/config]
+
+  group "Data Types", %w[lib/net/imap/flags.rb
+                         lib/net/imap/sequence_set.rb] +
+                         [%r{lib/net/imap/\w*_data\.rb},
+                          %r{lib/net/imap/\w*_result.rb},
+                          %r{lib/net/imap/data_\w+\.rb}]
+
   group "SASL",       %w[lib/net/imap/sasl.rb
                          lib/net/imap/sasl
+                         lib/net/imap/sasl_adapter.rb
                          lib/net/imap/authenticators.rb]
+
   group "StringPrep", %w[lib/net/imap/stringprep.rb
                          lib/net/imap/stringprep]
 end

--- a/Rakefile
+++ b/Rakefile
@@ -11,3 +11,14 @@ Rake::TestTask.new(:test) do |t|
 end
 
 task :default => :test
+
+desc "Output coverage data report, and error when threshholds aren't met"
+task "coverage:report" do
+  require "simplecov"
+  SimpleCov.collate "coverage/.resultset.json" do
+    coverage(:line) do
+      minimum           90
+      minimum_per_file  40
+    end
+  end
+end

--- a/test/lib/helper.rb
+++ b/test/lib/helper.rb
@@ -2,6 +2,7 @@ if !(ENV["SIMPLECOV_DISABLE"] in /\A(1|y(es)?|t(rue)?)\z/i) &&
     RUBY_ENGINE == "ruby" # C Ruby only
 
   require "simplecov"
+
   SimpleCov.start do
     command_name "Net::IMAP tests"
   end

--- a/test/lib/helper.rb
+++ b/test/lib/helper.rb
@@ -2,30 +2,8 @@ if !(ENV["SIMPLECOV_DISABLE"] in /\A(1|y(es)?|t(rue)?)\z/i) &&
     RUBY_ENGINE == "ruby" # C Ruby only
 
   require "simplecov"
-
-  SimpleCov.formatters = [
-    SimpleCov::Formatter::HTMLFormatter,
-    SimpleCov::Formatter::JSONFormatter,
-  ]
-
   SimpleCov.start do
     command_name "Net::IMAP tests"
-    enable_coverage  :branch
-    primary_coverage :branch
-    enable_coverage_for_eval
-
-    add_filter "/test/"
-    add_filter "/rakelib/"
-
-    add_group "Parser", %w[lib/net/imap/response_parser.rb
-                          lib/net/imap/response_parser]
-    add_group "Config", %w[lib/net/imap/config.rb
-                          lib/net/imap/config]
-    add_group "SASL", %w[lib/net/imap/sasl.rb
-                        lib/net/imap/sasl
-                        lib/net/imap/authenticators.rb]
-    add_group "StringPrep", %w[lib/net/imap/stringprep.rb
-                              lib/net/imap/stringprep]
   end
 end
 


### PR DESCRIPTION
There were a few issues that came from upgrading to v1.0 (in #718), one of which was identified by #717, but I didn't notice those issues until after merging both.  Oops!

This updates the simplecov config in several ways:
* updates to v1.0 config API, to avoid deprecation warnings
* drops the broken [joshmfrankel/simplecov-check-action](https://github.com/joshmfrankel/simplecov-check-action) action
* replaces the minimum coverage criteria with simplecov's builtin config
  Note that normal test runs will not trigger any coverage requirements.
  Run `rake coverage:report` to trigger an error on low coverage.
* enables "method" coverage
* updates the groups so there aren't any "ungrouped" files
* ~ratchets up the minimum coverage requirements to current level~ _(will do in another PR)_
* ~to allow higher minimum coverage per file, this adds some exceptions for outlier files.~ _(will do in another PR)_
* ~adds minimum coverage criteria for each group~ _(will do in another PR)_

A future PR will ratchet up the minimum coverage requirements and bring back something similar to `joshmfrankel/simplecov-check-action`.  But this should be good enough for now.