### PR TITLE
✅ Improve `SearchResult#eql?` and `#hash` tests

### DIFF
--- a/test/net/imap/test_search_result.rb
+++ b/test/net/imap/test_search_result.rb
@@ -30,15 +30,53 @@ class SearchDataTests < Net::IMAP::TestCase
     refute_equal nomodseq, sorted
   end
 
-  test "#eql? and #hash include the result type and modseq" do
-    result = SearchResult[1, 2, modseq: 3]
-    same = SearchResult[1, 2, modseq: 3]
+  test "#eql? and #hash always compare modseq and order" do
+    result      = SearchResult[1, 2, modseq: 3]
+    same        = SearchResult[1, 2, modseq: 3]
+    diff_order  = SearchResult[2, 1, modseq: 3]
+    diff_modseq = SearchResult[1, 2, modseq: 4]
+    no_modseq   = SearchResult[1, 2]
+    array       = [1, 2]
 
+    # comparing result.eql?(other)
     assert_operator result, :eql?, same
+    refute_operator result, :eql?, diff_order
+    refute_operator result, :eql?, diff_modseq
+    refute_operator result, :eql?, no_modseq
+    refute_operator result, :eql?, array
     assert_equal result.hash, same.hash
-    refute_operator result, :eql?, SearchResult[2, 1, modseq: 3]
-    refute_operator result, :eql?, SearchResult[1, 2, modseq: 4]
-    refute_operator SearchResult[1, 2], :eql?, [1, 2]
+    refute_equal result.hash, diff_order.hash
+    refute_equal result.hash, diff_modseq.hash
+    refute_equal result.hash, no_modseq.hash
+    refute_equal result.hash, array.hash
+
+    # reversing the order doesn't matter (except for Array#eql?)
+    assert_operator same       , :eql?, result
+    refute_operator diff_order , :eql?, result
+    refute_operator diff_modseq, :eql?, result
+    refute_operator no_modseq  , :eql?, result
+
+    assert_operator array      , :eql?, result
+
+    # comparing no_modseq.eql?(array)
+    refute_operator no_modseq, :eql?, array
+    refute_equal no_modseq.hash, array.hash
+  end
+
+  test "SearchResult.new(nz_numbers) == / eql? SearchResult[*nz_numbers]" do
+    array = [1, 5, 20, 3, 98]
+    new_with_array_arg   = SearchResult.new(array)
+    splatted_in_brackets = SearchResult[*array]
+    [nil, 12345].each do |modseq|
+      splatted_in_brackets = SearchResult[*array, modseq:]
+      new_with_array_arg   = SearchResult.new(array, modseq:)
+      assert_equal    splatted_in_brackets,        new_with_array_arg
+      assert_equal    new_with_array_arg,        splatted_in_brackets
+      assert_operator splatted_in_brackets, :eql?, new_with_array_arg
+      assert_operator new_with_array_arg, :eql?, splatted_in_brackets
+      assert_equal    splatted_in_brackets.hash,   new_with_array_arg.hash
+      assert_equal    new_with_array_arg.hash,   splatted_in_brackets.hash
+    end
   end
 
   test "SearchResult[*nz_numbers] == Array[*nz_numbers]" do
@@ -48,24 +86,26 @@ class SearchDataTests < Net::IMAP::TestCase
     assert_equal result, array
   end
 
-  test "SearchResult.new(nz_numbers) == Array.new(nz_numbers)" do
-    nz_numbers = [11, 35, 39, 1083, 958]
-    result = SearchResult.new(nz_numbers)
-    array  = Array.new(nz_numbers)
-    assert_equal array, result
-    assert_equal result, array
+  test "SearchResult[*nz_numbers] not eql? Array[*nz_numbers]" do
+    array  = [1, 5, 20, 3, 98]
+    result = SearchResult[*array]
+    refute_operator result, :eql?, array
+    refute_operator result.hash, :eql?, array.hash
   end
 
-  test "SearchResult[*nz_numbers, modseq: nz_number] != Array[*nz_numbers]" do
+  test "SearchResult[*nz_numbers, modseq: nz_number] != / not eql? Array[*nz_numbers]" do
     array  = [1, 5, 20, 3, 98]
     result = SearchResult[*array, modseq: 123456]
     refute_equal result, array
+    refute_operator result, :eql?, array
+    refute_equal result.hash, array.hash
   end
 
-  test "Array[*nz_numbers] == SearchResult[*nz_numbers, modseq: nz_number]" do
+  test "Array[*nz_numbers] == / eql? SearchResult[*nz_numbers, modseq: nz_number]" do
     array  = [1, 5, 20, 3, 98]
     result = SearchResult[*array, modseq: 123456]
     assert_equal array, result
+    assert_operator array, :eql?, result
   end
 
   test "SearchResult[*nz_numbers] == Array[*differently_sorted]" do
@@ -74,10 +114,19 @@ class SearchDataTests < Net::IMAP::TestCase
     assert_equal result, array
   end
 
-  test "Array[*nz_numbers] != SearchResult[*differently_sorted]" do
+  test "SearchResult[*nz_numbers] not eql? Array[*differently_sorted]" do
+    array  = [1, 5, 20, 3, 98]
+    result = SearchResult[*array.reverse]
+    refute_operator result, :eql?, array
+    refute_equal result.hash, array.hash
+  end
+
+  test "Array[*nz_numbers] != / not eql? SearchResult[*differently_sorted]" do
     array  = [1, 5, 20, 3, 98]
     result = SearchResult[*array.reverse]
     refute_equal array, result
+    refute_operator result, :eql?, array
+    refute_equal array.hash, result.hash
   end
 
   test "#inspect" do


### PR DESCRIPTION
This was motivated by a bug report (#738), which was originally missing tests.  But tests were added (🎉), so that merged first and this was rebased on top of it.