### PR TITLE
✅ Ratchet up minimum test coverage requirements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,3 +42,4 @@ jobs:
         !startsWith(matrix.ruby, 'truffleruby') && !startsWith(matrix.ruby, 'jruby') }}
       run: bundle exec rake test:coverage:report
       timeout-minutes: 1 # _should_ finish in under a second
+      continue-on-error: ${{ matrix.os != 'ubuntu-latest' || matrix.ruby != '4.0' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,5 +40,5 @@ jobs:
     - name: Report coverage
       if: ${{ matrix.os == 'ubuntu-latest' && github.event_name != 'pull_request' &&
         !startsWith(matrix.ruby, 'truffleruby') && !startsWith(matrix.ruby, 'jruby') }}
-      run: bundle exec rake coverage:report
+      run: bundle exec rake test:coverage:report
       timeout-minutes: 1 # _should_ finish in under a second

--- a/.simplecov
+++ b/.simplecov
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 SimpleCov.configure do
-  formatter SimpleCov::Formatter::HTMLFormatter
-
   enable_coverage  :branch
   enable_coverage  :method
   enable_coverage  :eval

--- a/.simplecov
+++ b/.simplecov
@@ -7,6 +7,9 @@ SimpleCov.configure do
   enable_coverage  :method
   enable_coverage  :eval
 
+  # eval branch coverage varies too much between runtime environments
+  ignore_branches :eval_generated
+
   skip "/test/"
   skip "/rakelib/"
   cover "lib/**/*.rb"

--- a/Rakefile
+++ b/Rakefile
@@ -12,10 +12,13 @@ end
 
 task :default => :test
 
-desc "Output coverage data report, and error when threshholds aren't met"
+desc "Output HTML coverage data report, and error when threshholds aren't met"
 task "test:coverage:report" do
   require "simplecov"
+
   SimpleCov.collate "coverage/.resultset.json" do
+    formatter SimpleCov::Formatter::HTMLFormatter
+
     coverage(:line) do
       minimum           95
 

--- a/Rakefile
+++ b/Rakefile
@@ -17,8 +17,52 @@ task "test:coverage:report" do
   require "simplecov"
   SimpleCov.collate "coverage/.resultset.json" do
     coverage(:line) do
-      minimum           90
-      minimum_per_file  40
+      minimum           95
+
+      minimum_per_group 98, only: "Config"
+      minimum_per_group 97, only: "StringPrep"
+      minimum_per_group 97, only: "SASL"
+      minimum_per_group 95, only: "Data Types"
+      minimum_per_group 94, only: "Parser"
+      minimum_per_group 92, only: "Client"
+
+      minimum_per_file  80
+      minimum_per_file  55, only: "lib/net/imap/search_result.rb"
+    end
+
+    # NOTE: branch coverage varies more widely between ruby versions
+    coverage(:branch) do
+      minimum           80
+
+      minimum_per_group 90, only: "Data Types"
+      minimum_per_group 85, only: "Config"
+      minimum_per_group 80, only: "Client"
+      minimum_per_group 80, only: "Parser"
+      minimum_per_group 70, only: "SASL"
+      minimum_per_group 70, only: "StringPrep"
+
+      minimum_per_file  60
+      minimum_per_file  50, only: "lib/net/imap/sasl/authenticators.rb"
+      minimum_per_file  50, only: "lib/net/imap/config/attr_accessors.rb"
+    end
+
+    coverage(:method) do
+      minimum            88
+
+      minimum_per_group 100, only: "Config"
+      minimum_per_group  90, only: "Data Types"
+      minimum_per_group  90, only: "StringPrep"
+      minimum_per_group  85, only: "Client"
+      minimum_per_group  80, only: "Parser"
+      minimum_per_group  80, only: "SASL"
+
+      minimum_per_file   65
+      minimum_per_file   60, only: "lib/net/imap/response_parser/parser_utils.rb"
+      minimum_per_file   55, only: "lib/net/imap/sasl/authenticators.rb"
+      minimum_per_file   50, only: "lib/net/imap/authenticators.rb"
+      minimum_per_file   50, only: "lib/net/imap/sasl/anonymous_authenticator.rb"
+      minimum_per_file   35, only: "lib/net/imap/sasl/protocol_adapters.rb"
+      minimum_per_file   20, only: "lib/net/imap/response_data.rb"
     end
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ end
 task :default => :test
 
 desc "Output coverage data report, and error when threshholds aren't met"
-task "coverage:report" do
+task "test:coverage:report" do
   require "simplecov"
   SimpleCov.collate "coverage/.resultset.json" do
     coverage(:line) do

--- a/test/lib/helper.rb
+++ b/test/lib/helper.rb
@@ -3,6 +3,9 @@ if !(ENV["SIMPLECOV_DISABLE"] in /\A(1|y(es)?|t(rue)?)\z/i) &&
 
   require "simplecov"
 
+  # run `rake coverage:report` for HTML/JSON formatter
+  SimpleCov.formatter = nil
+
   SimpleCov.start do
     command_name "Net::IMAP tests"
   end


### PR DESCRIPTION
Since simplecov v1.0 makes it easier to specify more detailed coverage requirements, I've raised the requirements to be just below the current coverage.

I've had some issues getting the coverage numbers in CI to match my numbers locally, which is concerning and annoying.  But so long as the numbers in CI remain stable, we can use those as the baseline.

This also adds a simple custom formatter which is both faster than the HTML formatter _and_ prints much more informative output to stderr.

The HTML formatter is still available via `rake coverage:report`.