### PR TITLE
Use the documented 16 KiB non-synchronizing literal default

### DIFF
--- a/lib/net/imap/config.rb
+++ b/lib/net/imap/config.rb
@@ -312,7 +312,7 @@ module Net
       # * +0.6+: 16 KiB
       attr_accessor :max_non_synchronizing_literal, type: Integer, defaults: {
         0.0r => -1,
-        0.6r => 16 << 16, # 16 KiB
+        0.6r => 16 << 10, # 16 KiB
       }
 
       # The maximum allowed server response size.  When +nil+, there is no limit


### PR DESCRIPTION
## Summary

Correct the 0.6 default non-synchronizing literal limit from 16 << 16 (1 MiB) to 16 << 10 (16 KiB). Both current documentation and the original merged #649 explicitly specify 16 KiB. Explicit configuration overrides and the older disabled default are unchanged.

## Reproduction

```ruby
require 'net/imap'
p Net::IMAP::Config.default.max_non_synchronizing_literal
# before: 1048576; after: 16384
```

## Verification

- 20 focused checks; nine failing expectations before, zero afterward. Default/new/versioned Config values, continuation decisions at 16 KiB boundaries, the older disabled default and an explicit 1 MiB override are covered. The original #649 diff confirms the documented intended value.
- Existing `rake test` on this isolated branch: **1726 tests, 12596 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications**, Ruby 4.0.6 via rbenv. The baseline also passes all 1,726 tests; assertion counts vary slightly across runs.
- Supplemental RuboCop Lint retains the same 48 existing findings. Ruby syntax and `git diff --check` pass. No repository tests, dependencies or workflows were added or modified; focused reproductions live outside the repository under the consumer's no-new-tests policy.
- Independent branch based on `6d2ef7a636a1e2449187a83b06ac7a5baa54ead2`; the runtime diff from released 0.6.6 is documentation-only before this patch.

## Compatibility and limits

Behavior change: with LITERAL+ and default configuration, literals larger than 16 KiB now wait for continuation instead of being sent without waiting up to 1 MiB. This may add a round trip. Callers intentionally wanting 1 MiB can explicitly configure it. LITERAL-/IMAP4rev2 capability rules are unchanged. Other Ruby/OS versions were not run locally. No production or external IMAP service was used. Local verification does not imply upstream CI approval or comprehensive behavioral coverage.
