### PR TITLE
♻️ Match subclasses in `SearchResult#eql?`/`#hash`

### DIFF
--- a/lib/net/imap/search_result.rb
+++ b/lib/net/imap/search_result.rb
@@ -73,11 +73,11 @@ module Net
       end
 
       # Hash equality.  Unlike #==, order will be taken into account.
-      def hash = [super, self.class, modseq].hash
+      def hash = [SearchResult, modseq, super].hash
 
       # Hash equality.  Unlike #==, order will be taken into account.
       def eql?(other)
-        self.class == other.class &&
+        SearchResult === other &&
           modseq == other.modseq &&
           super
       end

--- a/test/net/imap/test_search_result.rb
+++ b/test/net/imap/test_search_result.rb
@@ -93,6 +93,22 @@ class SearchDataTests < Net::IMAP::TestCase
     refute_operator result.hash, :eql?, array.hash
   end
 
+  # NOTE: this subclass is NOT overriding #==, #hash, or #eql?
+  Subclass = Class.new(SearchResult)
+
+  test "SearchResult[...] == / eql? Subclass[...]" do
+    array    = [1, 5, 20, 3, 98]
+    result   = SearchResult[*array]
+    subclass = Subclass[*array]
+    assert_operator result, :eql?, subclass
+    assert_equal result.hash, subclass.hash
+    modseq   = 12345
+    result   = SearchResult[*array, modseq:]
+    subclass = Subclass[*array, modseq:]
+    assert_operator result, :eql?, subclass
+    assert_equal result.hash, subclass.hash
+  end
+
   test "SearchResult[*nz_numbers, modseq: nz_number] != / not eql? Array[*nz_numbers]" do
     array  = [1, 5, 20, 3, 98]
     result = SearchResult[*array, modseq: 123456]


### PR DESCRIPTION
Copying the behavior of `Array#eql?` and `Array#hash`, this updates both `SearchResult#eql?` and `SearchResult#hash` to match explicitly on `SearchResult` rather than the specific `self.class`.  This way, they also match subclass instances (assuming the subclass doesn't override these methods).

`#hash` was also re-ordered to match `#eql?`.  This isn't needed for performance.  It just makes it a little bit easier to identify that the two methods are comparing the same properties.

This was motivated by #738.