### PR TITLE
✅ Fix JRuby local backtrace test assertions

### DIFF
--- a/test/lib/helper.rb
+++ b/test/lib/helper.rb
@@ -224,9 +224,22 @@ class Net::IMAP::TestCase < Test::Unit::TestCase
     else
       assert_raise(expected, &block)
     end
-    stack = caller
-    assert_equal stack, error.backtrace&.last(stack.size)
+    assert_local_backtrace error
     error
+  end
+
+  # Asserts that +error+ was raised in the same thread as +caller+ _and_ was
+  # called from the same level as +caller+.  The caller's own frame is ignored,
+  # as are all extra frames in +error+, but the remaining frames much match.
+  #
+  # NOTE: `stack = caller(2)` is different from `$!.backtrace[2..]` in JRuby.
+  # Rather than use `caller`, this raises a local exception to use its backtrace
+  # for the comparison.
+  def assert_local_backtrace(error)
+    local_stack = raise "generating local backtrace" rescue $!.backtrace[2..]
+    error_stack = error.backtrace&.last(local_stack.size)
+    assert_equal local_stack, error_stack
+    error_stack
   end
 
   # Combines +assert_local_raise+ with an assertion that the exception's cause

--- a/test/net/imap/test_imap_tls.rb
+++ b/test/net/imap/test_imap_tls.rb
@@ -110,7 +110,7 @@ class IMAP_TLS_Test < Net::IMAP::TestCase
         imap
       end
       assert_kind_of(OpenSSL::SSL::SSLError, ex)
-      assert_equal (stack = caller), ex.backtrace&.last(stack.size)
+      assert_local_backtrace ex
       assert_equal false, imap.tls_verified?
       assert_equal({}, imap.ssl_ctx_params)
       assert_equal(nil, imap.ssl_ctx.ca_file)


### PR DESCRIPTION
A bug was fixed in jruby-head, but that may not be in current releases:
* JRuby Issue: jruby/jruby#9528
* Fixed by: jruby/jruby#9528

With that issue fixed, these tests don't need to be marked pending! 😄

BUT, JRuby _does_ still have some incongruity between `caller(1)` and `raise rescue $!.backtrace[1..]`.  Some ruby block stack frames in `caller` are replaced by java stack frames in `Exception#backtrace`. For example:

```diff
--- Kernel#caller
+++ Exception#backtrace
  /home/nick/.local/share/rubies/jruby-dev/lib/ruby/gems/shared/gems/test-unit-3.7.8/lib/test/unit/testcase.rb:632:in 'block in run'
- /home/nick/.local/share/rubies/jruby-dev/lib/ruby/gems/shared/gems/test-unit-3.7.8/lib/test/unit/testcase.rb:631:in 'catch'
+ org/jruby/RubyKernel.java:1604:in 'catch'
+ org/jruby/RubyKernel.java:1599:in 'catch'
  /home/nick/.local/share/rubies/jruby-dev/lib/ruby/gems/shared/gems/test-unit-3.7.8/lib/test/unit/testcase.rb:631:in 'run'
```

The workaround is relatively simple: use a locally generated exception to generate the stack frames for comparison.