### PR TITLE
Scan raw command literals without copying the remaining input

### DIFF
--- a/lib/net/imap/command_data.rb
+++ b/lib/net/imap/command_data.rb
@@ -265,23 +265,27 @@ module Net
       def self.split(data)
         data = data.b # dups and ensures BINARY encoding
         parts = []
-        while data.match(/(~)?\{(0|[1-9]\d*)(\+)?\}\r\n/n)
-          text, binary, bytesize, non_sync, data = $`, !!$1, $2, !!$3, $'
+        offset = 0
+        while (match = /(~)?\{(0|[1-9]\d*)(\+)?\}\r\n/n.match(data, offset))
+          text = data.byteslice(offset...match.begin(0))
+          binary, bytesize, non_sync = !!match[1], match[2], !!match[3]
           bytesize = NumValidator.coerce_number64 bytesize
           parts << RawText[text] unless text.empty?
-          parts << extract_literal(data, binary:, bytesize:, non_sync:)
-          data.bytesplice(0, bytesize, "")
+          offset = match.end(0)
+          parts << extract_literal(data, offset:, binary:, bytesize:, non_sync:)
+          offset += bytesize
         end
-        parts << RawText[data] unless data.empty?
+        parts << RawText[data.byteslice(offset..)] if offset < data.bytesize
         parts
       end
 
-      def self.extract_literal(data, binary:, bytesize:, non_sync:)
-        if data.bytesize < bytesize
+      def self.extract_literal(data, offset:, binary:, bytesize:, non_sync:)
+        remaining = data.bytesize - offset
+        if remaining < bytesize
           raise DataFormatError, "Too few bytes in string for literal, " \
-            "expected: %s, remaining: %s" % [bytesize, data.bytesize]
+            "expected: %s, remaining: %s" % [bytesize, remaining]
         end
-        literal = data.byteslice(0, bytesize)
+        literal = data.byteslice(offset, bytesize)
         (binary ? Literal8 : Literal).new(data: literal, non_sync:)
       end
       private_class_method :extract_literal


### PR DESCRIPTION
## Summary

Scan RawData literal prefixes with an offset into one binary input string. The current loop copies the remaining tail and deletes the literal prefix for every literal, causing repeated copying as command size grows. Keep literal extraction, validation, flags and output ownership unchanged.

## Reproduction

```ruby
require 'net/imap'
input = ("raw {1024}\r\n" + 'x' * 1024) * 1000
2.times { Net::IMAP::RawData.split(input) }
timings = 7.times.map do
  GC.start
  start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
  3.times { Net::IMAP::RawData.split(input) }
  Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
end
p timings.sort[3]
```

## Verification

- 1,232 before/after outcomes match, including exact part classes/bytes/flags/frozen state and error classes/messages; 1,232 input-ownership checks pass. A bounded deterministic corpus includes empty, mixed, binary, truncated and invalid inputs. For 250/500/1,000 1-KiB literals, median times for three splits (seven samples) were 0.005862/0.021277/0.077983s before and 0.001138/0.002287/0.004667s after on Ruby 4.0.6. Largest input: 1,036,000 bytes. These are local synthetic measurements, not production claims. Related merged #679 introduced split; no duplicate open optimization was found.
- Existing `rake test` on this isolated branch: **1726 tests, 12594 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications**, Ruby 4.0.6 via rbenv. The baseline also passes all 1,726 tests; assertion counts vary slightly across runs.
- Supplemental RuboCop Lint retains the same 48 existing findings. Ruby syntax and `git diff --check` pass. No repository tests, dependencies or workflows were added or modified; focused reproductions live outside the repository under the consumer's no-new-tests policy.
- Independent branch based on `6d2ef7a636a1e2449187a83b06ac7a5baa54ead2`; the runtime diff from released 0.6.6 is documentation-only before this patch.

## Compatibility and limits

No intended public behavior, dependency or Ruby-minimum change. The private extract_literal helper gains an offset keyword. RawData validation remains unchanged; allocation totals and application-level throughput were not measured. Other Ruby/OS versions were not run locally. No production or external IMAP service was used. Local verification does not imply upstream CI approval or comprehensive behavioral coverage.
