### PR TITLE
✅ Update bin/test test runner and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ end
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `bundle exec rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run
+`bin/test` to run the tests. You can also run `bin/console` for an interactive
+prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 

--- a/bin/test
+++ b/bin/test
@@ -6,6 +6,8 @@ base_dir = File.expand_path("..", __dir__)
 $LOAD_PATH.unshift File.expand_path("test/lib", base_dir)
 $LOAD_PATH.unshift File.expand_path("lib",      base_dir)
 
-require_relative "lib/helper"
+require_relative "../test/lib/helper"
 
-exit Test::Unit::AutoRunner.run(true)
+exit(Test::Unit::AutoRunner.run(true) do |runner|
+  runner.default_test_paths << File.expand_path("test/net/imap", base_dir)
+end)


### PR DESCRIPTION
This moves the test runner script into the `bin` dir, and gets rid of that weird `"Done"` line that was printed to the console when running `test/run` with no args.

This also updates the README to recommend `bin/test` over `bundle exec rake test`.