### PR TITLE
🐛 Fix bug (introduced by #712) testing if string is quotable

### DIFF
--- a/lib/net/imap/command_data.rb
+++ b/lib/net/imap/command_data.rb
@@ -58,7 +58,7 @@ module Net
       end
     end
 
-    UNQUOTABLE_CHARS = /\0\r\n/
+    UNQUOTABLE_CHARS = /[\0\r\n]/
     ASTRING_SPECIALS = /[(){ \x00-\x1f\x7f%*"\\]/
     private_constant :UNQUOTABLE_CHARS, :ASTRING_SPECIALS
 

--- a/test/net/imap/test_imap.rb
+++ b/test/net/imap/test_imap.rb
@@ -1045,6 +1045,10 @@ class IMAPTest < Net::IMAP::TestCase
       send_args.call ["\xDE\xAD\xBE\xEF".b]
       assert_equal "({4}\r\n\xDE\xAD\xBE\xEF)".b, server.commands.pop.args
 
+      send_args.call ["hi\rthere\n", "huh?\r\nfake out"]
+      assert_equal "({9}\r\nhi\rthere\n {14}\r\nhuh?\r\nfake out)".b,
+                   server.commands.pop.args
+
       # enable automatic non-synchronizing literals
       imap.config.max_non_synchronizing_literal = 1024
       buff = bytes = nil


### PR DESCRIPTION
This bug was introduced by a742a109, as part of #712.  When I extracted the `UNQUOTABLE_CHARS` regexp into a constant, I didn't copied it exactly. It was converted from a character class into a sequence of bytes:
```ruby
    # It should've been this:
    UNQUOTABLE_CHARS = /[\r\n]/n
    # But I incorrectly copied it as this:
    UNQUOTABLE_CHARS = /\r\n/n
```

If that regexp were the only guard, this regexp would've allowed CRLF injections!  Fortunately, quoted strings are now sent using `Net::IMAP::QuotedString` (since #698, released in v0.6.4.1), and that _does_ correctly validate that the input is a valid quoted string.  So, the string isn't _sent_ as invalid quoted data.

Unfortunately, this does result in an exception for strings that could be valid literals.  And, because it crashes while sending command arguments, rather than during validation, the connection will be broken.