### PR TITLE
✅ Use release version of test-unit-ruby-core

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "irb"
 gem "rake"
 gem "rdoc", ">= 7.2.0"
 gem "test-unit"
-gem "test-unit-ruby-core", git: "https://github.com/ruby/test-unit-ruby-core"
+gem "test-unit-ruby-core"
 
 gem "benchmark", require: false
 gem "benchmark-driver", require: false


### PR DESCRIPTION
I don't know why this is breaking in CI.  Perhaps it's a bug in the ruby/setup action or perhaps it's a bug in bundler?

Either way, this project doesn't need to use the latest release from `git`, and @hsbt pushed a release of the current git `HEAD` anyway.  So it's worth a try to just see if using a normal release can fix CI.