### PR TITLE
🐛 Fix ResponseParser use of global config

### DIFF
--- a/lib/net/imap/response_parser/parser_utils.rb
+++ b/lib/net/imap/response_parser/parser_utils.rb
@@ -186,7 +186,7 @@ module Net
         end
 
         def peek_re?(re)
-          assert_no_lookahead if Net::IMAP.debug
+          assert_no_lookahead if config.debug?
           re.match?(@str, @pos)
         end
 


### PR DESCRIPTION
ResponseParser was using the global config here, but should've used its own instance config.