### PR TITLE
Use benchmark_driver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem "test-unit"
 gem "test-unit-ruby-core", git: "https://github.com/ruby/test-unit-ruby-core"
 
 gem "benchmark", require: false
-gem "benchmark-driver", require: false
+gem "benchmark_driver", require: false
 gem "vernier", require: false, platform: :mri
 
 group :test do


### PR DESCRIPTION
benchmark-driver is an alias gem to install benchmark_driver.